### PR TITLE
feat(restful-api-guidelines): add URL path nesting depth limit rule

### DIFF
--- a/plugins/restful-api-guidelines/skills/restful-api-guidelines/SKILL.md
+++ b/plugins/restful-api-guidelines/skills/restful-api-guidelines/SKILL.md
@@ -18,6 +18,17 @@ Source: https://github.com/ppzxc/restful-api-guidelines
 - **camelCase** for query parameters: `pageSize=20&sortOrder=desc`
 - ASCII lowercase letters, numerals, and hyphens only in path segments
 - Repeat parameter names for arrays: `?tag=tech&tag=design`
+- **Max nesting depth: 2 levels** — `/{resource}/{resourceId}/{innerResource}/{innerResourceId}`
+
+**Nesting depth rule:**
+
+Use at most one level of sub-resource nesting. For deeper relationships, use a flat top-level route instead.
+
+| Situation | ✅ Do | ❌ Don't |
+|-----------|-------|---------|
+| Order items under an order | `/orders/{orderId}/items/{itemId}` | `/users/{userId}/orders/{orderId}/items/{itemId}` |
+| Reviews on an order item | `/order-items/{orderItemId}/reviews/{reviewId}` | `/users/{userId}/orders/{orderId}/items/{itemId}/reviews/{reviewId}` |
+| Delivery zones under address | `/addresses/{addressId}/delivery-zones/{zoneId}` | `/users/{userId}/addresses/{addressId}/delivery-zones/{zoneId}` |
 
 ## HTTP Methods
 


### PR DESCRIPTION
## Summary
- URL 중첩 경로 깊이를 최대 2단계로 제한하는 규칙 추가

## Motivation
깊이 제한 없이 설계하면 `/users/{userId}/orders/{orderId}/items/{itemId}/reviews/{reviewId}` 같이 4단계 이상의 중첩 URL이 자연스럽게 생성됨. 이는 URL 가독성을 해치고 REST 자원 식별 원칙에서 멀어지는 결과를 초래함.

## Changes
- `/{resource}/{resourceId}/{innerResource}/{innerResourceId}` 를 최대 허용 깊이로 명시
- 3단계 이상이 필요한 경우 상위 리소스 기준 flat 라우트로 분리하는 전략 추가
- 잘못된 패턴과 올바른 패턴을 비교한 예시 테이블 추가

## Test plan
- [x] 규칙 없는 상태에서 에이전트 baseline 테스트 (위반 확인)
- [x] 규칙 추가 후 에이전트 검증 테스트 (준수 확인)