### PR TITLE
fix: restore and fix versioning section in SKILL.md

### DIFF
--- a/.claude/skills/restful-api-guidelines.md
+++ b/.claude/skills/restful-api-guidelines.md
@@ -316,7 +316,7 @@ When reviewing API code, identify violations using the checklist below and sugge
 #### Versioning
 - [ ] API version delivered via `X-API-Version` header, not URL path
 - [ ] `X-API-Version` value uses ISO 8601 date format (`YYYY-MM-DD`)
-- [ ] Breaking changes (field removal/rename, type change, required field addition) are accompanied by a new X-API-Version date
+- [ ] Breaking changes (field removal/rename, type change, required field addition, enum value removal, status code semantics change) are accompanied by a new X-API-Version date
 - [ ] Non-breaking changes (new optional fields, new endpoints, new Enum values) do not require version bump
 
 #### HTTP Methods & Status Codes


### PR DESCRIPTION
## Summary
- Restore missing `## API Versioning` section in deployed SKILL.md (was entirely absent)
- Add `## Deprecation` section to SKILL.md (Deprecation/Sunset/Link headers + 6-month notice rule)
- Add `status code semantics change` to breaking changes list in SKILL.md
- Add `status code semantics change` and `enum value removal` to Review checklist breaking changes in project skill

## Test plan
- [ ] SKILL.md has API Versioning section with correct breaking/compatible change list
- [ ] SKILL.md has Deprecation section with required headers
- [ ] Review checklist versioning items are complete