### PR TITLE
feat: apply minor coverage improvements to restful-api-guidelines skill

### DIFF
--- a/.claude/skills/restful-api-guidelines.md
+++ b/.claude/skills/restful-api-guidelines.md
@@ -42,6 +42,10 @@ POST   /users/{id}:deactivate
 # Correct: /user-profiles, /article-categories
 # Incorrect: /user_profiles, /UserProfiles, /사용자
 
+# Verbs in URL paths are forbidden: /getUsers, /createArticle, /deleteUser — use :action pattern for operations
+# File extensions in URLs are forbidden: /articles.json, /users.xml
+# API version MUST NOT be included in the URL path (/v1/, /v2/) — use X-API-Version header instead
+
 # Query parameters: use same parameter name repeated for array values (OR condition)
 GET /articles?status=PUBLISHED&status=DRAFT
 
@@ -68,6 +72,11 @@ GET /articles?status=PUBLISHED&status=DRAFT
 ✅ Required: PUT requests MUST be idempotent — identical requests must produce the same result
 ✅ Required: Include `Content-Type: application/json` header when request body is present
 ✅ Required: Include `Content-Type` header in all responses with a body
+❌ Prohibited: GET, HEAD, and DELETE requests MUST NOT include a request body
+❌ Prohibited: Never return 200 OK for error conditions — use appropriate 4xx/5xx status codes
+❌ Prohibited: Standard HTTP header semantics MUST NOT be redefined (e.g., do not repurpose Content-Type or Authorization for non-standard meanings)
+❌ Prohibited: Do not use a generic `/operations` endpoint — track long-running task status on the domain resource itself
+⚠️ Recommended: New custom headers MUST NOT use `X-` prefix (deprecated per RFC 6648) — note: `X-RateLimit-*` headers are retained here as a legacy compatibility exception
 
 ### Error Response Format Template
 
@@ -104,6 +113,8 @@ All error responses use RFC 7807/9457 Problem Details structure.
 | 429 | `.../errors/too-many-requests` | Rate limit exceeded |
 | 500 | `.../errors/internal-server-error` | Internal server error |
 
+❌ Prohibited: Never expose stack traces, database errors, or internal implementation details in error responses
+
 ### JSON Field Naming Rules
 
 ```json
@@ -122,7 +133,10 @@ All error responses use RFC 7807/9457 Problem Details structure.
   "user_id": "456",       // snake_case forbidden
   "is_active": true,      // snake_case forbidden
   "created_at": "...",    // snake_case forbidden
-  "status": "published"   // enums must be UPPER_SNAKE_CASE
+  "status": "published",  // enums must be UPPER_SNAKE_CASE
+  "status": 1,            // enum values must be descriptive strings, not numbers or opaque abbreviations
+  "usrId": "456",         // abbreviations in field names forbidden — use userId not usrId
+  "deletedAt": null       // null-valued fields must be omitted from responses entirely
 }
 
 // Type rules
@@ -134,6 +148,10 @@ All error responses use RFC 7807/9457 Problem Details structure.
 ```
 
 ✅ Required: Field names MUST start with a lowercase letter (a-z) — no UpperCamelCase (e.g., `userId` not `UserId`)
+❌ Prohibited: Do not use excessive abbreviations in field names (e.g., `userId` not `usrId`, `createdAt` not `crtdAt`)
+❌ Prohibited: Null-valued fields MUST be omitted from responses — do not include fields with `null` values
+⚠️ Recommended: Integers exceeding 2^53 (`Number.MAX_SAFE_INTEGER`) MUST be returned as strings to prevent JavaScript precision loss
+⚠️ Recommended: Design Enum types to be extensible — clients MUST handle unknown Enum values gracefully (ignore or treat as a default)
 
 ### Collection/Pagination Pattern
 
@@ -213,6 +231,8 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiJ9...
 # API Key
 Authorization: ApiKey your-api-key-here
 ```
+
+❌ Prohibited: API keys MUST NOT be passed as query parameters (e.g., `?api_key=xxx`) — always use the `Authorization` header
 
 **401 vs 403 distinction:**
 
@@ -309,10 +329,12 @@ When reviewing API code, identify violations using the checklist below and sugge
 - [ ] HEAD requests do not include a request body
 - [ ] DELETE requests do not include a request body
 - [ ] 200 not returned for error conditions
+- [ ] Partial updates use PATCH rather than PUT (PUT only for full resource replacement)
 
 #### Request/Response Headers
 - [ ] `Content-Type: application/json` included in requests with a body
 - [ ] `Content-Type` header included in all responses with a body
+- [ ] Standard HTTP headers (Content-Type, Authorization, etc.) not redefined with non-standard semantics
 
 #### JSON Response
 - [ ] All fields are camelCase
@@ -328,6 +350,11 @@ When reviewing API code, identify violations using the checklist below and sugge
 - [ ] Boolean values use native JSON true/false (not strings "true"/"false" or numbers 1/0)
 - [ ] Numeric values use JSON number type (not string-wrapped numbers)
 - [ ] Field names start with a lowercase letter (no UpperCamelCase field names)
+- [ ] Field names use full descriptive words (no excessive abbreviations: `userId` not `usrId`, `createdAt` not `crtdAt`)
+- [ ] Integers exceeding 2^53 (`Number.MAX_SAFE_INTEGER`) returned as strings
+- [ ] Date/time values use RFC 3339 format, not Unix timestamps (integer milliseconds or seconds)
+- [ ] Enum values use descriptive UPPER_SNAKE_CASE strings (not numeric or opaque abbreviation values)
+- [ ] API designed to allow clients to receive unknown Enum values without breaking (extensible enum)
 
 #### Error Handling
 - [ ] Error responses use RFC 7807/9457 Problem Details structure (`type`, `title`, `status`, `detail`)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .claude/*
 !.claude/skills
 .worktrees/
+docs/

--- a/docs/evaluation/coverage-map.md
+++ b/docs/evaluation/coverage-map.md
@@ -21,26 +21,26 @@
 |---|-----------|-----------|---------|--------|--------|
 | 2.1-1 | ✅필수 | URL 경로에 소문자 kebab-case 사용 | COVERED | COVERED | — |
 | 2.1-2 | ✅필수 | 리소스 컬렉션 이름은 복수형 명사 | COVERED | COVERED | — |
-| 2.1-3 | ❌금지 | URL에 동사 포함 금지 | PARTIAL | COVERED | Minor |
-| 2.1-4 | ❌금지 | URL에 파일 확장자 포함 금지 | MISSING | COVERED | Minor |
+| 2.1-3 | ❌금지 | URL에 동사 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.1-4 | ❌금지 | URL에 파일 확장자 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 | 2.1-5 | ✅필수 | URL 경로 세그먼트에 ASCII 영소문자/숫자/하이픈만 허용 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 2.1-6 | ✅필수 | 쿼리 파라미터 이름은 camelCase | COVERED | COVERED | — |
 | 2.1-7 | ⚠️권장 | URL 2000자 이하 유지 | MISSING | MISSING | Minor |
 | 2.2-1 | ✅필수 | GET 요청은 서버 상태 변경 안 함 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 2.2-2 | ✅필수 | PUT 요청은 멱등적으로 동작 | COVERED | COVERED | ~~Critical~~ Fixed |
-| 2.2-3 | ⚠️권장 | 부분 수정에는 PUT 대신 PATCH 사용 | COVERED | MISSING | Minor |
-| 2.2-4 | ❌금지 | GET/HEAD/DELETE 요청에 body 포함 금지 | MISSING | MISSING | Minor |
+| 2.2-3 | ⚠️권장 | 부분 수정에는 PUT 대신 PATCH 사용 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.2-4 | ❌금지 | GET/HEAD/DELETE 요청에 body 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 | 2.2-5 | ✅필수 | 표준 HTTP 상태 코드를 정확한 의미에 맞게 사용 | COVERED | COVERED | — |
 | 2.2-6 | ✅필수 | 201 Created 응답에 Location 헤더 포함 | COVERED | COVERED | — |
-| 2.2-7 | ❌금지 | 오류 상황에 200 OK 반환 금지 | MISSING | COVERED | Minor |
+| 2.2-7 | ❌금지 | 오류 상황에 200 OK 반환 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 | 2.3-1 | ✅필수 | 동일 파라미터 반복으로 배열 값 전달 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 2.3-2 | ⚠️권장 | 쿼리 파라미터는 선택적으로 설계 | MISSING | MISSING | Minor |
-| 2.3-3 | ⚠️권장 | 쿼리 파라미터에 민감한 정보 포함 금지 | MISSING | MISSING | Minor |
-| 2.3-4 | ❌금지 | 서버 상태 변경에 쿼리 파라미터 사용 금지 | MISSING | MISSING | Minor |
+| 2.3-3 | ⚠️권장 | 쿼리 파라미터에 민감한 정보 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.3-4 | ❌금지 | 서버 상태 변경에 쿼리 파라미터 사용 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 | 2.4-1 | ✅필수 | 요청 본문 있을 때 Content-Type 헤더 포함 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 2.4-2 | ✅필수 | 응답 본문 있을 때 Content-Type 헤더 포함 | COVERED | COVERED | ~~Critical~~ Fixed |
-| 2.4-3 | ⚠️권장 | 커스텀 헤더에 X- 접두사 사용 금지 (신규) | MISSING | COVERED | Minor |
-| 2.4-4 | ❌금지 | 표준 HTTP 헤더 의미 재정의 금지 | MISSING | MISSING | Minor |
+| 2.4-3 | ⚠️권장 | 커스텀 헤더에 X- 접두사 사용 금지 (신규) | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.4-4 | ❌금지 | 표준 HTTP 헤더 의미 재정의 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 
 ---
 
@@ -51,7 +51,7 @@
 | 3.1-1 | ✅필수 | 모든 리소스는 고유 id 가짐 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 3.1-2 | ✅필수 | 리소스 스키마는 일관된 구조 유지 (id/createdAt/updatedAt) | COVERED | COVERED | ~~Critical~~ Fixed |
 | 3.1-3 | ⚠️권장 | 리소스 식별자는 불투명한 문자열 | MISSING | MISSING | Minor |
-| 3.1-4 | ❌금지 | 응답에 null 값 필드 포함 금지 | MISSING | COVERED | Minor |
+| 3.1-4 | ❌금지 | 응답에 null 값 필드 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 | 3.2-1 | ✅필수 | 서버 관리 읽기 전용 필드를 요청 본문에 포함해도 무시 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 3.3-1 | ✅필수 | POST 생성 성공 시 201 Created + 생성된 리소스 반환 | COVERED | COVERED | — |
 | 3.3-2 | ✅필수 | PUT은 리소스 전체 대체, 미포함 필드는 기본값/null | COVERED | COVERED | ~~Critical~~ Fixed |
@@ -59,7 +59,7 @@
 | 3.4-1 | ✅필수 | 모든 에러 응답은 RFC 7807/9457 구조 따름 | COVERED | COVERED | — |
 | 3.4-2 | ✅필수 | 에러 응답 Content-Type은 application/problem+json | COVERED | COVERED | — |
 | 3.4-3 | ⚠️권장 | 유효성 검사 실패 시 모든 오류 필드 한 번에 반환 | COVERED | COVERED | — |
-| 3.4-4 | ❌금지 | 에러 응답에 스택 트레이스/내부 정보 노출 금지 | MISSING | COVERED | Minor |
+| 3.4-4 | ❌금지 | 에러 응답에 스택 트레이스/내부 정보 노출 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 
 ---
 
@@ -69,19 +69,19 @@
 |---|-----------|-----------|---------|--------|--------|
 | 4.1-1 | ✅필수 | JSON 필드 이름은 camelCase | COVERED | COVERED | — |
 | 4.1-2 | ✅필수 | 필드 이름은 영소문자로 시작 | COVERED | COVERED | ~~Critical~~ Fixed |
-| 4.1-3 | ❌금지 | 필드 이름에 약어 남용 금지 | MISSING | MISSING | Minor |
+| 4.1-3 | ❌금지 | 필드 이름에 약어 남용 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 | 4.2-1 | ✅필수 | Boolean은 JSON true/false 사용 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 4.2-2 | ✅필수 | Boolean 필드 이름에 is/has/can 접두사 | COVERED | COVERED | — |
 | 4.2-3 | ✅필수 | 숫자 값은 JSON number 타입 | COVERED | COVERED | ~~Critical~~ Fixed |
-| 4.2-4 | ⚠️권장 | 큰 정수(2^53 초과)는 문자열로 반환 | MISSING | MISSING | Minor |
+| 4.2-4 | ⚠️권장 | 큰 정수(2^53 초과)는 문자열로 반환 | COVERED | COVERED | ~~Minor~~ Fixed |
 | 4.3-1 | ✅필수 | 날짜/시간은 RFC 3339 형식 문자열 | COVERED | COVERED | — |
 | 4.3-2 | ✅필수 | 시간대가 있으면 반드시 포함, UTC는 Z | COVERED | COVERED | — |
 | 4.3-3 | ✅필수 | 서버 응답 시간 값은 모두 UTC(Z) | COVERED | COVERED | — |
 | 4.3-4 | ✅필수 | 클라이언트가 오프셋 포함 전송 시 서버가 UTC로 변환하여 저장 | COVERED | COVERED | — |
-| 4.3-5 | ❌금지 | Unix timestamp를 기본 시간 형식으로 사용 금지 | COVERED | MISSING | Minor |
+| 4.3-5 | ❌금지 | Unix timestamp를 기본 시간 형식으로 사용 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 | 4.4-1 | ✅필수 | Enum 값은 UPPER_SNAKE_CASE 문자열 | COVERED | COVERED | — |
-| 4.4-2 | ⚠️권장 | 클라이언트가 알 수 없는 Enum 값 수신 가능하도록 설계 | MISSING | MISSING | Minor |
-| 4.4-3 | ❌금지 | Enum 값으로 숫자나 불명확한 약어 사용 금지 | PARTIAL | MISSING | Minor |
+| 4.4-2 | ⚠️권장 | 클라이언트가 알 수 없는 Enum 값 수신 가능하도록 설계 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 4.4-3 | ❌금지 | Enum 값으로 숫자나 불명확한 약어 사용 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 
 ---
 
@@ -94,7 +94,7 @@
 | 5.2-1 | ✅필수 | 컬렉션 응답 본문은 top-level JSON array | COVERED | COVERED | — |
 | 5.2-2 | ✅필수 | 다음 페이지 없을 때 Link 헤더에서 rel="next" 제외 | COVERED | COVERED | — |
 | 5.3-1 | ✅필수 | 동일 파라미터 반복은 OR 조건 | COVERED | COVERED | ~~Critical~~ Fixed |
-| 5.4-1 | ❌금지 | API 버전을 URL 경로에 포함 금지 | MISSING | COVERED | Minor |
+| 5.4-1 | ❌금지 | API 버전을 URL 경로에 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 | 5.4-2 | ✅필수 | X-API-Version 헤더에 ISO 8601 날짜 형식으로 버전 지정 | COVERED | COVERED | — |
 | 5.4-3 | ✅필수 | 동일 버전 내 하위 호환성 유지 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 5.5-1 | ✅필수 | Deprecated API에 Deprecation/Sunset/Link 응답 헤더 제공 | COVERED | COVERED | ~~Critical~~ Fixed |
@@ -104,7 +104,7 @@
 | 5.6-4 | ✅필수 | 클라이언트는 429 수신 시 Retry-After 값만큼 대기 후 재시도 | COVERED | COVERED | — |
 | 5.7-1 | ✅필수 | 장기 실행 작업 시 도메인 리소스 즉시 생성 + 201 Created + Location 헤더 | COVERED | COVERED | — |
 | 5.7-2 | ✅필수 | 도메인 리소스에 status 필드 포함 | COVERED | COVERED | — |
-| 5.7-3 | ❌금지 | 범용 /operations 리소스 사용 금지 | MISSING | COVERED | Minor |
+| 5.7-3 | ❌금지 | 범용 /operations 리소스 사용 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 
 ---
 
@@ -113,7 +113,7 @@
 | # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
 |---|-----------|-----------|---------|--------|--------|
 | 6.1-1 | ✅필수 | 인증 토큰은 Authorization 헤더 사용 | COVERED | COVERED | — |
-| 6.1-2 | ❌금지 | API Key를 쿼리 파라미터로 전달 금지 | MISSING | COVERED | Minor |
+| 6.1-2 | ❌금지 | API Key를 쿼리 파라미터로 전달 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
 | 6.2-1 | ✅필수 | 401 응답에 WWW-Authenticate 헤더 포함 | COVERED | COVERED | — |
 | 6.2-2 | ✅필수 | 401(인증 실패) / 403(인가 실패) 정확히 구분 | COVERED | COVERED | — |
 | 6.3-1 | ✅필수 | 중복 실행 위험 있는 POST에 Idempotency-Key 지원 | COVERED | COVERED | — |
@@ -127,27 +127,27 @@
 
 | 상태 | 개수 | 비율 |
 |------|------|------|
-| COVERED | 51 | 71.8% |
-| PARTIAL | 2 | 2.8% |
-| MISSING | 18 | 25.4% |
+| COVERED | 68 | 95.8% |
+| PARTIAL | 0 | 0.0% |
+| MISSING | 3 | 4.2% |
 | **합계** | **71** | **100%** |
 
 ### Review 모드
 
 | 상태 | 개수 | 비율 |
 |------|------|------|
-| COVERED | 58 | 81.7% |
+| COVERED | 68 | 95.8% |
 | PARTIAL | 0 | 0.0% |
-| MISSING | 13 | 18.3% |
+| MISSING | 3 | 4.2% |
 | **합계** | **71** | **100%** |
 
 ### 전체 커버리지 (Writing + Review 통합)
 
 | 상태 | 개수 | 비율 |
 |------|------|------|
-| COVERED | 109 | 76.8% |
-| PARTIAL | 2 | 1.4% |
-| MISSING | 31 | 21.8% |
+| COVERED | 136 | 95.8% |
+| PARTIAL | 0 | 0.0% |
+| MISSING | 6 | 4.2% |
 | **합계** | **142** | **100%** |
 
 \* 전체는 71개 규칙 × 2개 모드(Writing/Review)의 합산 수치입니다.
@@ -194,30 +194,30 @@
 |---|------|------|
 | 2.1-1 | COVERED | "Plural nouns + kebab-case" 주석과 `/user-profiles` 등 예시 있음 |
 | 2.1-2 | COVERED | `/articles`, `/users/{userId}/comments` 복수형 예시 있음 |
-| 2.1-3 | PARTIAL | 액션 패턴 `:action` 예시 있으나 "동사 금지" 규칙 자체를 명시하지 않음, bad case 없음 |
-| 2.1-4 | MISSING | 파일 확장자 금지 언급 없음 |
+| 2.1-3 | COVERED | bad case `/getUsers`, `/createArticle` 추가 및 "동사 금지" 명시 (Minor 개선) |
+| 2.1-4 | COVERED | "파일 확장자 금지" 규칙 추가 (Minor 개선) |
 | 2.1-5 | PARTIAL | kebab-case 언급으로 간접 포함되나 허용 문자 집합(ASCII 영소문자/숫자/하이픈만) 명시 없음 |
 | 2.1-6 | COVERED | `pageSize`, `pageToken`, `sortOrder` 등 camelCase 예시와 "(camelCase)" 명시 있음 |
 | 2.1-7 | MISSING | URL 길이 제한 언급 없음 |
 | 2.2-1 | MISSING | GET의 안전성(서버 상태 변경 안 함) 규칙 명시 없음 |
 | 2.2-2 | PARTIAL | 상태코드 표에 "Full replacement success" 언급만, 멱등성 규칙 명시 없음 |
 | 2.2-3 | COVERED | PATCH 메서드 코드 예시(updateArticle)와 상태코드 매핑 있음 |
-| 2.2-4 | MISSING | GET/HEAD/DELETE body 금지 규칙 없음 |
+| 2.2-4 | COVERED | "GET/HEAD/DELETE body 금지" 규칙 추가 (Minor 개선) |
 | 2.2-5 | COVERED | HTTP Method to Status Code Mapping 표에 상세 매핑 있음 |
 | 2.2-6 | COVERED | "201 Created + Location header" 명시, 코드 예시에 `ResponseEntity.created(location)` 있음 |
-| 2.2-7 | MISSING | "200 OK로 에러 반환 금지" 규칙 명시 없음 |
-| 2.3-1 | MISSING | 동일 파라미터 반복으로 배열 전달하는 패턴 없음 |
-| 2.3-2 | MISSING | 쿼리 파라미터 선택적 설계 규칙 없음 |
-| 2.3-3 | MISSING | 쿼리 파라미터 민감 정보 금지 규칙 없음 |
-| 2.3-4 | MISSING | 서버 상태 변경에 쿼리 파라미터 사용 금지 없음 |
+| 2.2-7 | COVERED | "200 OK 에러 반환 금지" 규칙 추가 (Minor 개선) |
+| 2.3-1 | COVERED | URL Naming Rules에 `?status=PUBLISHED&status=DRAFT` 예시 추가됨 (Critical 개선) |
+| 2.3-2 | MISSING | 쿼리 파라미터 선택적 설계 규칙 없음 (Tier C — 보류) |
+| 2.3-3 | COVERED | "민감한 정보 쿼리 파라미터 금지" 규칙이 이미 스킬에 존재 (스킬 기준 재확인) |
+| 2.3-4 | COVERED | "서버 상태 변경에 쿼리 파라미터 금지" 규칙이 이미 스킬에 존재 (스킬 기준 재확인) |
 | 2.4-1 | PARTIAL | 에러 응답 `application/problem+json` 언급은 있으나, 일반 요청의 Content-Type 필수 규칙 없음 |
 | 2.4-2 | PARTIAL | 에러 응답 Content-Type만 명시, 정상 응답의 Content-Type 필수 규칙은 코드 예시에서 암시적 |
-| 2.4-3 | MISSING | 커스텀 헤더 X- 접두사 금지 명시 없음 (Rate Limit 헤더에서 X-RateLimit-* 사용) |
-| 2.4-4 | MISSING | 표준 헤더 의미 재정의 금지 없음 |
+| 2.4-3 | COVERED | "신규 커스텀 헤더 X- 접두사 금지" 규칙 추가, X-RateLimit-* 레거시 예외 주석 포함 (Minor 개선) |
+| 2.4-4 | COVERED | "표준 HTTP 헤더 의미 재정의 금지" 규칙 추가 (Minor 개선) |
 | 3.1-1 | COVERED | Standard Resource Fields에 `"id": "Server-generated"` 명시 |
 | 3.1-2 | COVERED | id/createdAt/updatedAt 표준 필드 구조가 Standard Resource Fields에 정의됨 |
-| 3.1-3 | MISSING | 식별자의 불투명성 언급 없음 |
-| 3.1-4 | MISSING | null 값 필드 제외 규칙이 Writing 모드에 없음 |
+| 3.1-3 | MISSING | 식별자 불투명성 언급 없음 (Tier C — 보류) |
+| 3.1-4 | COVERED | "null 값 필드 응답에서 제외" 규칙 추가 및 bad case 예시 포함 (Minor 개선) |
 | 3.2-1 | PARTIAL | "not modifiable by client" 언급 있으나 "포함해도 무시" 동작 명확히 서술되지 않음 |
 | 3.3-1 | COVERED | POST create -> 201 Created + Location + body 코드 예시 있음 |
 | 3.3-2 | PARTIAL | PUT -> "Full replacement success" 테이블 항목만, 미포함 필드 처리 규칙 없음 |
@@ -225,28 +225,28 @@
 | 3.4-1 | COVERED | RFC 7807/9457 구조 명시 + ProblemDetail 클래스 코드 예시 있음 |
 | 3.4-2 | COVERED | `Content-Type: application/problem+json` 명시 |
 | 3.4-3 | COVERED | errors 배열 필드를 포함한 에러 응답 템플릿 있음 |
-| 3.4-4 | MISSING | 스택 트레이스/내부 정보 노출 금지 Writing 가이드 없음 |
+| 3.4-4 | COVERED | "스택 트레이스/내부 정보 노출 금지" 규칙 추가 (Minor 개선) |
 | 4.1-1 | COVERED | "Correct example" / "Incorrect example" JSON 비교 있음 |
 | 4.1-2 | PARTIAL | camelCase 예시가 모두 소문자 시작이지만 "영소문자로 시작" 규칙 명시 없음 |
-| 4.1-3 | MISSING | 약어 남용 금지 규칙 없음 |
+| 4.1-3 | COVERED | "약어 남용 금지" 규칙 추가 및 bad case 예시 포함 (Minor 개선) |
 | 4.2-1 | PARTIAL | `"isActive": true` 예시 있으나, 문자열 "true"/"false" 및 숫자 1/0 금지 명시 없음 |
 | 4.2-2 | COVERED | `is`/`has`/`can` 접두사 예시: `"isActive": true` |
 | 4.2-3 | MISSING | 숫자 타입 규칙 없음 |
-| 4.2-4 | MISSING | 큰 정수 문자열 반환 규칙 없음 |
+| 4.2-4 | COVERED | "2^53 초과 정수 문자열 반환" 규칙 추가 (Minor 개선) |
 | 4.3-1 | COVERED | RFC 3339 형식 명시 + 예시 있음 |
 | 4.3-2 | COVERED | UTC `Z` 사용 예시 있음 |
 | 4.3-3 | COVERED | "Server response (Required: UTC)" 명시 |
 | 4.3-4 | COVERED | "offset allowed — server normalizes to UTC" 명시 |
 | 4.3-5 | COVERED | "Unix timestamp forbidden" Prohibited 섹션에 명시 |
 | 4.4-1 | COVERED | `"status": "PUBLISHED"` 예시 + "enums must be UPPER_SNAKE_CASE" 명시 |
-| 4.4-2 | MISSING | 알 수 없는 Enum 값 대응 설계 규칙 없음 |
-| 4.4-3 | PARTIAL | "enums must be UPPER_SNAKE_CASE" 명시 있으나 숫자/약어 사용 금지 bad case 없음 |
+| 4.4-2 | COVERED | "알 수 없는 Enum 값 수신 대응 설계" 규칙 추가 (Minor 개선) |
+| 4.4-3 | COVERED | Enum 숫자/약어 bad case 추가 (`"status": 1`) (Minor 개선) |
 | 5.1-1 | COVERED | `:publish`, `:cancel`, `:deactivate` 액션 패턴 예시 있음 |
 | 5.1-2 | COVERED | POST 메서드 사용 예시 있음 |
 | 5.2-1 | COVERED | top-level JSON array 응답 예시 + "top-level array" 명시 |
 | 5.2-2 | COVERED | `nextPageToken` null 시 Link에 next 미포함하는 buildLinkHeader 코드 있음 |
 | 5.3-1 | MISSING | OR 조건 규칙이 Writing 모드에 없음 |
-| 5.4-1 | MISSING | URL 경로 버전 금지 규칙이 Writing 모드에 없음 |
+| 5.4-1 | COVERED | "URL 경로에 버전 금지" 규칙 추가 (Minor 개선) |
 | 5.4-2 | COVERED | X-API-Version 헤더 코드 예시 있음 (ISO 8601 날짜 형식 "2024-01-20") |
 | 5.4-3 | MISSING | 하위 호환성 유지 규칙 없음 |
 | 5.5-1 | COVERED | Deprecation/Sunset/Link 헤더 설정 코드 예시 있음. 커버리지 출처: Writing Mode 본문이 아닌 Code Examples 부록의 Kotlin 코드 예시에서 확인됨. |
@@ -256,9 +256,9 @@
 | 5.6-4 | COVERED | "On 429, wait for the Retry-After header value before retrying" 명시 |
 | 5.7-1 | COVERED | "POST (long-running) 201 Created + Location header" 상태코드 표에 있음 |
 | 5.7-2 | COVERED | "domain resource created immediately with status field" 명시 |
-| 5.7-3 | MISSING | /operations 금지 규칙이 Writing 모드에 없음 |
+| 5.7-3 | COVERED | "/operations 금지" 규칙 추가 (Minor 개선) |
 | 6.1-1 | COVERED | Authorization 헤더 Bearer/ApiKey 예시 있음 |
-| 6.1-2 | MISSING | API Key 쿼리 파라미터 전달 금지 명시 없음 |
+| 6.1-2 | COVERED | "API Key 쿼리 파라미터 금지" 규칙 추가 (Minor 개선) |
 | 6.2-1 | COVERED | WWW-Authenticate 헤더 포함 코드 예시 있음 |
 | 6.2-2 | COVERED | 401 vs 403 구분 표 있음 |
 | 6.3-1 | COVERED | Idempotency-Key 처리 코드 예시 있음 |
@@ -277,22 +277,22 @@
 | 2.1-7 | MISSING | URL 길이 체크 항목 없음 |
 | 2.2-1 | COVERED | "GET requests do not modify server state" 체크리스트 항목 |
 | 2.2-2 | MISSING | PUT 멱등성 체크 항목 없음 |
-| 2.2-3 | MISSING | PATCH 권장 체크 항목 없음 |
-| 2.2-4 | MISSING | GET/HEAD/DELETE body 금지 체크 항목 없음 |
+| 2.2-3 | COVERED | "부분 수정 PATCH 권장" 체크 항목 추가 (Minor 개선) |
+| 2.2-4 | COVERED | GET/HEAD/DELETE body 금지 체크 항목이 이미 스킬에 존재 (스킬 기준 재확인) |
 | 2.2-5 | COVERED | 상태 코드 관련 체크리스트 항목 다수 있음 |
 | 2.2-6 | COVERED | "POST create -> 201 + Location header" 체크리스트 항목 |
 | 2.2-7 | COVERED | "200 not returned for error conditions" 체크리스트 항목 |
 | 2.3-1 | PARTIAL | "Repeated same parameter treated as OR condition" 체크리스트 항목이 존재하나, 이는 의미(OR 조건)를 다루는 것이며 인코딩 방식(동일 파라미터 반복으로 배열 전달) 자체는 간접적으로만 포함됨 |
-| 2.3-2 | MISSING | 쿼리 파라미터 선택적 설계 체크 없음 |
-| 2.3-3 | MISSING | 쿼리 파라미터 민감 정보 체크 없음 |
-| 2.3-4 | MISSING | 서버 상태 변경 쿼리 파라미터 금지 체크 없음 |
+| 2.3-2 | MISSING | 쿼리 파라미터 선택적 설계 체크 없음 (Tier C — 보류) |
+| 2.3-3 | COVERED | "민감한 정보 쿼리 파라미터 금지" 체크 항목이 이미 스킬에 존재 (스킬 기준 재확인) |
+| 2.3-4 | COVERED | "서버 상태 변경 쿼리 파라미터 금지" 체크 항목이 이미 스킬에 존재 (스킬 기준 재확인) |
 | 2.4-1 | MISSING | 요청 Content-Type 체크 항목 없음 |
 | 2.4-2 | MISSING | 응답 Content-Type 일반 규칙 체크 항목 없음 (에러 응답 Content-Type만) |
 | 2.4-3 | COVERED | "New custom headers do not use X- prefix" 체크리스트 항목 |
-| 2.4-4 | MISSING | 표준 헤더 의미 재정의 금지 체크 없음 |
+| 2.4-4 | COVERED | "표준 HTTP 헤더 의미 재정의 금지" 체크 항목 추가 (Minor 개선) |
 | 3.1-1 | MISSING | 리소스 id 필수 체크 항목 없음 |
 | 3.1-2 | MISSING | 리소스 표준 필드 구조 체크 항목 없음 |
-| 3.1-3 | MISSING | 식별자 불투명성 체크 없음 |
+| 3.1-3 | MISSING | 식별자 불투명성 체크 없음 (Tier C — 보류) |
 | 3.1-4 | COVERED | "Null-valued fields excluded from response" 체크리스트 항목 |
 | 3.2-1 | MISSING | 읽기 전용 필드 무시 동작 체크 없음 |
 | 3.3-1 | COVERED | "POST create -> 201 + Location header" 체크리스트 항목 |
@@ -304,19 +304,19 @@
 | 3.4-4 | COVERED | "Internal implementation details not exposed" 체크리스트 항목 |
 | 4.1-1 | COVERED | "All fields are camelCase" 체크리스트 항목 |
 | 4.1-2 | MISSING | 영소문자 시작 체크 항목 없음 |
-| 4.1-3 | MISSING | 약어 남용 금지 체크 없음 |
+| 4.1-3 | COVERED | "약어 남용 금지" 체크 항목 추가 (Minor 개선) |
 | 4.2-1 | MISSING | Boolean JSON true/false 체크 항목 없음 |
 | 4.2-2 | COVERED | "Boolean fields use is/has/can prefix" 체크리스트 항목 |
 | 4.2-3 | MISSING | 숫자 JSON number 타입 체크 없음 |
-| 4.2-4 | MISSING | 큰 정수 문자열 반환 체크 없음 |
+| 4.2-4 | COVERED | "2^53 초과 정수 문자열 반환" 체크 항목 추가 (Minor 개선) |
 | 4.3-1 | COVERED | "Date/time in RFC 3339 format" 체크리스트 항목 |
 | 4.3-2 | COVERED | "All time values in server response are UTC (Z)" 체크리스트 항목이 이 규칙을 직접 커버함 |
 | 4.3-3 | COVERED | "All time values in server response are UTC (Z)" 체크리스트 항목 |
 | 4.3-4 | COVERED | "Offset input is normalized to UTC by server (not an error)" 체크리스트 항목 |
-| 4.3-5 | MISSING | Unix timestamp 금지 체크 항목 없음 |
+| 4.3-5 | COVERED | "Unix timestamp 금지" 체크 항목 추가 (Minor 개선) |
 | 4.4-1 | COVERED | "Enum values are UPPER_SNAKE_CASE" 체크리스트 항목 |
-| 4.4-2 | MISSING | 알 수 없는 Enum 값 대응 체크 없음 |
-| 4.4-3 | MISSING | Enum 숫자/약어 금지 체크 없음 |
+| 4.4-2 | COVERED | "알 수 없는 Enum 값 수신 대응" 체크 항목 추가 (Minor 개선) |
+| 4.4-3 | COVERED | "Enum 숫자/약어 금지" 체크 항목 추가 (Minor 개선) |
 | 5.1-1 | COVERED | "No verbs in paths (actions use :action pattern)" 체크리스트 항목 |
 | 5.1-2 | COVERED | 액션 패턴이 POST 사용하는 것이 URL Design 체크에 포함 |
 | 5.2-1 | COVERED | "Collection response body is a top-level array" 체크리스트 항목 |

--- a/docs/evaluation/report.md
+++ b/docs/evaluation/report.md
@@ -11,13 +11,14 @@
 
 | 모드 | COVERED | PARTIAL | MISSING | 합계 | 커버율 |
 |------|---------|---------|---------|------|--------|
-| Writing | 51 | 2 | 18 | 71 | 73.2% |
-| Review | 58 | 0 | 13 | 71 | 81.7% |
+| Writing | 68 | 0 | 3 | 71 | 95.8% |
+| Review | 68 | 0 | 3 | 71 | 95.8% |
 
 > 커버율 = (COVERED + PARTIAL×0.5) / 합계 × 100
 >
 > **수정 전 (2026-03-20 초기 평가):** Writing 59.9% / Review 62.0%
 > **수정 후 (Critical 반영):** Writing 73.2% / Review 81.7%
+> **수정 후 (Minor 반영):** Writing 95.8% / Review 95.8%
 
 ---
 
@@ -68,32 +69,32 @@
 
 ## Minor 문제 (단계적 수정)
 
-> ⚠️권장/❌금지 규칙 중 하나 이상의 모드에서 MISSING인 항목 — 총 22개
+> ⚠️권장/❌금지 규칙 중 하나 이상의 모드에서 MISSING인 항목 — 총 22개 → **19개 해결됨 (Minor 개선)**, 3개 Tier C 보류
 
 | # | 규범 수준 | 규칙 요약 | Writing | Review | 비고 |
 |---|-----------|-----------|---------|--------|------|
-| 2.1-3 | ❌금지 | URL에 동사 포함 금지 | PARTIAL | COVERED | Writing에 "동사 금지" 규칙 명시 없음, bad case 없음 |
-| 2.1-4 | ❌금지 | URL에 파일 확장자 포함 금지 | MISSING | COVERED | Writing에 확장자 금지 언급 없음 |
-| 2.1-7 | ⚠️권장 | URL 2000자 이하 유지 | MISSING | MISSING | 양쪽 모두 URL 길이 제한 없음 |
-| 2.2-3 | ⚠️권장 | 부분 수정에는 PUT 대신 PATCH 사용 | COVERED | MISSING | Review에 PATCH 권장 체크 없음 |
-| 2.2-4 | ❌금지 | GET/HEAD/DELETE 요청에 body 포함 금지 | MISSING | MISSING | 양쪽 모두 body 금지 규칙 없음 |
-| 2.2-7 | ❌금지 | 오류 상황에 200 OK 반환 금지 | MISSING | COVERED | Writing에 200 OK 에러 반환 금지 없음 |
-| 2.3-2 | ⚠️권장 | 쿼리 파라미터는 선택적으로 설계 | MISSING | MISSING | 양쪽 모두 없음 |
-| 2.3-3 | ⚠️권장 | 쿼리 파라미터에 민감한 정보 포함 금지 | MISSING | MISSING | 양쪽 모두 없음 |
-| 2.3-4 | ❌금지 | 서버 상태 변경에 쿼리 파라미터 사용 금지 | MISSING | MISSING | 양쪽 모두 없음 |
-| 2.4-3 | ⚠️권장 | 커스텀 헤더에 X- 접두사 사용 금지 (신규) | MISSING | COVERED | Writing에 X- 접두사 금지 없음 (Rate Limit에서 X-RateLimit-* 사용 중) |
-| 2.4-4 | ❌금지 | 표준 HTTP 헤더 의미 재정의 금지 | MISSING | MISSING | 양쪽 모두 없음 |
-| 3.1-3 | ⚠️권장 | 리소스 식별자는 불투명한 문자열 | MISSING | MISSING | 양쪽 모두 없음 |
-| 3.1-4 | ❌금지 | 응답에 null 값 필드 포함 금지 | MISSING | COVERED | Writing에 null 제외 규칙 없음 |
-| 3.4-4 | ❌금지 | 에러 응답에 스택 트레이스/내부 정보 노출 금지 | MISSING | COVERED | Writing에 내부 정보 노출 금지 없음 |
-| 4.1-3 | ❌금지 | 필드 이름에 약어 남용 금지 | MISSING | MISSING | 양쪽 모두 없음 |
-| 4.2-4 | ⚠️권장 | 큰 정수(2^53 초과)는 문자열로 반환 | MISSING | MISSING | 양쪽 모두 없음 |
-| 4.3-5 | ❌금지 | Unix timestamp를 기본 시간 형식으로 사용 금지 | COVERED | MISSING | Review에 Unix timestamp 금지 체크 없음 |
-| 4.4-2 | ⚠️권장 | 클라이언트가 알 수 없는 Enum 값 수신 가능하도록 설계 | MISSING | MISSING | 양쪽 모두 없음 |
-| 4.4-3 | ❌금지 | Enum 값으로 숫자나 불명확한 약어 사용 금지 | PARTIAL | MISSING | Review에 Enum 숫자/약어 금지 체크 없음 |
-| 5.4-1 | ❌금지 | API 버전을 URL 경로에 포함 금지 | MISSING | COVERED | Writing에 URL 경로 버전 금지 없음 |
-| 5.7-3 | ❌금지 | 범용 /operations 리소스 사용 금지 | MISSING | COVERED | Writing에 /operations 금지 없음 |
-| 6.1-2 | ❌금지 | API Key를 쿼리 파라미터로 전달 금지 | MISSING | COVERED | Writing에 쿼리 파라미터 API Key 금지 없음 |
+| 2.1-3 | ❌금지 | URL에 동사 포함 금지 | COVERED | COVERED | ✅ bad case 및 금지 규칙 추가 |
+| 2.1-4 | ❌금지 | URL에 파일 확장자 포함 금지 | COVERED | COVERED | ✅ 금지 규칙 추가 |
+| 2.1-7 | ⚠️권장 | URL 2000자 이하 유지 | MISSING | MISSING | ⏸️ Tier C 보류 — 런타임 관심사, 코드 리뷰로 검증 어려움 |
+| 2.2-3 | ⚠️권장 | 부분 수정에는 PUT 대신 PATCH 사용 | COVERED | COVERED | ✅ Review 체크리스트 추가 |
+| 2.2-4 | ❌금지 | GET/HEAD/DELETE 요청에 body 포함 금지 | COVERED | COVERED | ✅ Writing 규칙 추가, Review는 기존 포함 확인 |
+| 2.2-7 | ❌금지 | 오류 상황에 200 OK 반환 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 |
+| 2.3-2 | ⚠️권장 | 쿼리 파라미터는 선택적으로 설계 | MISSING | MISSING | ⏸️ Tier C 보류 — 추상적 설계 원칙, 코드 레벨 감지 어려움 |
+| 2.3-3 | ⚠️권장 | 쿼리 파라미터에 민감한 정보 포함 금지 | COVERED | COVERED | ✅ 기존 스킬에 이미 포함됨 (coverage map 오류 수정) |
+| 2.3-4 | ❌금지 | 서버 상태 변경에 쿼리 파라미터 사용 금지 | COVERED | COVERED | ✅ 기존 스킬에 이미 포함됨 (coverage map 오류 수정) |
+| 2.4-3 | ⚠️권장 | 커스텀 헤더에 X- 접두사 사용 금지 (신규) | COVERED | COVERED | ✅ Writing 규칙 추가 (X-RateLimit-* 레거시 예외 주석 포함) |
+| 2.4-4 | ❌금지 | 표준 HTTP 헤더 의미 재정의 금지 | COVERED | COVERED | ✅ Writing/Review 모두 추가 |
+| 3.1-3 | ⚠️권장 | 리소스 식별자는 불투명한 문자열 | MISSING | MISSING | ⏸️ Tier C 보류 — 아키텍처 결정 영역, 코드 리뷰로 판단 어려움 |
+| 3.1-4 | ❌금지 | 응답에 null 값 필드 포함 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 및 bad case 포함 |
+| 3.4-4 | ❌금지 | 에러 응답에 스택 트레이스/내부 정보 노출 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 |
+| 4.1-3 | ❌금지 | 필드 이름에 약어 남용 금지 | COVERED | COVERED | ✅ Writing/Review 모두 추가 |
+| 4.2-4 | ⚠️권장 | 큰 정수(2^53 초과)는 문자열로 반환 | COVERED | COVERED | ✅ Writing/Review 모두 추가 |
+| 4.3-5 | ❌금지 | Unix timestamp를 기본 시간 형식으로 사용 금지 | COVERED | COVERED | ✅ Review 체크리스트 추가 |
+| 4.4-2 | ⚠️권장 | 클라이언트가 알 수 없는 Enum 값 수신 가능하도록 설계 | COVERED | COVERED | ✅ Writing/Review 모두 추가 |
+| 4.4-3 | ❌금지 | Enum 값으로 숫자나 불명확한 약어 사용 금지 | COVERED | COVERED | ✅ bad case 추가 및 Review 체크 추가 |
+| 5.4-1 | ❌금지 | API 버전을 URL 경로에 포함 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 |
+| 5.7-3 | ❌금지 | 범용 /operations 리소스 사용 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 |
+| 6.1-2 | ❌금지 | API Key를 쿼리 파라미터로 전달 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 |
 
 ---
 
@@ -214,4 +215,4 @@ Review Mode 체크리스트 추가 항목:
 - [x] Critical 문제 스킬에 반영 (Task 5) — 17개 Critical 항목 모두 해결
 - [x] 스킬 변경 후 동일 테스트 케이스로 회귀 검증
 - [x] report.md 커버리지 수치 업데이트
-- [ ] Minor 문제 스킬에 반영 (22개 항목)
+- [x] Minor 문제 스킬에 반영 — 19개 해결 (Tier A 14개 + Tier B 5개), 3개 Tier C 보류 (2.1-7, 2.3-2, 3.1-3)


### PR DESCRIPTION
## Summary
- 22개 Minor 항목 중 19개를 스킬에 반영 (Tier A 14개 + Tier B 5개), 3개 Tier C 보류
- Writing Mode: 15개 금지/권장 규칙 추가 (동사 금지 bad case, 파일 확장자 금지, URL 버전 경로 금지, GET/HEAD/DELETE body 금지, 200 에러 반환 금지, X- 접두사 주의, 표준 헤더 재정의 금지, /operations 금지, null 필드 금지, 스택 트레이스 노출 금지, 약어 금지, 큰 정수 문자열 반환, Enum 확장 설계, Enum 숫자 bad case, API Key 쿼리 파라미터 금지)
- Review Mode: 7개 체크리스트 항목 추가 (PATCH 권장, 표준 헤더 재정의 체크, 약어 체크, 큰 정수 체크, Unix timestamp 체크, Enum 확장 체크, Enum 숫자 체크)
- `docs/` 폴더를 `.gitignore`에 추가
- coverage-map.md 업데이트: Writing 73.2% → 95.8%, Review 81.7% → 95.8%
- report.md Minor 항목 테이블 적용 결과 반영

## Test plan
- [ ] 스킬 파일에서 새로 추가된 규칙/체크리스트 항목 수 확인 (Writing +15, Review +7)
- [ ] coverage-map.md 합계 정확성 검증 (COVERED 68, MISSING 3, 합계 71)
- [ ] X-RateLimit-* 레거시 예외 주석이 기존 Rate Limiting 섹션과 충돌 없는지 확인