### PR TITLE
feat(api): adopt RFC 6648 header naming and add MADR decision record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .worktrees/
 docs/*
 !docs/adr/
+!docs/decisions/

--- a/docs/decisions/0003-adopt-rfc-6648-for-custom-http-header-naming.md
+++ b/docs/decisions/0003-adopt-rfc-6648-for-custom-http-header-naming.md
@@ -1,0 +1,60 @@
+# Adopt RFC 6648 for Custom HTTP Header Naming
+
+## Status
+
+accepted
+
+## Context and Problem Statement
+
+`api:restful-guidelines` 스킬의 Headers 섹션은 "Custom headers omit deprecated `X-` prefix (RFC 6648)"라고 명시하면서도,
+API Versioning 예시에서 `X-API-Version`, Headers 섹션에서 `X-Total-Count`를 사용하는 자기 모순 상태였다.
+신규 프로젝트에서 어떤 커스텀 헤더 네이밍 규칙을 따라야 하는가?
+
+## Decision Drivers
+
+* RFC 6648 (BCP 178) — 신규 파라미터에 `X-` 접두사 사용을 금지
+* 신규 프로젝트이므로 기존 클라이언트와의 하위 호환성 부담이 없음
+* 스킬 내부 일관성 — 규칙과 예시가 동일한 기준을 따라야 함
+* IETF 표준 정렬 — `Idempotency-Key`는 IETF 드래프트가 `X-` 없이 정의
+
+## Considered Options
+
+* Option A: `X-` 접두사 유지 (현상 유지)
+* Option B: 모든 신규 커스텀 헤더에서 `X-` 접두사 제거 (RFC 6648 준수)
+
+## Decision Outcome
+
+Chosen option: "Option B", because RFC 6648/BCP 178이 명시적으로 신규 헤더의 `X-` 접두사를 금지하며,
+신규 프로젝트이므로 마이그레이션 비용이 없고, 스킬 자체 규칙과 예시의 일관성을 확보할 수 있기 때문이다.
+
+변경 대상 헤더:
+
+| 변경 전 | 변경 후 | 비고 |
+|---------|---------|------|
+| `X-API-Version` | `Api-Version` | ISO 8601 날짜 기반 버전 |
+| `X-Total-Count` | `Total-Count` | 컬렉션 총 개수 |
+| `X-Idempotency-Key` | `Idempotency-Key` | IETF 드래프트와 일치 |
+| `X-Organization-Id` | `Organization-Id` | 멀티테넌트 식별 |
+| `X-Forwarded-For` | 유지 | RFC 7239 표준, 프록시 호환성 예외 |
+
+### Consequences
+
+* Good: RFC 6648/BCP 178 준수로 장기적으로 표준 헤더로 승격 시 이름 충돌 없음
+* Good: 스킬 규칙과 예시가 일관됨 — 자기 모순 해소
+* Good: `Idempotency-Key`가 IETF 드래프트와 즉시 호환
+* Bad: `X-` 접두사에 익숙한 개발자에게 초기 혼란 가능 — 명시적 RFC 인용으로 완화
+
+## Pros and Cons of the Options
+
+### Option A: `X-` 접두사 유지
+
+* Good: 관행적으로 익숙한 패턴
+* Bad: RFC 6648을 직접 위반
+* Bad: 스킬 자체 규칙("Custom headers omit X- prefix")과 모순
+
+### Option B: `X-` 접두사 제거 (RFC 6648 준수)
+
+* Good: RFC 6648/BCP 178 완전 준수
+* Good: 신규 프로젝트이므로 마이그레이션 비용 제로
+* Good: IETF 드래프트(`Idempotency-Key`) 및 표준 정렬
+* Bad: 일부 레거시 문서나 서드파티 예시와 불일치 가능 — 예외 목록으로 관리

--- a/plugins/api/docs/evaluation/coverage-map.md
+++ b/plugins/api/docs/evaluation/coverage-map.md
@@ -1,0 +1,341 @@
+# Coverage Map — RESTful API Guidelines Skill
+
+**평가 날짜:** 2026-03-20
+**README:** README.md
+**스킬:** .claude/skills/restful-api-guidelines.md
+
+---
+
+## 범례
+| 상태 | 의미 |
+|------|------|
+| COVERED | 규칙의 핵심 요건이 명시적 문장 또는 코드 예시로 표현됨 |
+| PARTIAL | 언급되지만 반례/예외/적용 범위 누락 |
+| MISSING | 스킬에서 찾을 수 없음 |
+
+---
+
+## 섹션 2: HTTP 기본 규칙
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
+|---|-----------|-----------|---------|--------|--------|
+| 2.1-1 | ✅필수 | URL 경로에 소문자 kebab-case 사용 | COVERED | COVERED | — |
+| 2.1-2 | ✅필수 | 리소스 컬렉션 이름은 복수형 명사 | COVERED | COVERED | — |
+| 2.1-3 | ❌금지 | URL에 동사 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.1-4 | ❌금지 | URL에 파일 확장자 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.1-5 | ✅필수 | URL 경로 세그먼트에 ASCII 영소문자/숫자/하이픈만 허용 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 2.1-6 | ✅필수 | 쿼리 파라미터 이름은 camelCase | COVERED | COVERED | — |
+| 2.1-7 | ⚠️권장 | URL 2000자 이하 유지 | MISSING | MISSING | Minor |
+| 2.2-1 | ✅필수 | GET 요청은 서버 상태 변경 안 함 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 2.2-2 | ✅필수 | PUT 요청은 멱등적으로 동작 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 2.2-3 | ⚠️권장 | 부분 수정에는 PUT 대신 PATCH 사용 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.2-4 | ❌금지 | GET/HEAD/DELETE 요청에 body 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.2-5 | ✅필수 | 표준 HTTP 상태 코드를 정확한 의미에 맞게 사용 | COVERED | COVERED | — |
+| 2.2-6 | ✅필수 | 201 Created 응답에 Location 헤더 포함 | COVERED | COVERED | — |
+| 2.2-7 | ❌금지 | 오류 상황에 200 OK 반환 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.3-1 | ✅필수 | 동일 파라미터 반복으로 배열 값 전달 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 2.3-2 | ⚠️권장 | 쿼리 파라미터는 선택적으로 설계 | MISSING | MISSING | Minor |
+| 2.3-3 | ⚠️권장 | 쿼리 파라미터에 민감한 정보 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.3-4 | ❌금지 | 서버 상태 변경에 쿼리 파라미터 사용 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.4-1 | ✅필수 | 요청 본문 있을 때 Content-Type 헤더 포함 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 2.4-2 | ✅필수 | 응답 본문 있을 때 Content-Type 헤더 포함 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 2.4-3 | ⚠️권장 | 커스텀 헤더에 X- 접두사 사용 금지 (신규) | COVERED | COVERED | ~~Minor~~ Fixed |
+| 2.4-4 | ❌금지 | 표준 HTTP 헤더 의미 재정의 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+
+---
+
+## 섹션 3: REST 원칙
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
+|---|-----------|-----------|---------|--------|--------|
+| 3.1-1 | ✅필수 | 모든 리소스는 고유 id 가짐 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 3.1-2 | ✅필수 | 리소스 스키마는 일관된 구조 유지 (id/createdAt/updatedAt) | COVERED | COVERED | ~~Critical~~ Fixed |
+| 3.1-3 | ⚠️권장 | 리소스 식별자는 불투명한 문자열 | MISSING | MISSING | Minor |
+| 3.1-4 | ❌금지 | 응답에 null 값 필드 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 3.2-1 | ✅필수 | 서버 관리 읽기 전용 필드를 요청 본문에 포함해도 무시 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 3.3-1 | ✅필수 | POST 생성 성공 시 201 Created + 생성된 리소스 반환 | COVERED | COVERED | — |
+| 3.3-2 | ✅필수 | PUT은 리소스 전체 대체, 미포함 필드는 기본값/null | COVERED | COVERED | ~~Critical~~ Fixed |
+| 3.3-3 | ✅필수 | DELETE 성공 시 204 No Content 반환 | COVERED | COVERED | — |
+| 3.4-1 | ✅필수 | 모든 에러 응답은 RFC 7807/9457 구조 따름 | COVERED | COVERED | — |
+| 3.4-2 | ✅필수 | 에러 응답 Content-Type은 application/problem+json | COVERED | COVERED | — |
+| 3.4-3 | ⚠️권장 | 유효성 검사 실패 시 모든 오류 필드 한 번에 반환 | COVERED | COVERED | — |
+| 3.4-4 | ❌금지 | 에러 응답에 스택 트레이스/내부 정보 노출 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+
+---
+
+## 섹션 4: JSON 규칙
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
+|---|-----------|-----------|---------|--------|--------|
+| 4.1-1 | ✅필수 | JSON 필드 이름은 camelCase | COVERED | COVERED | — |
+| 4.1-2 | ✅필수 | 필드 이름은 영소문자로 시작 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 4.1-3 | ❌금지 | 필드 이름에 약어 남용 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 4.2-1 | ✅필수 | Boolean은 JSON true/false 사용 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 4.2-2 | ✅필수 | Boolean 필드 이름에 is/has/can 접두사 | COVERED | COVERED | — |
+| 4.2-3 | ✅필수 | 숫자 값은 JSON number 타입 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 4.2-4 | ⚠️권장 | 큰 정수(2^53 초과)는 문자열로 반환 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 4.3-1 | ✅필수 | 날짜/시간은 RFC 3339 형식 문자열 | COVERED | COVERED | — |
+| 4.3-2 | ✅필수 | 시간대가 있으면 반드시 포함, UTC는 Z | COVERED | COVERED | — |
+| 4.3-3 | ✅필수 | 서버 응답 시간 값은 모두 UTC(Z) | COVERED | COVERED | — |
+| 4.3-4 | ✅필수 | 클라이언트가 오프셋 포함 전송 시 서버가 UTC로 변환하여 저장 | COVERED | COVERED | — |
+| 4.3-5 | ❌금지 | Unix timestamp를 기본 시간 형식으로 사용 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 4.4-1 | ✅필수 | Enum 값은 UPPER_SNAKE_CASE 문자열 | COVERED | COVERED | — |
+| 4.4-2 | ⚠️권장 | 클라이언트가 알 수 없는 Enum 값 수신 가능하도록 설계 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 4.4-3 | ❌금지 | Enum 값으로 숫자나 불명확한 약어 사용 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+
+---
+
+## 섹션 5: 공통 API 패턴
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
+|---|-----------|-----------|---------|--------|--------|
+| 5.1-1 | ✅필수 | 액션은 리소스 URL 뒤에 :action 형태 | COVERED | COVERED | — |
+| 5.1-2 | ✅필수 | 액션 엔드포인트에 POST 메서드 사용 | COVERED | COVERED | — |
+| 5.2-1 | ✅필수 | 컬렉션 응답 본문은 top-level JSON array | COVERED | COVERED | — |
+| 5.2-2 | ✅필수 | 다음 페이지 없을 때 Link 헤더에서 rel="next" 제외 | COVERED | COVERED | — |
+| 5.3-1 | ✅필수 | 동일 파라미터 반복은 OR 조건 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 5.4-1 | ❌금지 | API 버전을 URL 경로에 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 5.4-2 | ✅필수 | X-API-Version 헤더에 ISO 8601 날짜 형식으로 버전 지정 | COVERED | COVERED | — |
+| 5.4-3 | ✅필수 | 동일 버전 내 하위 호환성 유지 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 5.5-1 | ✅필수 | Deprecated API에 Deprecation/Sunset/Link 응답 헤더 제공 | COVERED | COVERED | ~~Critical~~ Fixed |
+| 5.6-1 | ✅필수 | 속도 제한 응답에 X-RateLimit-* 헤더 포함 | COVERED | COVERED | — |
+| 5.6-2 | ✅필수 | 429 응답에 Retry-After 헤더 포함 | COVERED | COVERED | — |
+| 5.6-3 | ✅필수 | 429 응답 본문은 RFC 7807 Problem Details 구조 | COVERED | COVERED | — |
+| 5.6-4 | ✅필수 | 클라이언트는 429 수신 시 Retry-After 값만큼 대기 후 재시도 | COVERED | COVERED | — |
+| 5.7-1 | ✅필수 | 장기 실행 작업 시 도메인 리소스 즉시 생성 + 201 Created + Location 헤더 | COVERED | COVERED | — |
+| 5.7-2 | ✅필수 | 도메인 리소스에 status 필드 포함 | COVERED | COVERED | — |
+| 5.7-3 | ❌금지 | 범용 /operations 리소스 사용 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+
+---
+
+## 섹션 6: 인증 및 보안
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
+|---|-----------|-----------|---------|--------|--------|
+| 6.1-1 | ✅필수 | 인증 토큰은 Authorization 헤더 사용 | COVERED | COVERED | — |
+| 6.1-2 | ❌금지 | API Key를 쿼리 파라미터로 전달 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
+| 6.2-1 | ✅필수 | 401 응답에 WWW-Authenticate 헤더 포함 | COVERED | COVERED | — |
+| 6.2-2 | ✅필수 | 401(인증 실패) / 403(인가 실패) 정확히 구분 | COVERED | COVERED | — |
+| 6.3-1 | ✅필수 | 중복 실행 위험 있는 POST에 Idempotency-Key 지원 | COVERED | COVERED | — |
+| 6.3-2 | ✅필수 | Idempotency-Key 값은 클라이언트 생성 UUID v4 | COVERED | COVERED | ~~Critical~~ Fixed |
+
+---
+
+## 커버리지 합계
+
+### Writing 모드
+
+| 상태 | 개수 | 비율 |
+|------|------|------|
+| COVERED | 68 | 95.8% |
+| PARTIAL | 0 | 0.0% |
+| MISSING | 3 | 4.2% |
+| **합계** | **71** | **100%** |
+
+### Review 모드
+
+| 상태 | 개수 | 비율 |
+|------|------|------|
+| COVERED | 68 | 95.8% |
+| PARTIAL | 0 | 0.0% |
+| MISSING | 3 | 4.2% |
+| **합계** | **71** | **100%** |
+
+### 전체 커버리지 (Writing + Review 통합)
+
+| 상태 | 개수 | 비율 |
+|------|------|------|
+| COVERED | 136 | 95.8% |
+| PARTIAL | 0 | 0.0% |
+| MISSING | 6 | 4.2% |
+| **합계** | **142** | **100%** |
+
+\* 전체는 71개 규칙 × 2개 모드(Writing/Review)의 합산 수치입니다.
+
+---
+
+## Critical 규칙 목록
+
+> **참고:** 아래 목록은 평가 시점의 스킬 갭을 기록한 것으로, Task 5 스킬 개선 후 모두 해소됐습니다. 현재 커버리지는 위 섹션별 테이블을 참조하세요.
+
+✅필수 규칙이 Writing 또는 Review 모드에서 MISSING 또는 PARTIAL인 항목:
+
+| # | 규칙 요약 | Writing | Review | 비고 |
+|---|-----------|---------|--------|------|
+| 2.1-5 | URL 경로 세그먼트에 ASCII 영소문자/숫자/하이픈만 허용 | PARTIAL | PARTIAL | kebab-case 언급은 있으나 허용 문자 집합을 명시적으로 제한하지 않음 |
+| 2.2-1 | GET 요청은 서버 상태 변경 안 함 | MISSING | COVERED | Writing 모드에 안전성(safety) 규칙 명시 없음 |
+| 2.2-2 | PUT 요청은 멱등적으로 동작 | PARTIAL | MISSING | Writing 모드 상태코드 표에 "Full replacement" 언급만, Review에 멱등성 체크 없음 |
+| 2.3-1 | 동일 파라미터 반복으로 배열 값 전달 | MISSING | PARTIAL | Review 체크리스트의 "Repeated same parameter treated as OR condition" 항목이 의미(OR 조건)를 다루나, 인코딩 방식(반복 파라미터 전달) 자체는 간접적으로만 포함됨 |
+| 2.4-1 | 요청 본문 있을 때 Content-Type 헤더 포함 | PARTIAL | MISSING | 에러 응답의 Content-Type만 언급, 일반 요청 Content-Type 규칙 없음 |
+| 2.4-2 | 응답 본문 있을 때 Content-Type 헤더 포함 | PARTIAL | MISSING | 에러 응답의 Content-Type만 명시, 일반 응답 Content-Type 규칙 없음 |
+| 3.1-1 | 모든 리소스는 고유 id 가짐 | COVERED | MISSING | Review 체크리스트에 리소스 id 필수 항목 없음 |
+| 3.1-2 | 리소스 스키마는 일관된 구조 유지 (id/createdAt/updatedAt) | COVERED | MISSING | Review 체크리스트에 표준 필드 구조 검증 항목 없음 |
+| 3.2-1 | 서버 관리 읽기 전용 필드를 요청 본문에 포함해도 무시 | PARTIAL | MISSING | Writing에 "not modifiable by client" 언급, 무시 동작 명시 불충분 |
+| 3.3-2 | PUT은 리소스 전체 대체, 미포함 필드는 기본값/null | PARTIAL | MISSING | "Full replacement" 언급만, 미포함 필드 처리 규칙 누락 |
+| 4.1-2 | 필드 이름은 영소문자로 시작 | PARTIAL | MISSING | camelCase 예시에서 암시되나 명시적 규칙 없음 |
+| 4.2-1 | Boolean은 JSON true/false 사용 | PARTIAL | MISSING | 코드 예시에서 true/false 사용하나, 문자열/"1"/"0" 금지 명시 없음 |
+| 4.2-3 | 숫자 값은 JSON number 타입 | MISSING | MISSING | 숫자 타입 규칙 자체가 스킬에 없음 |
+| 5.3-1 | 동일 파라미터 반복은 OR 조건 | MISSING | COVERED | Writing 모드에 필터링 OR/AND 조건 규칙 없음 |
+| 5.4-3 | 동일 버전 내 하위 호환성 유지 | MISSING | MISSING | 하위 호환성 유지 규칙 및 호환/비호환 변경 목록이 스킬에 없음 |
+| 5.5-1 | Deprecated API에 Deprecation/Sunset/Link 응답 헤더 제공 | COVERED | MISSING | Review 체크리스트에 Deprecation 헤더 검증 항목 없음 |
+| 6.3-2 | Idempotency-Key 값은 클라이언트 생성 UUID v4 | PARTIAL | MISSING | 코드 예시에 UUID 형태 값 있으나 "UUID v4" 명시 없음, Review 체크 없음 |
+
+**Critical 항목 총 17개** (✅필수 규칙 중 Writing 또는 Review에서 MISSING/PARTIAL)
+
+---
+
+## 판정 근거 요약
+
+> **참고:** 아래 판정 근거는 평가 시점 기준입니다. Task 5 스킬 개선 후 변경된 항목은 Writing/Review 상태가 업데이트됐으나 원문은 참고용으로 보존합니다.
+
+### Writing 모드 판정 근거
+
+| # | 판정 | 근거 |
+|---|------|------|
+| 2.1-1 | COVERED | "Plural nouns + kebab-case" 주석과 `/user-profiles` 등 예시 있음 |
+| 2.1-2 | COVERED | `/articles`, `/users/{userId}/comments` 복수형 예시 있음 |
+| 2.1-3 | COVERED | bad case `/getUsers`, `/createArticle` 추가 및 "동사 금지" 명시 (Minor 개선) |
+| 2.1-4 | COVERED | "파일 확장자 금지" 규칙 추가 (Minor 개선) |
+| 2.1-5 | PARTIAL | kebab-case 언급으로 간접 포함되나 허용 문자 집합(ASCII 영소문자/숫자/하이픈만) 명시 없음 |
+| 2.1-6 | COVERED | `pageSize`, `pageToken`, `sortOrder` 등 camelCase 예시와 "(camelCase)" 명시 있음 |
+| 2.1-7 | MISSING | URL 길이 제한 언급 없음 |
+| 2.2-1 | MISSING | GET의 안전성(서버 상태 변경 안 함) 규칙 명시 없음 |
+| 2.2-2 | PARTIAL | 상태코드 표에 "Full replacement success" 언급만, 멱등성 규칙 명시 없음 |
+| 2.2-3 | COVERED | PATCH 메서드 코드 예시(updateArticle)와 상태코드 매핑 있음 |
+| 2.2-4 | COVERED | "GET/HEAD/DELETE body 금지" 규칙 추가 (Minor 개선) |
+| 2.2-5 | COVERED | HTTP Method to Status Code Mapping 표에 상세 매핑 있음 |
+| 2.2-6 | COVERED | "201 Created + Location header" 명시, 코드 예시에 `ResponseEntity.created(location)` 있음 |
+| 2.2-7 | COVERED | "200 OK 에러 반환 금지" 규칙 추가 (Minor 개선) |
+| 2.3-1 | COVERED | URL Naming Rules에 `?status=PUBLISHED&status=DRAFT` 예시 추가됨 (Critical 개선) |
+| 2.3-2 | MISSING | 쿼리 파라미터 선택적 설계 규칙 없음 (Tier C — 보류) |
+| 2.3-3 | COVERED | "민감한 정보 쿼리 파라미터 금지" 규칙이 이미 스킬에 존재 (스킬 기준 재확인) |
+| 2.3-4 | COVERED | "서버 상태 변경에 쿼리 파라미터 금지" 규칙이 이미 스킬에 존재 (스킬 기준 재확인) |
+| 2.4-1 | PARTIAL | 에러 응답 `application/problem+json` 언급은 있으나, 일반 요청의 Content-Type 필수 규칙 없음 |
+| 2.4-2 | PARTIAL | 에러 응답 Content-Type만 명시, 정상 응답의 Content-Type 필수 규칙은 코드 예시에서 암시적 |
+| 2.4-3 | COVERED | "신규 커스텀 헤더 X- 접두사 금지" 규칙 추가, X-RateLimit-* 레거시 예외 주석 포함 (Minor 개선) |
+| 2.4-4 | COVERED | "표준 HTTP 헤더 의미 재정의 금지" 규칙 추가 (Minor 개선) |
+| 3.1-1 | COVERED | Standard Resource Fields에 `"id": "Server-generated"` 명시 |
+| 3.1-2 | COVERED | id/createdAt/updatedAt 표준 필드 구조가 Standard Resource Fields에 정의됨 |
+| 3.1-3 | MISSING | 식별자 불투명성 언급 없음 (Tier C — 보류) |
+| 3.1-4 | COVERED | "null 값 필드 응답에서 제외" 규칙 추가 및 bad case 예시 포함 (Minor 개선) |
+| 3.2-1 | PARTIAL | "not modifiable by client" 언급 있으나 "포함해도 무시" 동작 명확히 서술되지 않음 |
+| 3.3-1 | COVERED | POST create -> 201 Created + Location + body 코드 예시 있음 |
+| 3.3-2 | PARTIAL | PUT -> "Full replacement success" 테이블 항목만, 미포함 필드 처리 규칙 없음 |
+| 3.3-3 | COVERED | DELETE -> 204 No Content 매핑 및 `ResponseEntity.noContent().build()` 코드 있음 |
+| 3.4-1 | COVERED | RFC 7807/9457 구조 명시 + ProblemDetail 클래스 코드 예시 있음 |
+| 3.4-2 | COVERED | `Content-Type: application/problem+json` 명시 |
+| 3.4-3 | COVERED | errors 배열 필드를 포함한 에러 응답 템플릿 있음 |
+| 3.4-4 | COVERED | "스택 트레이스/내부 정보 노출 금지" 규칙 추가 (Minor 개선) |
+| 4.1-1 | COVERED | "Correct example" / "Incorrect example" JSON 비교 있음 |
+| 4.1-2 | PARTIAL | camelCase 예시가 모두 소문자 시작이지만 "영소문자로 시작" 규칙 명시 없음 |
+| 4.1-3 | COVERED | "약어 남용 금지" 규칙 추가 및 bad case 예시 포함 (Minor 개선) |
+| 4.2-1 | PARTIAL | `"isActive": true` 예시 있으나, 문자열 "true"/"false" 및 숫자 1/0 금지 명시 없음 |
+| 4.2-2 | COVERED | `is`/`has`/`can` 접두사 예시: `"isActive": true` |
+| 4.2-3 | MISSING | 숫자 타입 규칙 없음 |
+| 4.2-4 | COVERED | "2^53 초과 정수 문자열 반환" 규칙 추가 (Minor 개선) |
+| 4.3-1 | COVERED | RFC 3339 형식 명시 + 예시 있음 |
+| 4.3-2 | COVERED | UTC `Z` 사용 예시 있음 |
+| 4.3-3 | COVERED | "Server response (Required: UTC)" 명시 |
+| 4.3-4 | COVERED | "offset allowed — server normalizes to UTC" 명시 |
+| 4.3-5 | COVERED | "Unix timestamp forbidden" Prohibited 섹션에 명시 |
+| 4.4-1 | COVERED | `"status": "PUBLISHED"` 예시 + "enums must be UPPER_SNAKE_CASE" 명시 |
+| 4.4-2 | COVERED | "알 수 없는 Enum 값 수신 대응 설계" 규칙 추가 (Minor 개선) |
+| 4.4-3 | COVERED | Enum 숫자/약어 bad case 추가 (`"status": 1`) (Minor 개선) |
+| 5.1-1 | COVERED | `:publish`, `:cancel`, `:deactivate` 액션 패턴 예시 있음 |
+| 5.1-2 | COVERED | POST 메서드 사용 예시 있음 |
+| 5.2-1 | COVERED | top-level JSON array 응답 예시 + "top-level array" 명시 |
+| 5.2-2 | COVERED | `nextPageToken` null 시 Link에 next 미포함하는 buildLinkHeader 코드 있음 |
+| 5.3-1 | MISSING | OR 조건 규칙이 Writing 모드에 없음 |
+| 5.4-1 | COVERED | "URL 경로에 버전 금지" 규칙 추가 (Minor 개선) |
+| 5.4-2 | COVERED | X-API-Version 헤더 코드 예시 있음 (ISO 8601 날짜 형식 "2024-01-20") |
+| 5.4-3 | MISSING | 하위 호환성 유지 규칙 없음 |
+| 5.5-1 | COVERED | Deprecation/Sunset/Link 헤더 설정 코드 예시 있음. 커버리지 출처: Writing Mode 본문이 아닌 Code Examples 부록의 Kotlin 코드 예시에서 확인됨. |
+| 5.6-1 | COVERED | addRateLimitHeaders 함수에 X-RateLimit-* 헤더 설정 코드 있음 |
+| 5.6-2 | COVERED | Retry-After 헤더 설정 코드 있음 |
+| 5.6-3 | COVERED | 429 응답에 ProblemDetail 구조 사용 코드 있음 |
+| 5.6-4 | COVERED | "On 429, wait for the Retry-After header value before retrying" 명시 |
+| 5.7-1 | COVERED | "POST (long-running) 201 Created + Location header" 상태코드 표에 있음 |
+| 5.7-2 | COVERED | "domain resource created immediately with status field" 명시 |
+| 5.7-3 | COVERED | "/operations 금지" 규칙 추가 (Minor 개선) |
+| 6.1-1 | COVERED | Authorization 헤더 Bearer/ApiKey 예시 있음 |
+| 6.1-2 | COVERED | "API Key 쿼리 파라미터 금지" 규칙 추가 (Minor 개선) |
+| 6.2-1 | COVERED | WWW-Authenticate 헤더 포함 코드 예시 있음 |
+| 6.2-2 | COVERED | 401 vs 403 구분 표 있음 |
+| 6.3-1 | COVERED | Idempotency-Key 처리 코드 예시 있음 |
+| 6.3-2 | PARTIAL | 코드 예시의 키 값이 UUID 형태이나 "UUID v4" 명시 없음 |
+
+### Review 모드 판정 근거
+
+| # | 판정 | 근거 |
+|---|------|------|
+| 2.1-1 | COVERED | "Lowercase kebab-case used in paths" 체크리스트 항목 |
+| 2.1-2 | COVERED | "Resource names are plural nouns" 체크리스트 항목 |
+| 2.1-3 | COVERED | "No verbs in paths (actions use :action pattern)" 체크리스트 항목 |
+| 2.1-4 | COVERED | "No file extensions in URLs" 체크리스트 항목 |
+| 2.1-5 | PARTIAL | kebab-case 체크는 있으나 허용 문자 집합 검증 항목 없음 |
+| 2.1-6 | COVERED | "Query parameters are camelCase" 체크리스트 항목 |
+| 2.1-7 | MISSING | URL 길이 체크 항목 없음 |
+| 2.2-1 | COVERED | "GET requests do not modify server state" 체크리스트 항목 |
+| 2.2-2 | MISSING | PUT 멱등성 체크 항목 없음 |
+| 2.2-3 | COVERED | "부분 수정 PATCH 권장" 체크 항목 추가 (Minor 개선) |
+| 2.2-4 | COVERED | GET/HEAD/DELETE body 금지 체크 항목이 이미 스킬에 존재 (스킬 기준 재확인) |
+| 2.2-5 | COVERED | 상태 코드 관련 체크리스트 항목 다수 있음 |
+| 2.2-6 | COVERED | "POST create -> 201 + Location header" 체크리스트 항목 |
+| 2.2-7 | COVERED | "200 not returned for error conditions" 체크리스트 항목 |
+| 2.3-1 | PARTIAL | "Repeated same parameter treated as OR condition" 체크리스트 항목이 존재하나, 이는 의미(OR 조건)를 다루는 것이며 인코딩 방식(동일 파라미터 반복으로 배열 전달) 자체는 간접적으로만 포함됨 |
+| 2.3-2 | MISSING | 쿼리 파라미터 선택적 설계 체크 없음 (Tier C — 보류) |
+| 2.3-3 | COVERED | "민감한 정보 쿼리 파라미터 금지" 체크 항목이 이미 스킬에 존재 (스킬 기준 재확인) |
+| 2.3-4 | COVERED | "서버 상태 변경 쿼리 파라미터 금지" 체크 항목이 이미 스킬에 존재 (스킬 기준 재확인) |
+| 2.4-1 | MISSING | 요청 Content-Type 체크 항목 없음 |
+| 2.4-2 | MISSING | 응답 Content-Type 일반 규칙 체크 항목 없음 (에러 응답 Content-Type만) |
+| 2.4-3 | COVERED | "New custom headers do not use X- prefix" 체크리스트 항목 |
+| 2.4-4 | COVERED | "표준 HTTP 헤더 의미 재정의 금지" 체크 항목 추가 (Minor 개선) |
+| 3.1-1 | MISSING | 리소스 id 필수 체크 항목 없음 |
+| 3.1-2 | MISSING | 리소스 표준 필드 구조 체크 항목 없음 |
+| 3.1-3 | MISSING | 식별자 불투명성 체크 없음 (Tier C — 보류) |
+| 3.1-4 | COVERED | "Null-valued fields excluded from response" 체크리스트 항목 |
+| 3.2-1 | MISSING | 읽기 전용 필드 무시 동작 체크 없음 |
+| 3.3-1 | COVERED | "POST create -> 201 + Location header" 체크리스트 항목 |
+| 3.3-2 | MISSING | PUT 전체 대체 + 미포함 필드 처리 체크 없음 |
+| 3.3-3 | COVERED | "DELETE success -> 204 (no body)" 체크리스트 항목 |
+| 3.4-1 | COVERED | "Error responses use RFC 7807/9457 Problem Details structure" 체크리스트 항목 |
+| 3.4-2 | COVERED | "Content-Type: application/problem+json used" 체크리스트 항목 |
+| 3.4-3 | COVERED | "All validation errors returned at once" 체크리스트 항목 |
+| 3.4-4 | COVERED | "Internal implementation details not exposed" 체크리스트 항목 |
+| 4.1-1 | COVERED | "All fields are camelCase" 체크리스트 항목 |
+| 4.1-2 | MISSING | 영소문자 시작 체크 항목 없음 |
+| 4.1-3 | COVERED | "약어 남용 금지" 체크 항목 추가 (Minor 개선) |
+| 4.2-1 | MISSING | Boolean JSON true/false 체크 항목 없음 |
+| 4.2-2 | COVERED | "Boolean fields use is/has/can prefix" 체크리스트 항목 |
+| 4.2-3 | MISSING | 숫자 JSON number 타입 체크 없음 |
+| 4.2-4 | COVERED | "2^53 초과 정수 문자열 반환" 체크 항목 추가 (Minor 개선) |
+| 4.3-1 | COVERED | "Date/time in RFC 3339 format" 체크리스트 항목 |
+| 4.3-2 | COVERED | "All time values in server response are UTC (Z)" 체크리스트 항목이 이 규칙을 직접 커버함 |
+| 4.3-3 | COVERED | "All time values in server response are UTC (Z)" 체크리스트 항목 |
+| 4.3-4 | COVERED | "Offset input is normalized to UTC by server (not an error)" 체크리스트 항목 |
+| 4.3-5 | COVERED | "Unix timestamp 금지" 체크 항목 추가 (Minor 개선) |
+| 4.4-1 | COVERED | "Enum values are UPPER_SNAKE_CASE" 체크리스트 항목 |
+| 4.4-2 | COVERED | "알 수 없는 Enum 값 수신 대응" 체크 항목 추가 (Minor 개선) |
+| 4.4-3 | COVERED | "Enum 숫자/약어 금지" 체크 항목 추가 (Minor 개선) |
+| 5.1-1 | COVERED | "No verbs in paths (actions use :action pattern)" 체크리스트 항목 |
+| 5.1-2 | COVERED | 액션 패턴이 POST 사용하는 것이 URL Design 체크에 포함 |
+| 5.2-1 | COVERED | "Collection response body is a top-level array" 체크리스트 항목 |
+| 5.2-2 | COVERED | "rel=next excluded from Link header when no next page" 체크리스트 항목 |
+| 5.3-1 | COVERED | "Repeated same parameter treated as OR condition" 체크리스트 항목 |
+| 5.4-1 | COVERED | "No version in URL path" + "API version delivered via X-API-Version header, not URL path" 체크리스트 항목 |
+| 5.4-2 | COVERED | "X-API-Version value uses ISO 8601 date format" 체크리스트 항목 |
+| 5.4-3 | MISSING | 하위 호환성 유지 체크 없음 |
+| 5.5-1 | MISSING | Deprecation 헤더 체크 항목 없음 |
+| 5.6-1 | COVERED | Rate Limiting 체크리스트에 X-RateLimit-* 헤더 항목 있음 |
+| 5.6-2 | COVERED | "429 response includes Retry-After header" 체크리스트 항목 |
+| 5.6-3 | COVERED | "429 response body uses Problem Details structure" 체크리스트 항목 |
+| 5.6-4 | COVERED | "Client retry respects Retry-After value" 체크리스트 항목 |
+| 5.7-1 | COVERED | "Long-running task returns 201 Created + Location header" 체크리스트 항목 |
+| 5.7-2 | COVERED | "Domain resource has status field" 체크리스트 항목 |
+| 5.7-3 | COVERED | "No generic /operations endpoint" 체크리스트 항목 |
+| 6.1-1 | COVERED | "Auth token delivered via Authorization header" 체크리스트 항목 |
+| 6.1-2 | COVERED | "(query parameter forbidden)" 체크리스트 항목 |
+| 6.2-1 | COVERED | "401 response includes WWW-Authenticate header" 체크리스트 항목 |
+| 6.2-2 | COVERED | "401/403 properly distinguished" 체크리스트 항목 |
+| 6.3-1 | COVERED | "Idempotency-Key supported for duplicate-risk POST operations" 체크리스트 항목 |
+| 6.3-2 | MISSING | UUID v4 명시 체크 항목 없음 |

--- a/plugins/api/docs/evaluation/report.md
+++ b/plugins/api/docs/evaluation/report.md
@@ -1,0 +1,218 @@
+# RESTful API Guidelines Skill 성능 평가 보고서
+
+**평가 날짜:** 2026-03-20
+**평가 대상:** `.claude/skills/restful-api-guidelines.md`
+**기준 문서:** `README.md`
+**테스트 케이스:** `docs/evaluation/test-cases.md` (총 54개)
+
+---
+
+## 커버리지 요약
+
+| 모드 | COVERED | PARTIAL | MISSING | 합계 | 커버율 |
+|------|---------|---------|---------|------|--------|
+| Writing | 68 | 0 | 3 | 71 | 95.8% |
+| Review | 68 | 0 | 3 | 71 | 95.8% |
+
+> 커버율 = (COVERED + PARTIAL×0.5) / 합계 × 100
+>
+> **수정 전 (2026-03-20 초기 평가):** Writing 59.9% / Review 62.0%
+> **수정 후 (Critical 반영):** Writing 73.2% / Review 81.7%
+> **수정 후 (Minor 반영):** Writing 95.8% / Review 95.8%
+
+---
+
+## Critical 문제 (즉시 수정 대상)
+
+> ✅필수 규칙이 Writing 또는 Review 모드에서 MISSING 또는 PARTIAL — 총 17개 → **모두 해결됨 (Task 5)**
+
+### Writing Mode Critical 문제
+
+| # | 규칙 요약 | 상태 | 누락 내용 | 스킬 추가 필요 사항 |
+|---|-----------|------|-----------|---------------------|
+| 2.1-5 | URL 경로 세그먼트에 ASCII 영소문자/숫자/하이픈만 허용 | PARTIAL | kebab-case 언급은 있으나 허용 문자 집합(ASCII 영소문자, 숫자, 하이픈만)을 명시적으로 제한하지 않음 | Writing 가이드에 "URL path segments MUST contain only ASCII lowercase letters (a-z), digits (0-9), and hyphens (-)" 규칙 추가 |
+| 2.2-1 | GET 요청은 서버 상태 변경 안 함 | MISSING | Writing 모드에 HTTP 메서드 안전성(safety) 규칙이 전혀 없음 | "GET and HEAD requests MUST NOT modify server state (safe methods)" 규칙 추가 |
+| 2.2-2 | PUT 요청은 멱등적으로 동작 | PARTIAL | 상태코드 표에 "Full replacement" 언급만 있고, 멱등성(동일 요청 반복 시 동일 결과) 규칙이 명시되지 않음 | "PUT and DELETE MUST be idempotent — repeated identical requests produce the same result" 규칙 추가 |
+| 2.3-1 | 동일 파라미터 반복으로 배열 값 전달 | MISSING | 배열 값 전달 시 동일 파라미터 반복 방식(?status=A&status=B) 패턴이 없음 | "Array values in query parameters MUST use repeated parameter names: `?status=ACTIVE&status=DRAFT`" 규칙 추가 |
+| 2.4-1 | 요청 본문 있을 때 Content-Type 헤더 포함 | PARTIAL | 에러 응답의 Content-Type(`application/problem+json`)만 언급, 일반 요청/응답의 Content-Type 필수 규칙 없음 | "Requests with a body MUST include Content-Type header (typically `application/json`)" 규칙 추가 |
+| 2.4-2 | 응답 본문 있을 때 Content-Type 헤더 포함 | PARTIAL | 에러 응답 Content-Type만 명시, 정상 응답의 Content-Type 규칙이 코드 예시에서만 암시적 | "Responses with a body MUST include Content-Type header" 규칙 추가 |
+| 3.2-1 | 서버 관리 읽기 전용 필드를 요청 본문에 포함해도 무시 | PARTIAL | "not modifiable by client" 언급은 있으나 "클라이언트가 보내더라도 서버가 무시" 동작이 명확히 서술되지 않음 | "Server MUST silently ignore read-only fields (id, createdAt, updatedAt) if included in request body" 규칙 추가 |
+| 3.3-2 | PUT은 리소스 전체 대체, 미포함 필드는 기본값/null | PARTIAL | "Full replacement" 언급만 있고 미포함 필드 처리 규칙이 누락됨 | "PUT replaces the entire resource — omitted fields revert to default values or null" 규칙 추가 |
+| 4.1-2 | 필드 이름은 영소문자로 시작 | PARTIAL | camelCase 예시가 모두 소문자 시작이지만 "영소문자로 시작" 규칙이 명시되지 않음 | "Field names MUST start with a lowercase ASCII letter (a-z)" 규칙을 camelCase 규칙과 함께 명시 |
+| 4.2-1 | Boolean은 JSON true/false 사용 | PARTIAL | `"isActive": true` 예시만 있고, 문자열 "true"/"false"나 숫자 1/0 사용 금지가 명시되지 않음 | "Boolean values MUST use JSON native `true`/`false` — string `\"true\"`/`\"false\"` or numeric `1`/`0` are prohibited" 추가 |
+| 4.2-3 | 숫자 값은 JSON number 타입 | MISSING | 숫자 타입 규칙 자체가 스킬에 없음 | "Numeric values MUST use JSON number type, not strings (e.g., `\"age\": 25` not `\"age\": \"25\"`)" 규칙 추가 |
+| 5.3-1 | 동일 파라미터 반복은 OR 조건 | MISSING | Writing 모드에 필터링 시 OR/AND 조건 규칙이 없음 | "Repeated query parameters are treated as OR condition: `?status=ACTIVE&status=DRAFT` means status is ACTIVE OR DRAFT" 규칙 추가 |
+| 5.4-3 | 동일 버전 내 하위 호환성 유지 | MISSING | 하위 호환성 유지 규칙 및 호환/비호환 변경 목록이 없음 | "Within the same API version, all changes MUST be backward-compatible (no field removal, no type change, no required field addition)" 규칙 추가 |
+| 6.3-2 | Idempotency-Key 값은 클라이언트 생성 UUID v4 | PARTIAL | 코드 예시의 키 값이 UUID 형태이나 "UUID v4" 사양이 명시되지 않음 | "Idempotency-Key value MUST be a client-generated UUID v4" 명시 추가 |
+
+### Review Mode Critical 문제
+
+| # | 규칙 요약 | 상태 | 누락 내용 | 스킬 추가 필요 사항 |
+|---|-----------|------|-----------|---------------------|
+| 2.1-5 | URL 경로 세그먼트에 ASCII 영소문자/숫자/하이픈만 허용 | PARTIAL | kebab-case 체크는 있으나 허용 문자 집합 검증 항목이 없음 | "Path segments contain only a-z, 0-9, hyphens" 체크리스트 항목 추가 |
+| 2.2-2 | PUT 요청은 멱등적으로 동작 | MISSING | PUT 멱등성 체크 항목이 없음 | "PUT requests are idempotent (repeated calls produce same result)" 체크 항목 추가 |
+| 2.3-1 | 동일 파라미터 반복으로 배열 값 전달 | PARTIAL | OR 조건 체크는 있으나 인코딩 방식(반복 파라미터) 자체의 검증이 간접적 | "Array query parameters use repeated keys (not comma-separated)" 체크 항목 추가 |
+| 2.4-1 | 요청 본문 있을 때 Content-Type 헤더 포함 | MISSING | 요청 Content-Type 체크 항목이 없음 | "Requests with body include Content-Type header" 체크 항목 추가 |
+| 2.4-2 | 응답 본문 있을 때 Content-Type 헤더 포함 | MISSING | 응답 Content-Type 일반 규칙 체크 항목이 없음 | "Responses with body include Content-Type header" 체크 항목 추가 |
+| 3.1-1 | 모든 리소스는 고유 id 가짐 | MISSING | 리소스 id 필수 체크 항목이 없음 | "Every resource has a unique `id` field" 체크 항목 추가 |
+| 3.1-2 | 리소스 스키마는 일관된 구조 유지 (id/createdAt/updatedAt) | MISSING | 표준 필드 구조 검증 항목이 없음 | "Resource includes standard fields: id, createdAt, updatedAt" 체크 항목 추가 |
+| 3.2-1 | 서버 관리 읽기 전용 필드를 요청 본문에 포함해도 무시 | MISSING | 읽기 전용 필드 무시 동작 체크가 없음 | "Server-managed fields (id, createdAt, updatedAt) ignored if sent in request body" 체크 항목 추가 |
+| 3.3-2 | PUT은 리소스 전체 대체, 미포함 필드는 기본값/null | MISSING | PUT 전체 대체 및 미포함 필드 처리 체크가 없음 | "PUT replaces entire resource; omitted fields reset to defaults" 체크 항목 추가 |
+| 4.1-2 | 필드 이름은 영소문자로 시작 | MISSING | 영소문자 시작 체크 항목이 없음 | "Field names start with lowercase letter" 체크 항목 추가 |
+| 4.2-1 | Boolean은 JSON true/false 사용 | MISSING | Boolean JSON true/false 체크 항목이 없음 | "Boolean values use JSON true/false (not string or numeric)" 체크 항목 추가 |
+| 4.2-3 | 숫자 값은 JSON number 타입 | MISSING | 숫자 JSON number 타입 체크가 없음 | "Numeric values use JSON number type (not strings)" 체크 항목 추가 |
+| 5.4-3 | 동일 버전 내 하위 호환성 유지 | MISSING | 하위 호환성 유지 체크가 없음 | "Changes within same version are backward-compatible" 체크 항목 추가 |
+| 5.5-1 | Deprecated API에 Deprecation/Sunset/Link 응답 헤더 제공 | MISSING | Deprecation 헤더 검증 항목이 없음 | "Deprecated endpoints include Deprecation, Sunset, Link headers" 체크 항목 추가 |
+| 6.3-2 | Idempotency-Key 값은 클라이언트 생성 UUID v4 | MISSING | UUID v4 명시 체크 항목이 없음 | "Idempotency-Key value is UUID v4" 체크 항목 추가 |
+
+---
+
+## Minor 문제 (단계적 수정)
+
+> ⚠️권장/❌금지 규칙 중 하나 이상의 모드에서 MISSING인 항목 — 총 22개 → **19개 해결됨 (Minor 개선)**, 3개 Tier C 보류
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 비고 |
+|---|-----------|-----------|---------|--------|------|
+| 2.1-3 | ❌금지 | URL에 동사 포함 금지 | COVERED | COVERED | ✅ bad case 및 금지 규칙 추가 |
+| 2.1-4 | ❌금지 | URL에 파일 확장자 포함 금지 | COVERED | COVERED | ✅ 금지 규칙 추가 |
+| 2.1-7 | ⚠️권장 | URL 2000자 이하 유지 | MISSING | MISSING | ⏸️ Tier C 보류 — 런타임 관심사, 코드 리뷰로 검증 어려움 |
+| 2.2-3 | ⚠️권장 | 부분 수정에는 PUT 대신 PATCH 사용 | COVERED | COVERED | ✅ Review 체크리스트 추가 |
+| 2.2-4 | ❌금지 | GET/HEAD/DELETE 요청에 body 포함 금지 | COVERED | COVERED | ✅ Writing 규칙 추가, Review는 기존 포함 확인 |
+| 2.2-7 | ❌금지 | 오류 상황에 200 OK 반환 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 |
+| 2.3-2 | ⚠️권장 | 쿼리 파라미터는 선택적으로 설계 | MISSING | MISSING | ⏸️ Tier C 보류 — 추상적 설계 원칙, 코드 레벨 감지 어려움 |
+| 2.3-3 | ⚠️권장 | 쿼리 파라미터에 민감한 정보 포함 금지 | COVERED | COVERED | ✅ 기존 스킬에 이미 포함됨 (coverage map 오류 수정) |
+| 2.3-4 | ❌금지 | 서버 상태 변경에 쿼리 파라미터 사용 금지 | COVERED | COVERED | ✅ 기존 스킬에 이미 포함됨 (coverage map 오류 수정) |
+| 2.4-3 | ⚠️권장 | 커스텀 헤더에 X- 접두사 사용 금지 (신규) | COVERED | COVERED | ✅ Writing 규칙 추가 (X-RateLimit-* 레거시 예외 주석 포함) |
+| 2.4-4 | ❌금지 | 표준 HTTP 헤더 의미 재정의 금지 | COVERED | COVERED | ✅ Writing/Review 모두 추가 |
+| 3.1-3 | ⚠️권장 | 리소스 식별자는 불투명한 문자열 | MISSING | MISSING | ⏸️ Tier C 보류 — 아키텍처 결정 영역, 코드 리뷰로 판단 어려움 |
+| 3.1-4 | ❌금지 | 응답에 null 값 필드 포함 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 및 bad case 포함 |
+| 3.4-4 | ❌금지 | 에러 응답에 스택 트레이스/내부 정보 노출 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 |
+| 4.1-3 | ❌금지 | 필드 이름에 약어 남용 금지 | COVERED | COVERED | ✅ Writing/Review 모두 추가 |
+| 4.2-4 | ⚠️권장 | 큰 정수(2^53 초과)는 문자열로 반환 | COVERED | COVERED | ✅ Writing/Review 모두 추가 |
+| 4.3-5 | ❌금지 | Unix timestamp를 기본 시간 형식으로 사용 금지 | COVERED | COVERED | ✅ Review 체크리스트 추가 |
+| 4.4-2 | ⚠️권장 | 클라이언트가 알 수 없는 Enum 값 수신 가능하도록 설계 | COVERED | COVERED | ✅ Writing/Review 모두 추가 |
+| 4.4-3 | ❌금지 | Enum 값으로 숫자나 불명확한 약어 사용 금지 | COVERED | COVERED | ✅ bad case 추가 및 Review 체크 추가 |
+| 5.4-1 | ❌금지 | API 버전을 URL 경로에 포함 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 |
+| 5.7-3 | ❌금지 | 범용 /operations 리소스 사용 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 |
+| 6.1-2 | ❌금지 | API Key를 쿼리 파라미터로 전달 금지 | COVERED | COVERED | ✅ Writing 규칙 추가 |
+
+---
+
+## 개선 권고사항
+
+### 즉시 수정 (Critical)
+
+**카테고리 1: HTTP 메서드 안전성/멱등성 규칙**
+
+Writing Mode 추가 내용:
+- "GET and HEAD requests MUST NOT modify server state (safe methods)"
+- "PUT and DELETE MUST be idempotent — repeated identical requests produce the same result"
+- "PUT replaces the entire resource — omitted fields revert to default values or null"
+
+Review Mode 체크리스트 추가 항목:
+- "PUT requests are idempotent (repeated calls produce same result)"
+- "PUT replaces entire resource; omitted fields reset to defaults"
+
+**카테고리 2: URL/쿼리 파라미터 규칙**
+
+Writing Mode 추가 내용:
+- "URL path segments MUST contain only ASCII lowercase letters (a-z), digits (0-9), and hyphens (-)"
+- "Array values in query parameters MUST use repeated parameter names: `?status=ACTIVE&status=DRAFT`"
+- "Repeated query parameters are treated as OR condition"
+
+Review Mode 체크리스트 추가 항목:
+- "Path segments contain only a-z, 0-9, hyphens"
+- "Array query parameters use repeated keys (not comma-separated)"
+
+**카테고리 3: HTTP 헤더 규칙 (Content-Type)**
+
+Writing Mode 추가 내용:
+- "Requests with a body MUST include `Content-Type` header (typically `application/json`)"
+- "Responses with a body MUST include `Content-Type` header"
+
+Review Mode 체크리스트 추가 항목:
+- "Requests with body include Content-Type header"
+- "Responses with body include Content-Type header"
+
+**카테고리 4: 리소스 스키마 Review 규칙**
+
+Review Mode 체크리스트 추가 항목:
+- "Every resource has a unique `id` field"
+- "Resource includes standard fields: id, createdAt, updatedAt"
+- "Server-managed fields (id, createdAt, updatedAt) ignored if sent in request body"
+
+Writing Mode 추가 내용:
+- "Server MUST silently ignore read-only fields (id, createdAt, updatedAt) if included in request body" (기존 "not modifiable by client" 문구를 보완)
+
+**카테고리 5: JSON 타입 규칙**
+
+Writing Mode 추가 내용:
+- "Field names MUST start with a lowercase ASCII letter (a-z)" (camelCase 규칙 보완)
+- "Boolean values MUST use JSON native `true`/`false` — string `\"true\"`/`\"false\"` or numeric `1`/`0` are prohibited"
+- "Numeric values MUST use JSON number type, not strings (e.g., `\"age\": 25` not `\"age\": \"25\"`)"
+
+Review Mode 체크리스트 추가 항목:
+- "Field names start with lowercase letter"
+- "Boolean values use JSON true/false (not string or numeric)"
+- "Numeric values use JSON number type (not strings)"
+
+**카테고리 6: 버전 관리/Deprecation 규칙**
+
+Writing Mode 추가 내용:
+- "Within the same API version, all changes MUST be backward-compatible (no field removal, no type change, no required field addition)"
+
+Review Mode 체크리스트 추가 항목:
+- "Changes within same version are backward-compatible"
+- "Deprecated endpoints include Deprecation, Sunset, Link headers"
+
+**카테고리 7: 멱등성 키 규칙**
+
+Writing Mode 추가 내용:
+- "Idempotency-Key value MUST be a client-generated UUID v4" (기존 코드 예시 보완)
+
+Review Mode 체크리스트 추가 항목:
+- "Idempotency-Key value is UUID v4"
+
+### 다음 단계 (Minor)
+
+아래 항목을 우선순위 순으로 정리한다. 양쪽 모두 MISSING인 항목을 최우선으로 처리한다.
+
+**우선순위 1: 양쪽 모두 MISSING (7개)**
+
+1. **2.2-4** GET/HEAD/DELETE 요청에 body 포함 금지 — 잘못된 구현을 방지하는 기본 규칙
+2. **2.3-4** 서버 상태 변경에 쿼리 파라미터 사용 금지 — 보안/안전성 관련
+3. **2.4-4** 표준 HTTP 헤더 의미 재정의 금지 — 상호운용성 관련
+4. **2.1-7** URL 2000자 이하 유지 — 클라이언트 호환성 관련
+5. **4.1-3** 필드 이름에 약어 남용 금지 — 가독성 관련
+6. **2.3-2** 쿼리 파라미터는 선택적으로 설계
+7. **2.3-3** 쿼리 파라미터에 민감한 정보 포함 금지
+
+**우선순위 2: 양쪽 모두 MISSING + 권장 (4개)**
+
+8. **3.1-3** 리소스 식별자는 불투명한 문자열
+9. **4.2-4** 큰 정수(2^53 초과)는 문자열로 반환
+10. **4.4-2** 클라이언트가 알 수 없는 Enum 값 수신 가능하도록 설계
+
+**우선순위 3: 한쪽만 MISSING (12개)**
+
+11. **2.1-3** URL에 동사 포함 금지 — Writing PARTIAL
+12. **2.1-4** URL에 파일 확장자 포함 금지 — Writing MISSING
+13. **2.2-3** 부분 수정에는 PUT 대신 PATCH 사용 — Review MISSING
+14. **2.2-7** 오류 상황에 200 OK 반환 금지 — Writing MISSING
+15. **2.4-3** 커스텀 헤더에 X- 접두사 사용 금지 — Writing MISSING
+16. **3.1-4** 응답에 null 값 필드 포함 금지 — Writing MISSING
+17. **3.4-4** 에러 응답에 스택 트레이스/내부 정보 노출 금지 — Writing MISSING
+18. **4.3-5** Unix timestamp 금지 — Review MISSING
+19. **4.4-3** Enum 숫자/약어 사용 금지 — Review MISSING
+20. **5.4-1** API 버전을 URL 경로에 포함 금지 — Writing MISSING
+21. **5.7-3** 범용 /operations 리소스 사용 금지 — Writing MISSING
+22. **6.1-2** API Key를 쿼리 파라미터로 전달 금지 — Writing MISSING
+
+---
+
+## 다음 단계
+
+- [x] Critical 문제 스킬에 반영 (Task 5) — 17개 Critical 항목 모두 해결
+- [x] 스킬 변경 후 동일 테스트 케이스로 회귀 검증
+- [x] report.md 커버리지 수치 업데이트
+- [x] Minor 문제 스킬에 반영 — 19개 해결 (Tier A 14개 + Tier B 5개), 3개 Tier C 보류 (2.1-7, 2.3-2, 3.1-3)

--- a/plugins/api/docs/evaluation/test-cases.md
+++ b/plugins/api/docs/evaluation/test-cases.md
@@ -1,0 +1,2410 @@
+# Test Cases — RESTful API Guidelines Skill Evaluation
+
+**작성일:** 2026-03-20
+**대상 스킬:** `.claude/skills/restful-api-guidelines.md`
+**참조:** `docs/evaluation/coverage-map.md`
+
+---
+
+## 섹션 2: HTTP 기본 규칙
+
+### TC-2-01: URL 소문자 kebab-case
+
+- 규칙: "✅ **필수**: URL 경로에는 소문자 kebab-case를 사용한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@RestController
+@RequestMapping("/userProfiles")
+class UserProfileController {
+
+    @GetMapping("/{id}/paymentMethods")
+    fun getPaymentMethods(@PathVariable id: String): ResponseEntity<List<PaymentMethod>> {
+        // URL에 camelCase 사용 — 금지
+        val methods = paymentService.findByUserId(id)
+        return ResponseEntity.ok(methods)
+    }
+}
+```
+
+✅ Good:
+```kotlin
+@RestController
+@RequestMapping("/user-profiles")
+class UserProfileController {
+
+    @GetMapping("/{id}/payment-methods")
+    fun getPaymentMethods(@PathVariable id: String): ResponseEntity<List<PaymentMethod>> {
+        val methods = paymentService.findByUserId(id)
+        return ResponseEntity.ok(methods)
+    }
+}
+```
+
+- 검증 포인트: Writing 모드의 "Plural nouns + kebab-case" 주석 및 `/user-profiles` 예시, Review 체크리스트의 "Lowercase kebab-case used in paths" 항목
+
+---
+
+### TC-2-01a: URL 허용 문자 제한 (ASCII 영소문자/숫자/하이픈만)
+
+- 규칙: "URL 경로 세그먼트에는 ASCII 영소문자, 숫자, 하이픈(`-`)만 사용한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: PARTIAL / Review: PARTIAL
+  (coverage-map.md 2.1-5 기준)
+
+❌ Bad:
+```
+GET /사용자_프로필          # 비ASCII 문자
+GET /User-Profiles       # 대문자
+GET /user_profiles       # 언더스코어
+GET /userProfiles        # camelCase
+```
+
+✅ Good:
+```
+GET /user-profiles
+GET /article-categories/123
+```
+
+- 검증 포인트: Review 체크리스트 "Lowercase kebab-case used in paths"가 kebab-case를 다루지만 허용 문자 집합(ASCII 영소문자/숫자/하이픈만) 명시가 없어 PARTIAL. 비ASCII 문자 사용 케이스는 탐지 불가.
+
+---
+
+### TC-2-02: 리소스 컬렉션 복수형 명사
+
+- 규칙: "✅ **필수**: 리소스 컬렉션 이름은 복수형 명사를 사용한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@RestController
+@RequestMapping("/article")
+class ArticleController {
+
+    @GetMapping("/{id}/comment")
+    fun getComments(@PathVariable id: String): ResponseEntity<List<Comment>> {
+        val comments = commentService.findByArticleId(id)
+        return ResponseEntity.ok(comments)
+    }
+}
+```
+
+✅ Good:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    @GetMapping("/{id}/comments")
+    fun getComments(@PathVariable id: String): ResponseEntity<List<Comment>> {
+        val comments = commentService.findByArticleId(id)
+        return ResponseEntity.ok(comments)
+    }
+}
+```
+
+- 검증 포인트: Writing 모드의 `/articles`, `/users/{userId}/comments` 복수형 예시, Review 체크리스트의 "Resource names are plural nouns" 항목
+
+---
+
+### TC-2-03: URL에 동사 포함 금지
+
+- 규칙: "❌ **금지**: URL에 동사를 포함하지 않는다. 액션은 HTTP 메서드로 표현한다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: PARTIAL / Review: COVERED
+
+❌ Bad:
+```kotlin
+@RestController
+class UserController {
+
+    @PostMapping("/createUser")
+    fun createUser(@RequestBody request: CreateUserRequest): ResponseEntity<User> {
+        val user = userService.create(request)
+        return ResponseEntity.ok(user)
+    }
+
+    @GetMapping("/getArticles")
+    fun getArticles(): ResponseEntity<List<Article>> {
+        return ResponseEntity.ok(articleService.findAll())
+    }
+
+    @DeleteMapping("/deleteComment/{id}")
+    fun deleteComment(@PathVariable id: String): ResponseEntity<Void> {
+        commentService.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+}
+```
+
+✅ Good:
+```kotlin
+@RestController
+class UserController {
+
+    @PostMapping("/users")
+    fun createUser(@RequestBody request: CreateUserRequest): ResponseEntity<User> {
+        val user = userService.create(request)
+        val location = URI.create("/users/${user.id}")
+        return ResponseEntity.created(location).body(user)
+    }
+}
+
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    @GetMapping
+    fun getArticles(): ResponseEntity<List<Article>> {
+        return ResponseEntity.ok(articleService.findAll())
+    }
+}
+
+@RestController
+@RequestMapping("/comments")
+class CommentController {
+
+    @DeleteMapping("/{id}")
+    fun deleteComment(@PathVariable id: String): ResponseEntity<Void> {
+        commentService.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+}
+```
+
+- 검증 포인트: Writing 모드에 `:action` 패턴 예시는 있으나 "동사 금지" 규칙 자체 명시 없음(PARTIAL), Review 체크리스트의 "No verbs in paths (actions use :action pattern)" 항목
+
+---
+
+### TC-2-04: URL 파일 확장자 금지
+
+- 규칙: "❌ **금지**: URL에 파일 확장자(`.json`, `.xml`)를 포함하지 않는다. 콘텐츠 협상은 `Accept` 헤더를 사용한다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: COVERED
+
+❌ Bad:
+```kotlin
+@RestController
+class ArticleController {
+
+    @GetMapping("/articles.json")
+    fun getArticlesJson(): ResponseEntity<List<Article>> {
+        return ResponseEntity.ok(articleService.findAll())
+    }
+
+    @GetMapping("/articles/{id}.xml")
+    fun getArticleXml(@PathVariable id: String): ResponseEntity<Article> {
+        return ResponseEntity.ok(articleService.findById(id))
+    }
+}
+```
+
+✅ Good:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getArticles(
+        @RequestHeader("Accept", defaultValue = "application/json") accept: String
+    ): ResponseEntity<List<Article>> {
+        return ResponseEntity.ok(articleService.findAll())
+    }
+
+    @GetMapping("/{id}")
+    fun getArticle(@PathVariable id: String): ResponseEntity<Article> {
+        return ResponseEntity.ok(articleService.findById(id))
+    }
+}
+```
+
+- 검증 포인트: Writing 모드에 파일 확장자 금지 언급 없음(MISSING), Review 체크리스트의 "No file extensions in URLs" 항목
+
+---
+
+### TC-2-05: URL 2000자 이하
+
+- 규칙: "⚠️ **권장**: URL은 2000자 이하로 유지한다. 그 이상이 필요한 경우 쿼리 파라미터를 요청 본문으로 이동하는 것을 고려한다."
+- 규범 수준: ⚠️권장
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: MISSING
+
+❌ Bad:
+```kotlin
+// 수십 개의 필터 파라미터를 모두 쿼리스트링으로 전달 — URL이 2000자를 초과할 수 있음
+@GetMapping("/reports")
+fun searchReports(
+    @RequestParam status: List<String>,     // ?status=A&status=B&...&status=Z
+    @RequestParam category: List<String>,   // &category=...
+    @RequestParam tag: List<String>,        // &tag=...  (수백 개)
+    @RequestParam region: List<String>      // &region=...
+): ResponseEntity<List<Report>> {
+    return ResponseEntity.ok(reportService.search(status, category, tag, region))
+}
+
+// GET /reports?status=A&status=B&...&tag=tag1&tag=tag2&...&tag=tag200&region=...
+// → URL 길이 2000자 초과
+```
+
+✅ Good:
+```kotlin
+// 복잡한 필터 조건은 POST 검색 엔드포인트로 이동
+@PostMapping("/reports:search")
+fun searchReports(@RequestBody request: ReportSearchRequest): ResponseEntity<List<Report>> {
+    return ResponseEntity.ok(reportService.search(request))
+}
+
+data class ReportSearchRequest(
+    val status: List<String>? = null,
+    val category: List<String>? = null,
+    val tag: List<String>? = null,
+    val region: List<String>? = null
+)
+```
+
+- 검증 포인트: 스킬의 Writing/Review 모드 모두에서 URL 길이 제한 언급 없음(MISSING)
+
+---
+
+### TC-2-06: 201 Created + Location 헤더
+
+- 규칙: "✅ **필수**: 201 Created 응답에는 `Location` 헤더로 생성된 리소스의 URL을 포함한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@PostMapping("/articles")
+fun createArticle(@RequestBody request: CreateArticleRequest): ResponseEntity<Article> {
+    val article = articleService.create(request)
+    // Location 헤더 없이 200 OK 반환 — 잘못된 패턴
+    return ResponseEntity.ok(article)
+}
+```
+
+✅ Good:
+```kotlin
+@PostMapping("/articles")
+fun createArticle(@RequestBody request: CreateArticleRequest): ResponseEntity<Article> {
+    val article = articleService.create(request)
+    val location = URI.create("/articles/${article.id}")
+    return ResponseEntity.created(location).body(article)
+}
+```
+
+- 검증 포인트: Writing 모드의 "201 Created + Location header" 명시 및 `ResponseEntity.created(location)` 코드 예시, Review 체크리스트의 "POST create → 201 + Location header" 항목
+
+---
+
+### TC-2-07: GET/HEAD/DELETE에 body 포함 금지
+
+- 규칙: "❌ **금지**: GET, HEAD, DELETE 요청에 요청 본문(body)을 포함하지 않는다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: MISSING
+
+❌ Bad:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    // GET에 body 포함 — 금지
+    @GetMapping("/search")
+    fun searchArticles(@RequestBody request: SearchRequest): ResponseEntity<List<Article>> {
+        return ResponseEntity.ok(articleService.search(request))
+    }
+
+    // DELETE에 body 포함 — 금지
+    @DeleteMapping("/{id}")
+    fun deleteArticle(
+        @PathVariable id: String,
+        @RequestBody reason: DeleteReasonRequest
+    ): ResponseEntity<Void> {
+        articleService.delete(id, reason)
+        return ResponseEntity.noContent().build()
+    }
+}
+```
+
+✅ Good:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    // 검색 조건은 쿼리 파라미터로 전달
+    @GetMapping
+    fun searchArticles(
+        @RequestParam(required = false) q: String?,
+        @RequestParam(required = false) status: String?
+    ): ResponseEntity<List<Article>> {
+        return ResponseEntity.ok(articleService.search(q, status))
+    }
+
+    // DELETE는 body 없이 처리, 부가 정보가 필요하면 별도 액션으로 분리
+    @DeleteMapping("/{id}")
+    fun deleteArticle(@PathVariable id: String): ResponseEntity<Void> {
+        articleService.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+}
+```
+
+- 검증 포인트: 스킬의 Writing/Review 모드 모두에서 GET/HEAD/DELETE body 금지 규칙 없음(MISSING)
+
+---
+
+### TC-2-08: 오류 상황에 200 OK 반환 금지
+
+- 규칙: "❌ **금지**: 오류 상황에 200 OK를 반환하지 않는다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: COVERED
+
+❌ Bad:
+```kotlin
+@GetMapping("/articles/{id}")
+fun getArticle(@PathVariable id: String): ResponseEntity<Map<String, Any>> {
+    val article = articleService.findById(id)
+    if (article == null) {
+        // 오류 상황인데 200 OK 반환 — 금지
+        return ResponseEntity.ok(mapOf(
+            "success" to false,
+            "error" to "Article not found"
+        ))
+    }
+    return ResponseEntity.ok(mapOf("success" to true, "data" to article))
+}
+```
+
+✅ Good:
+```kotlin
+@GetMapping("/articles/{id}")
+fun getArticle(@PathVariable id: String): ResponseEntity<Article> {
+    val article = articleService.findById(id)
+        ?: throw ApiException(
+            status = HttpStatus.NOT_FOUND,
+            type = "https://api.example.com/errors/resource-not-found",
+            title = "Resource not found",
+            detail = "The requested article could not be found.",
+            instance = "/articles/$id"
+        )
+    return ResponseEntity.ok(article)
+}
+```
+
+- 검증 포인트: Writing 모드에 "200 OK로 에러 반환 금지" 규칙 명시 없음(MISSING), Review 체크리스트의 "200 not returned for error conditions" 항목
+
+---
+
+### TC-2-09: 서버 상태 변경에 쿼리 파라미터 사용 금지
+
+- 규칙: "❌ **금지**: 서버 상태를 변경하는 작업에 쿼리 파라미터를 사용하지 않는다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: MISSING
+
+❌ Bad:
+```kotlin
+// 쿼리 파라미터로 서버 상태 변경 — 금지
+@PostMapping("/articles")  // GET → POST로 변경
+fun publishArticle(@RequestParam action: String, @RequestParam id: String): ResponseEntity<Article> {
+    if (action == "publish") {
+        return ResponseEntity.ok(articleService.publish(id))
+    }
+    return ResponseEntity.badRequest().build()
+}
+```
+
+✅ Good:
+```kotlin
+// 상태 변경은 POST + 액션 패턴 사용
+@PostMapping("/articles/{id}:publish")
+fun publishArticle(@PathVariable id: String): ResponseEntity<Article> {
+    val article = articleService.publish(id)
+    return ResponseEntity.ok(article)
+}
+
+@PostMapping("/articles/{id}:archive")
+fun archiveArticle(@PathVariable id: String): ResponseEntity<Article> {
+    val article = articleService.archive(id)
+    return ResponseEntity.ok(article)
+}
+```
+
+- 검증 포인트: 스킬의 Writing/Review 모드 모두에서 서버 상태 변경에 쿼리 파라미터 사용 금지 규칙 없음(MISSING)
+
+---
+
+### TC-2-10: 동일 파라미터 반복으로 배열 값 전달
+
+- 규칙: "✅ **필수**: 동일한 파라미터 이름을 반복하여 배열 값을 전달한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: PARTIAL
+
+❌ Bad:
+```kotlin
+// 쉼표 구분 문자열로 배열 값 전달 — 비표준
+@GetMapping("/articles")
+fun getArticles(
+    @RequestParam tags: String  // ?tags=tech,design,backend
+): ResponseEntity<List<Article>> {
+    val tagList = tags.split(",")
+    return ResponseEntity.ok(articleService.findByTags(tagList))
+}
+
+// 또는 brackets 표기법 — 비표준
+// GET /articles?tags[]=tech&tags[]=design
+```
+
+✅ Good:
+```kotlin
+// 동일 파라미터를 반복하여 배열 전달
+@GetMapping("/articles")
+fun getArticles(
+    @RequestParam(required = false) tag: List<String>?
+    // GET /articles?tag=tech&tag=design&tag=backend
+): ResponseEntity<List<Article>> {
+    return ResponseEntity.ok(articleService.findByTags(tag ?: emptyList()))
+}
+```
+
+- 검증 포인트: Writing 모드에 동일 파라미터 반복으로 배열 전달 패턴 없음(MISSING), Review 체크리스트의 "Repeated same parameter treated as OR condition" 항목은 의미(OR 조건)를 다루며 인코딩 방식은 간접적(PARTIAL)
+
+---
+
+### TC-2-11: Content-Type 헤더 포함
+
+- 규칙: "✅ **필수**: 요청 본문이 있는 경우 `Content-Type` 헤더를 포함한다." / "✅ **필수**: 응답 본문이 있는 경우 `Content-Type` 헤더를 포함한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: PARTIAL / Review: MISSING
+
+❌ Bad:
+```kotlin
+// Bad — Content-Type 헤더를 명시하지 않고 응답 본문을 반환
+@PostMapping
+fun createArticle(@RequestBody request: CreateArticleRequest): ResponseEntity<Article> {
+    val article = articleService.create(request)
+    val location = URI.create("/articles/${article.id}")
+    // produces 없이 ResponseEntity로만 반환 시 프레임워크 설정에 따라 Content-Type 누락 가능
+    return ResponseEntity.created(location).body(article)
+}
+
+// 또는 raw HttpServletResponse 사용 시:
+@PostMapping("/raw")
+fun createArticleRaw(response: HttpServletResponse, @RequestBody request: CreateArticleRequest) {
+    val article = articleService.create(request)
+    // Content-Type 헤더 누락
+    response.outputStream.write(objectMapper.writeValueAsBytes(article))
+}
+```
+
+✅ Good:
+```kotlin
+// Good — Content-Type 명시
+@PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+fun createArticle(@RequestBody request: CreateArticleRequest): ResponseEntity<Article> {
+    val article = articleService.create(request)
+    val location = URI.create("/articles/${article.id}")
+    return ResponseEntity.created(location)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(article)
+}
+```
+
+- 검증 포인트: Spring Boot는 `@RestController` + `produces` 설정으로 자동 처리되나, HTTP 규칙상 응답 본문이 있는 모든 응답에 Content-Type 헤더가 있어야 함. Writing 모드는 에러 응답 `application/problem+json`만 언급하고 일반 요청/응답 Content-Type 규칙 없음(PARTIAL), Review 모드에 요청/응답 Content-Type 체크 항목 없음(MISSING)
+
+---
+
+## 섹션 3: REST 원칙
+
+### TC-3-01: null 값 필드 응답 포함 금지
+
+- 규칙: "❌ **금지**: 응답에 null 값 필드를 포함하지 않는다. 값이 없는 필드는 응답에서 제외한다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: COVERED
+
+❌ Bad:
+```kotlin
+data class ArticleResponse(
+    val id: String,
+    val title: String,
+    val content: String,
+    val deletedAt: String? = null,   // null 값이 응답에 포함됨
+    val publishedAt: String? = null  // null 값이 응답에 포함됨
+)
+
+// JSON 직렬화 결과:
+// { "id": "123", "title": "제목", "content": "...", "deletedAt": null, "publishedAt": null }
+```
+
+✅ Good:
+```kotlin
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class ArticleResponse(
+    val id: String,
+    val title: String,
+    val content: String,
+    val deletedAt: String? = null,
+    val publishedAt: String? = null
+)
+
+// JSON 직렬화 결과 (null 필드 제외):
+// { "id": "123", "title": "제목", "content": "..." }
+```
+
+- 검증 포인트: Writing 모드에 null 값 필드 제외 규칙 없음(MISSING), Review 체크리스트의 "Null-valued fields excluded from response" 항목
+
+---
+
+### TC-3-02: 읽기 전용 필드 요청 본문 무시
+
+- 규칙: "✅ **필수**: 서버가 관리하는 읽기 전용 필드(`id`, `createdAt`, `updatedAt`)를 클라이언트가 요청 본문에 포함하더라도 이를 무시한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: PARTIAL / Review: MISSING
+
+❌ Bad:
+```kotlin
+@PostMapping("/articles")
+fun createArticle(@RequestBody request: Map<String, Any>): ResponseEntity<Article> {
+    // 클라이언트가 보낸 id, createdAt을 그대로 사용 — 금지
+    val article = Article(
+        id = request["id"] as? String ?: UUID.randomUUID().toString(),
+        title = request["title"] as String,
+        createdAt = request["createdAt"] as? Instant ?: Instant.now(),
+        updatedAt = request["updatedAt"] as? Instant ?: Instant.now()
+    )
+    articleRepository.save(article)
+    val location = URI.create("/articles/${article.id}")
+    return ResponseEntity.created(location).body(article)
+}
+```
+
+✅ Good:
+```kotlin
+// 클라이언트 요청 (id 포함)
+// POST /articles
+// { "id": "hack-123", "title": "제목", "content": "내용", "createdAt": "2020-01-01T00:00:00Z" }
+//
+// 서버는 위 요청에서 id, createdAt을 무시하고 서버가 직접 생성함
+
+@PostMapping("/articles")
+fun createArticle(@RequestBody request: CreateArticleRequest): ResponseEntity<Article> {
+    // 클라이언트가 id, createdAt, updatedAt을 보내더라도 무시하고 서버가 생성
+    val article = Article(
+        id = UUID.randomUUID().toString(),
+        title = request.title,
+        content = request.content,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now()
+    )
+    articleRepository.save(article)
+    val location = URI.create("/articles/${article.id}")
+    return ResponseEntity.created(location).body(article)
+}
+
+data class CreateArticleRequest(
+    val title: String,
+    val content: String
+    // id, createdAt, updatedAt은 요청 DTO에 포함하지 않음
+)
+```
+
+- 검증 포인트: Writing 모드의 Standard Resource Fields에 "not modifiable by client" 언급 있으나 무시 동작 명시 불충분(PARTIAL), Review 체크리스트에 읽기 전용 필드 무시 동작 체크 없음(MISSING)
+
+---
+
+### TC-3-03: RFC 7807 에러 응답 구조
+
+- 규칙: "✅ **필수**: 모든 에러 응답은 RFC 7807 / RFC 9457 (Problem Details for HTTP APIs) 표준을 따른다." / "✅ **필수**: 에러 응답의 `Content-Type`은 `application/problem+json`을 사용한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+// 비표준 에러 응답 구조
+@ExceptionHandler(ResourceNotFoundException::class)
+fun handleNotFound(ex: ResourceNotFoundException): ResponseEntity<Map<String, Any>> {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .contentType(MediaType.APPLICATION_JSON)  // application/json — 잘못됨
+        .body(mapOf(
+            "success" to false,
+            "message" to ex.message,
+            "code" to "NOT_FOUND"
+        ))
+}
+```
+
+✅ Good:
+```kotlin
+@ExceptionHandler(ResourceNotFoundException::class)
+fun handleNotFound(
+    ex: ResourceNotFoundException,
+    request: HttpServletRequest
+): ResponseEntity<ProblemDetail> {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .contentType(MediaType.parseMediaType("application/problem+json"))
+        .body(ProblemDetail(
+            type = "https://api.example.com/errors/resource-not-found",
+            title = "Resource not found",
+            status = 404,
+            detail = ex.message ?: "The requested resource could not be found.",
+            instance = request.requestURI
+        ))
+}
+```
+
+- 검증 포인트: Writing 모드의 Error Response Format Template (RFC 7807/9457 구조 + `Content-Type: application/problem+json` 명시), Review 체크리스트의 "Error responses use RFC 7807/9457 Problem Details structure" 및 "Content-Type: application/problem+json used" 항목
+
+---
+
+### TC-3-04: DELETE 성공 시 204 No Content
+
+- 규칙: "✅ **필수**: 삭제 성공 시 204 No Content를 반환한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@DeleteMapping("/articles/{id}")
+fun deleteArticle(@PathVariable id: String): ResponseEntity<Map<String, String>> {
+    articleService.delete(id)
+    // 200 OK + body 반환 — 잘못된 패턴
+    return ResponseEntity.ok(mapOf("message" to "Article deleted successfully"))
+}
+```
+
+✅ Good:
+```kotlin
+@DeleteMapping("/articles/{id}")
+fun deleteArticle(@PathVariable id: String): ResponseEntity<Void> {
+    articleService.delete(id)
+    return ResponseEntity.noContent().build()
+}
+```
+
+- 검증 포인트: Writing 모드의 HTTP Method to Status Code Mapping 표 "DELETE | 204 No Content" 및 `ResponseEntity.noContent().build()` 코드 예시, Review 체크리스트의 "DELETE success → 204 (no body)" 항목
+
+---
+
+### TC-3-05: POST 201 Created + 리소스 반환
+
+- 규칙: "✅ **필수**: 새 리소스 생성 성공 시 201 Created와 생성된 리소스를 반환한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@PostMapping("/articles")
+fun createArticle(@RequestBody request: CreateArticleRequest): ResponseEntity<Map<String, String>> {
+    val article = articleService.create(request)
+    // 200 OK, Location 헤더 없음, 생성된 리소스 미반환
+    return ResponseEntity.ok(mapOf("id" to article.id))
+}
+```
+
+✅ Good:
+```kotlin
+@PostMapping("/articles")
+fun createArticle(@RequestBody request: CreateArticleRequest): ResponseEntity<Article> {
+    val article = articleService.create(request)
+    val location = URI.create("/articles/${article.id}")
+    return ResponseEntity.created(location).body(article)
+}
+```
+
+- 검증 포인트: Writing 모드의 "POST (create) | 201 Created + Location header" 매핑 및 `createArticle` 코드 예시, Review 체크리스트의 "POST create → 201 + Location header" 항목
+
+---
+
+### TC-3-06: 유효성 검사 실패 시 모든 오류 한 번에 반환
+
+- 규칙: "⚠️ **권장**: 유효성 검사 실패 시 모든 오류 필드를 한 번에 반환한다 (하나씩 반환하지 않는다)."
+- 규범 수준: ⚠️권장
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+// 첫 번째 오류만 반환하고 나머지는 무시
+@PostMapping("/articles")
+fun createArticle(@RequestBody request: CreateArticleRequest): ResponseEntity<Article> {
+    if (request.title.isBlank()) {
+        throw ValidationException("title", "제목은 필수 입력값입니다.")
+        // content 오류는 검사하지 않음 — 클라이언트가 여러 번 요청해야 함
+    }
+    if (request.content.length < 10) {
+        throw ValidationException("content", "본문은 10자 이상이어야 합니다.")
+    }
+    // ...
+}
+```
+
+✅ Good:
+```kotlin
+@PostMapping("/articles")
+fun createArticle(@RequestBody @Valid request: CreateArticleRequest): ResponseEntity<Article> {
+    // Bean Validation + 전역 예외 핸들러로 모든 오류를 한 번에 수집
+    val article = articleService.create(request)
+    val location = URI.create("/articles/${article.id}")
+    return ResponseEntity.created(location).body(article)
+}
+
+@ExceptionHandler(MethodArgumentNotValidException::class)
+fun handleValidation(
+    ex: MethodArgumentNotValidException,
+    request: HttpServletRequest
+): ResponseEntity<ProblemDetail> {
+    val fieldErrors = ex.bindingResult.fieldErrors.map { error ->
+        ProblemDetail.FieldError(
+            field = error.field,
+            message = error.defaultMessage ?: "Invalid value"
+        )
+    }
+    return ResponseEntity.badRequest()
+        .contentType(MediaType.parseMediaType("application/problem+json"))
+        .body(ProblemDetail(
+            type = "https://api.example.com/errors/validation-failed",
+            title = "Validation failed",
+            status = 400,
+            detail = "Request data validation failed.",
+            instance = request.requestURI,
+            errors = fieldErrors
+        ))
+}
+```
+
+- 검증 포인트: 스킬의 RFC 7807 템플릿에 `errors` 배열 확장 필드가 있으나, 유효성 실패 시 '모든 오류를 한 번에 반환해야 한다'는 명시적 지침이 Writing Mode에 없고 Review 체크리스트에도 "All validation errors returned at once" 항목이 없음(MISSING). TC-3-03이 RFC 7807 구조(3.4-1/3.4-2)를 별도로 커버한다.
+
+---
+
+### TC-3-07: 에러 응답에 내부 정보 노출 금지
+
+- 규칙: "❌ **금지**: 에러 응답에 스택 트레이스, 내부 시스템 경로, DB 오류 메시지 등 내부 구현 정보를 노출하지 않는다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: COVERED
+
+❌ Bad:
+```kotlin
+@ExceptionHandler(Exception::class)
+fun handleException(ex: Exception, request: HttpServletRequest): ResponseEntity<Map<String, Any>> {
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(mapOf(
+            "error" to ex.message,
+            // 스택 트레이스 노출 — 금지
+            "stackTrace" to ex.stackTraceToString(),
+            // 내부 시스템 경로 노출 — 금지
+            "path" to "/var/app/services/article-service/src/main/kotlin/...",
+            // DB 오류 메시지 노출 — 금지
+            "cause" to "org.postgresql.util.PSQLException: duplicate key value violates unique constraint"
+        ))
+}
+```
+
+✅ Good:
+```kotlin
+@ExceptionHandler(Exception::class)
+fun handleException(ex: Exception, request: HttpServletRequest): ResponseEntity<ProblemDetail> {
+    // 내부 정보는 서버 로그에만 기록
+    logger.error("Unhandled exception", ex)
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .contentType(MediaType.parseMediaType("application/problem+json"))
+        .body(ProblemDetail(
+            type = "https://api.example.com/errors/internal-server-error",
+            title = "Internal server error",
+            status = 500,
+            detail = "An unexpected error occurred. Please try again later.",
+            instance = request.requestURI,
+            traceId = MDC.get("traceId")
+        ))
+}
+```
+
+- 검증 포인트: Writing 모드에 스택 트레이스/내부 정보 노출 금지 가이드 없음(MISSING), Review 체크리스트의 "Internal implementation details (stack traces, DB errors) not exposed" 항목
+
+---
+
+### TC-3-08: 표준 리소스 필드 구조
+
+- 규칙: "✅ **필수**: 리소스 스키마는 일관된 구조를 유지한다." (id, createdAt, updatedAt 표준 필드)
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: MISSING
+
+❌ Bad:
+```json
+{
+  "articleId": "123",
+  "title": "RESTful API 설계",
+  "content": "...",
+  "created": "2024-01-15 09:00:00",
+  "modified": "2024-01-20 14:30:00"
+}
+```
+
+✅ Good:
+```json
+{
+  "id": "123",
+  "title": "RESTful API 설계",
+  "content": "...",
+  "createdAt": "2024-01-15T09:00:00Z",
+  "updatedAt": "2024-01-20T14:30:00Z"
+}
+```
+
+- 검증 포인트: Writing 모드의 Standard Resource Fields에 id/createdAt/updatedAt 표준 구조 정의(COVERED), Review 체크리스트에 표준 필드 구조 검증 항목 없음(MISSING)
+
+---
+
+## 섹션 4: JSON 규칙
+
+### TC-4-01: JSON 필드 이름 camelCase
+
+- 규칙: "✅ **필수**: JSON 필드 이름은 camelCase를 사용한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+data class ArticleResponse(
+    val article_id: String,      // snake_case — 금지
+    val user_name: String,       // snake_case — 금지
+    val created_at: String,      // snake_case — 금지
+    val is_published: Boolean    // snake_case — 금지
+)
+
+// JSON 출력: { "article_id": "123", "user_name": "john", "created_at": "...", "is_published": true }
+```
+
+✅ Good:
+```kotlin
+data class ArticleResponse(
+    val articleId: String,
+    val userName: String,
+    val createdAt: String,
+    val isPublished: Boolean
+)
+
+// JSON 출력: { "articleId": "123", "userName": "john", "createdAt": "...", "isPublished": true }
+```
+
+- 검증 포인트: Writing 모드의 JSON Field Naming Rules "Correct example" / "Incorrect example" 비교, Review 체크리스트의 "All fields are camelCase" 항목. 이 케이스는 4.1-2(필드 이름 영소문자로 시작) 규칙도 부분적으로 커버한다. snake_case 예시는 모두 영소문자로 시작하므로 4.1-2 위반 패턴(예: `UserId`) 의 별도 TC가 필요할 수 있다.
+
+---
+
+### TC-4-02: 필드명 약어 금지
+
+- 규칙: "❌ **금지**: 필드 이름에 약어를 남용하지 않는다. 명확한 전체 단어를 우선한다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: MISSING
+
+❌ Bad:
+```json
+{
+  "usr": "john",
+  "ts": "2024-01-20T10:00:00Z",
+  "cnt": 5,
+  "desc": "A short description",
+  "qty": 10,
+  "amt": 1500
+}
+```
+
+✅ Good:
+```json
+{
+  "username": "john",
+  "timestamp": "2024-01-20T10:00:00Z",
+  "count": 5,
+  "description": "A short description",
+  "quantity": 10,
+  "amount": 1500
+}
+```
+
+- 검증 포인트: 스킬의 Writing/Review 모드 모두에서 약어 남용 금지 규칙 없음(MISSING)
+
+---
+
+### TC-4-03: Boolean 필드 is/has/can 접두사
+
+- 규칙: "✅ **필수**: Boolean 필드 이름은 `is`, `has`, `can` 등의 접두사를 사용한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```json
+{
+  "active": true,
+  "admin": false,
+  "editPermission": true,
+  "verified": true,
+  "subscribed": false
+}
+```
+
+✅ Good:
+```json
+{
+  "isActive": true,
+  "isAdmin": false,
+  "canEdit": true,
+  "isVerified": true,
+  "hasSubscription": false
+}
+```
+
+- 검증 포인트: Writing 모드의 `"isActive": true` 예시 및 JSON 필드 규칙, Review 체크리스트의 "Boolean fields use is/has/can prefix" 항목
+
+---
+
+### TC-4-04: Boolean은 JSON true/false 사용
+
+- 규칙: "✅ **필수**: Boolean 값에는 JSON `true`/`false`를 사용한다. 문자열 `\"true\"`/`\"false\"` 또는 숫자 `1`/`0`을 사용하지 않는다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: PARTIAL / Review: MISSING
+
+❌ Bad:
+```json
+{
+  "isActive": "true",
+  "hasPermission": "false",
+  "canEdit": 1,
+  "isVerified": 0
+}
+```
+
+✅ Good:
+```json
+{
+  "isActive": true,
+  "hasPermission": false,
+  "canEdit": true,
+  "isVerified": false
+}
+```
+
+- 검증 포인트: Writing 모드에 `"isActive": true` 코드 예시 있으나 문자열/"1"/"0" 금지 명시 없음(PARTIAL), Review 체크리스트에 Boolean JSON true/false 체크 항목 없음(MISSING)
+
+---
+
+### TC-4-05: 큰 정수 문자열 반환
+
+- 규칙: "⚠️ **권장**: JavaScript의 안전한 정수 범위(2^53 - 1)를 초과하는 큰 정수는 문자열로 반환한다."
+- 규범 수준: ⚠️권장
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: MISSING
+
+❌ Bad:
+```json
+{
+  "id": 9007199254740993,
+  "snowflakeId": 1234567890123456789,
+  "count": 42,
+  "price": 19.99
+}
+```
+
+✅ Good:
+```json
+{
+  "id": "9007199254740993",
+  "snowflakeId": "1234567890123456789",
+  "count": 42,
+  "price": 19.99
+}
+```
+
+- 검증 포인트: 스킬의 Writing/Review 모드 모두에서 큰 정수 문자열 반환 규칙 없음(MISSING)
+
+---
+
+### TC-4-06: 날짜/시간 RFC 3339 형식 및 UTC
+
+- 규칙: "✅ **필수**: 모든 날짜/시간 값은 RFC 3339 형식(ISO 8601 프로파일)의 문자열로 표현한다." / "✅ **필수**: 서버 응답의 모든 시간 값은 UTC(`Z`)로 반환한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```json
+{
+  "createdAt": "2024-01-20 10:00:00",
+  "updatedAt": "Jan 20, 2024 3:00 PM",
+  "scheduledAt": "2024/01/25 09:30:00+09:00",
+  "publishedAt": "20240120T150000Z"
+}
+```
+
+✅ Good:
+```json
+{
+  "createdAt": "2024-01-20T10:00:00Z",
+  "updatedAt": "2024-01-20T15:00:00Z",
+  "scheduledAt": "2024-01-25T00:30:00Z",
+  "birthDate": "1990-05-15"
+}
+```
+
+- 검증 포인트: Writing 모드의 Date/Time 섹션 RFC 3339 형식 예시 및 "Server response (Required: UTC)" 명시, Review 체크리스트의 "Date/time in RFC 3339 format" 및 "All time values in server response are UTC (Z)" 항목
+
+---
+
+### TC-4-07: 오프셋 포함 시간 서버가 UTC로 변환 저장
+
+- 규칙: "✅ **필수**: 클라이언트가 오프셋이 포함된 시간을 전송하면, 서버는 이를 UTC로 변환하여 저장한다. 에러를 반환하지 않는다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@PostMapping("/events")
+fun createEvent(@RequestBody request: CreateEventRequest): ResponseEntity<Event> {
+    val scheduledAt = OffsetDateTime.parse(request.scheduledAt)
+
+    // 오프셋이 포함되면 에러 반환 — 잘못된 처리
+    if (scheduledAt.offset != ZoneOffset.UTC) {
+        throw ApiException(
+            status = HttpStatus.BAD_REQUEST,
+            type = "https://api.example.com/errors/invalid-request",
+            title = "Invalid time format",
+            detail = "Time values must be in UTC format."
+        )
+    }
+
+    // 또는 오프셋을 무시하고 그대로 저장 — 잘못된 처리
+    val event = eventService.create(request.copy(scheduledAt = request.scheduledAt))
+    val location = URI.create("/events/${event.id}")
+    return ResponseEntity.created(location).body(event)
+}
+```
+
+✅ Good:
+```kotlin
+@PostMapping("/events")
+fun createEvent(@RequestBody request: CreateEventRequest): ResponseEntity<Event> {
+    // 오프셋 포함 시간을 UTC로 정규화하여 저장
+    val scheduledAt = OffsetDateTime.parse(request.scheduledAt)
+        .withOffsetSameInstant(ZoneOffset.UTC)  // UTC로 변환
+        .toInstant()
+
+    val event = eventService.create(
+        title = request.title,
+        scheduledAt = scheduledAt  // UTC로 변환된 값 저장
+    )
+    val location = URI.create("/events/${event.id}")
+    return ResponseEntity.created(location).body(event)
+    // 응답: { "scheduledAt": "2024-01-25T00:30:00Z" }
+}
+```
+
+- 검증 포인트: Writing 모드의 "offset allowed — server normalizes to UTC" 명시, Review 체크리스트의 "Offset input is normalized to UTC by server (not an error)" 항목
+
+---
+
+### TC-4-08: Unix timestamp 금지
+
+- 규칙: "❌ **금지**: Unix timestamp(epoch milliseconds/seconds)를 기본 시간 형식으로 사용하지 않는다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: MISSING
+
+❌ Bad:
+```json
+{
+  "createdAt": 1705744800000,
+  "updatedAt": 1705762200,
+  "scheduledAt": 1706140200000
+}
+```
+
+✅ Good:
+```json
+{
+  "createdAt": "2024-01-20T10:00:00Z",
+  "updatedAt": "2024-01-20T15:00:00Z",
+  "scheduledAt": "2024-01-25T00:30:00Z"
+}
+```
+
+- 검증 포인트: Writing 모드의 Prohibited 섹션에 "Unix timestamp forbidden" 명시(COVERED), Review 체크리스트에 Unix timestamp 금지 체크 항목 없음(MISSING)
+
+---
+
+### TC-4-09: Enum UPPER_SNAKE_CASE
+
+- 규칙: "✅ **필수**: Enum 값은 UPPER_SNAKE_CASE 문자열을 사용한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+enum class ArticleStatus {
+    published,      // 소문자 — 금지
+    Draft,          // PascalCase — 금지
+    in_review,      // lower_snake_case — 금지
+    pendingApproval // camelCase — 금지
+}
+
+// JSON: { "status": "published" }
+```
+
+✅ Good:
+```kotlin
+enum class ArticleStatus {
+    PUBLISHED,
+    DRAFT,
+    IN_REVIEW,
+    PENDING_APPROVAL
+}
+
+// JSON: { "status": "PUBLISHED" }
+```
+
+- 검증 포인트: Writing 모드의 `"status": "PUBLISHED"` 예시 및 "enums must be UPPER_SNAKE_CASE" 명시, Review 체크리스트의 "Enum values are UPPER_SNAKE_CASE" 항목
+
+---
+
+### TC-4-10: Enum 숫자/약어 사용 금지
+
+- 규칙: "❌ **금지**: Enum 값으로 숫자나 불명확한 약어를 사용하지 않는다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: PARTIAL / Review: MISSING
+
+❌ Bad:
+```json
+{
+  "status": 1,
+  "priority": "hi",
+  "category": "misc",
+  "type": 3
+}
+```
+
+✅ Good:
+```json
+{
+  "status": "PUBLISHED",
+  "priority": "HIGH",
+  "category": "MISCELLANEOUS",
+  "type": "PREMIUM_MEMBERSHIP"
+}
+```
+
+- 검증 포인트: Writing 모드에 "enums must be UPPER_SNAKE_CASE" 명시 있으나 숫자/약어 사용 금지 bad case 없음(PARTIAL), Review 체크리스트에 Enum 숫자/약어 금지 체크 항목 없음(MISSING)
+
+---
+
+## 섹션 5: 공통 API 패턴
+
+### TC-5-01: 액션 패턴 :action 형태
+
+- 규칙: "✅ **필수**: 액션은 리소스 URL 뒤에 `:action` 형태로 표현한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    // URL에 동사를 별도 경로로 사용 — 금지
+    @PostMapping("/{id}/publish")
+    fun publishArticle(@PathVariable id: String): ResponseEntity<Article> {
+        val article = articleService.publish(id)
+        return ResponseEntity.ok(article)
+    }
+
+    // 쿼리 파라미터로 액션 지정 — 금지
+    @PostMapping("/{id}")
+    fun performAction(
+        @PathVariable id: String,
+        @RequestParam action: String
+    ): ResponseEntity<Article> {
+        return when (action) {
+            "cancel" -> ResponseEntity.ok(articleService.cancel(id))
+            else -> ResponseEntity.badRequest().build()
+        }
+    }
+}
+```
+
+✅ Good:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    @PostMapping("/{id}:publish")
+    fun publishArticle(@PathVariable id: String): ResponseEntity<Article> {
+        val article = articleService.publish(id)
+        return ResponseEntity.ok(article)
+    }
+
+    @PostMapping("/{id}:cancel")
+    fun cancelArticle(@PathVariable id: String): ResponseEntity<Article> {
+        val article = articleService.cancel(id)
+        return ResponseEntity.ok(article)
+    }
+}
+```
+
+- 검증 포인트: Writing 모드의 "Action pattern" 섹션에 `:publish`, `:cancel`, `:deactivate` 예시, Review 체크리스트의 "No verbs in paths (actions use `:action` pattern)" 항목
+
+---
+
+### TC-5-02: 액션 엔드포인트 POST 메서드
+
+- 규칙: "✅ **필수**: 액션 엔드포인트에는 POST 메서드를 사용한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    // GET으로 액션 수행 — 금지 (서버 상태 변경)
+    @GetMapping("/{id}:publish")
+    fun publishArticle(@PathVariable id: String): ResponseEntity<Article> {
+        val article = articleService.publish(id)
+        return ResponseEntity.ok(article)
+    }
+
+    // PUT으로 액션 수행 — 부적절
+    @PutMapping("/{id}:cancel")
+    fun cancelArticle(@PathVariable id: String): ResponseEntity<Article> {
+        val article = articleService.cancel(id)
+        return ResponseEntity.ok(article)
+    }
+}
+```
+
+✅ Good:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    @PostMapping("/{id}:publish")
+    fun publishArticle(@PathVariable id: String): ResponseEntity<Article> {
+        val article = articleService.publish(id)
+        return ResponseEntity.ok(article)
+    }
+
+    @PostMapping("/{id}:cancel")
+    fun cancelArticle(@PathVariable id: String): ResponseEntity<Article> {
+        val article = articleService.cancel(id)
+        return ResponseEntity.ok(article)
+    }
+}
+```
+
+- 검증 포인트: Writing 모드의 HTTP Method to Status Code Mapping 표 "POST (action) | 200 OK | Action performed" 및 코드 예시의 `@PostMapping("/{id}:publish")`, Review 체크리스트에서 액션 패턴이 POST 사용하는 것이 URL Design 체크에 포함
+
+---
+
+### TC-5-03: 컬렉션 응답 top-level array
+
+- 규칙: "✅ **필수**: 컬렉션 조회 응답 본문은 리소스 배열(top-level JSON array)을 반환한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    // envelope 객체로 감싸서 반환 — 금지
+    @GetMapping
+    fun getArticles(): ResponseEntity<Map<String, Any>> {
+        val articles = articleService.findAll()
+        return ResponseEntity.ok(mapOf(
+            "data" to articles,
+            "totalCount" to articles.size,
+            "page" to 1
+        ))
+    }
+}
+
+// 응답:
+// {
+//   "data": [ { "id": "1", ... }, { "id": "2", ... } ],
+//   "totalCount": 2,
+//   "page": 1
+// }
+```
+
+✅ Good:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    @GetMapping
+    fun getArticles(
+        @RequestParam(defaultValue = "20") pageSize: Int,
+        @RequestParam(required = false) pageToken: String?
+    ): ResponseEntity<List<Article>> {
+        val result = articleService.getArticles(pageSize, pageToken)
+        val headers = HttpHeaders()
+        buildLinkHeader(result, pageSize).let { headers.set("Link", it) }
+        result.totalCount?.let { headers.set("X-Total-Count", it.toString()) }
+        return ResponseEntity.ok().headers(headers).body(result.items)
+    }
+}
+
+// 응답:
+// HTTP/1.1 200 OK
+// Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next"
+// X-Total-Count: 100
+//
+// [
+//   { "id": "1", "title": "첫 번째 글" },
+//   { "id": "2", "title": "두 번째 글" }
+// ]
+```
+
+- 검증 포인트: Writing 모드의 Collection/Pagination Pattern에 "top-level array" 명시 및 `ResponseEntity<List<Article>>` 코드 예시, Review 체크리스트의 "Collection response body is a top-level array (no envelope)" 항목
+
+---
+
+### TC-5-04: Link 헤더 rel="next" 제외 (다음 페이지 없을 때)
+
+- 규칙: "✅ **필수**: 다음 페이지가 없을 때 `Link` 헤더에서 `rel=\"next\"`를 제외한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+// 다음 페이지가 없는데도 rel="next"를 포함 — 금지
+fun <T> buildLinkHeader(result: PageResult<T>, pageSize: Int): String {
+    val base = "https://api.example.com/articles?pageSize=$pageSize"
+    val links = mutableListOf<String>()
+    // nextPageToken이 null인데도 빈 문자열로 next 링크 생성
+    links += "<$base&pageToken=${result.nextPageToken ?: ""}>; rel=\"next\""
+    links += "<$base>; rel=\"first\""
+    return links.joinToString(", ")
+}
+
+// 응답 (마지막 페이지):
+// Link: <https://api.example.com/articles?pageSize=20&pageToken=>; rel="next",
+//       <https://api.example.com/articles?pageSize=20>; rel="first"
+```
+
+✅ Good:
+```kotlin
+fun <T> buildLinkHeader(result: PageResult<T>, pageSize: Int): String {
+    val base = "https://api.example.com/articles?pageSize=$pageSize"
+    val links = mutableListOf<String>()
+    // nextPageToken이 null이면 rel="next" 자체를 생략
+    result.nextPageToken?.let { links += "<$base&pageToken=$it>; rel=\"next\"" }
+    result.prevPageToken?.let { links += "<$base&pageToken=$it>; rel=\"prev\"" }
+    links += "<$base>; rel=\"first\""
+    return links.joinToString(", ")
+}
+
+// 응답 (마지막 페이지) — rel="next" 없음:
+// Link: <https://api.example.com/articles?pageSize=20>; rel="first"
+```
+
+- 검증 포인트: Writing 모드의 `buildLinkHeader` 코드에서 `nextPageToken?.let` 패턴으로 null 시 next 미포함, Review 체크리스트의 "rel=\"next\" excluded from Link header when no next page" 항목
+
+---
+
+### TC-5-05: 페이지네이션 파라미터 camelCase (2.1-6 연계)
+
+- 규칙: "✅ **필수**: 쿼리 파라미터 이름은 camelCase를 사용한다." (2.1-6과 연계)
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```
+GET /articles?page_size=20&page_token=abc&order_by=created_at:desc
+GET /articles?PageSize=20&PageToken=abc
+GET /articles?page-size=20&page-token=abc
+```
+
+✅ Good:
+```
+GET /articles?pageSize=20&pageToken=abc
+GET /articles?pageSize=20&page=2
+GET /articles?orderBy=createdAt:desc
+```
+
+- 검증 포인트: Writing 모드의 Collection/Pagination Pattern에 `pageSize`, `pageToken`, `orderBy` 등 camelCase 파라미터 예시 및 "(camelCase)" 명시, Review 체크리스트의 "Query parameters are camelCase (pageSize, pageToken, orderBy)" 항목
+
+---
+
+### TC-5-06: X-Total-Count 헤더
+
+- 규칙: "⚠️ **권장**: 전체 항목 수를 제공할 때 `X-Total-Count` 헤더를 사용한다."
+- 규범 수준: ⚠️권장
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@GetMapping
+fun getArticles(): ResponseEntity<Map<String, Any>> {
+    val articles = articleService.findAll()
+    // 전체 항목 수를 응답 본문에 포함 — envelope 패턴으로 이어짐
+    return ResponseEntity.ok(mapOf(
+        "items" to articles,
+        "totalCount" to articles.size
+    ))
+}
+```
+
+✅ Good:
+```kotlin
+@GetMapping
+fun getArticles(
+    @RequestParam(defaultValue = "20") pageSize: Int,
+    @RequestParam(required = false) pageToken: String?
+): ResponseEntity<List<Article>> {
+    val result = articleService.getArticles(pageSize, pageToken)
+    val headers = HttpHeaders()
+    buildLinkHeader(result, pageSize).let { headers.set("Link", it) }
+    result.totalCount?.let { headers.set("X-Total-Count", it.toString()) }
+    return ResponseEntity.ok().headers(headers).body(result.items)
+}
+
+// 응답:
+// HTTP/1.1 200 OK
+// X-Total-Count: 100
+// Link: <...>; rel="next"
+//
+// [ { "id": "1", ... }, { "id": "2", ... } ]
+```
+
+- 검증 포인트: Writing 모드의 Collection/Pagination Pattern에 `X-Total-Count: 100` 헤더 예시 및 코드에서 `headers.set("X-Total-Count", ...)`, Review 체크리스트의 "X-Total-Count header used when providing total item count" 항목
+
+---
+
+### TC-5-07: 범위 필터 After/Before 접미사
+
+- 규칙: "⚠️ **권장**: 범위 필터(range)에는 `After`/`Before` 접미사를 사용한다."
+- 규범 수준: ⚠️권장
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: COVERED
+
+❌ Bad:
+```
+GET /articles?created_from=2024-01-01T00:00:00Z&created_to=2024-02-01T00:00:00Z
+GET /articles?startDate=2024-01-01&endDate=2024-02-01
+GET /articles?minCreatedAt=2024-01-01T00:00:00Z&maxCreatedAt=2024-02-01T00:00:00Z
+```
+
+✅ Good:
+```
+GET /articles?createdAfter=2024-01-01T00:00:00Z
+GET /articles?createdBefore=2024-02-01T00:00:00Z
+GET /articles?createdAfter=2024-01-01T00:00:00Z&createdBefore=2024-02-01T00:00:00Z
+```
+
+- 검증 포인트: Writing 모드에 범위 필터 After/Before 패턴 없음(MISSING), Review 체크리스트의 "Range filters use After/Before suffix (createdAfter, createdBefore)" 항목
+
+---
+
+### TC-5-08: 동일 파라미터 반복 OR 조건
+
+- 규칙: "✅ **필수**: 동일 파라미터 반복은 OR 조건으로 처리한다. 서로 다른 파라미터 간 조합은 AND 조건이다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: COVERED
+
+❌ Bad:
+```kotlin
+@GetMapping("/articles")
+fun getArticles(
+    @RequestParam(required = false) status: List<String>?
+): ResponseEntity<List<Article>> {
+    // 동일 파라미터 반복을 AND 조건으로 처리 — 금지
+    // GET /articles?status=PUBLISHED&status=DRAFT
+    // → status가 PUBLISHED이면서 동시에 DRAFT인 것만 반환 (논리적으로 불가능)
+    val articles = articleService.findByAllStatuses(status ?: emptyList())
+    return ResponseEntity.ok(articles)
+}
+```
+
+✅ Good:
+```kotlin
+@GetMapping("/articles")
+fun getArticles(
+    @RequestParam(required = false) status: List<String>?,
+    @RequestParam(required = false) authorId: String?
+): ResponseEntity<List<Article>> {
+    // 동일 파라미터 반복 = OR 조건
+    // GET /articles?status=PUBLISHED&status=DRAFT&authorId=123
+    // → (status=PUBLISHED OR status=DRAFT) AND authorId=123
+    val articles = articleService.findByStatusesAndAuthor(
+        statuses = status ?: emptyList(),  // OR 조건
+        authorId = authorId                // AND 조건
+    )
+    return ResponseEntity.ok(articles)
+}
+```
+
+- 검증 포인트: Writing 모드에 OR 조건 규칙 없음(MISSING), Review 체크리스트의 "Repeated same parameter treated as OR condition" 항목
+
+---
+
+### TC-5-09: orderBy 파라미터 형식
+
+- 규칙: "⚠️ **권장**: 정렬은 `orderBy` 파라미터를 사용하며, 필드명과 방향을 조합하여 표현한다."
+- 규범 수준: ⚠️권장
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```
+GET /articles?sort=created_at&direction=desc
+GET /articles?sortBy=createdAt&sortDir=desc
+GET /articles?sort=-createdAt
+GET /articles?sort[0][field]=createdAt&sort[0][dir]=desc
+```
+
+✅ Good:
+```
+GET /articles?orderBy=createdAt:desc
+GET /articles?orderBy=title:asc
+GET /articles?orderBy=createdAt:desc,title:asc
+```
+
+- 검증 포인트: Writing 모드의 Collection/Pagination Pattern에 `orderBy=createdAt:desc,title:asc` 예시, Review 체크리스트의 "Query parameters are camelCase (pageSize, pageToken, orderBy)" 항목에서 orderBy 파라미터명 확인
+
+---
+
+### TC-5-10: API 버전 URL 경로 포함 금지
+
+- 규칙: "❌ **금지**: API 버전을 URL 경로에 포함하지 않는다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: COVERED
+
+❌ Bad:
+```kotlin
+@RestController
+@RequestMapping("/v1/articles")
+class ArticleV1Controller {
+
+    @GetMapping
+    fun getArticles(): ResponseEntity<List<Article>> {
+        return ResponseEntity.ok(articleService.findAll())
+    }
+}
+
+@RestController
+@RequestMapping("/v2/articles")
+class ArticleV2Controller {
+
+    @GetMapping
+    fun getArticles(): ResponseEntity<List<ArticleV2>> {
+        return ResponseEntity.ok(articleService.findAllV2())
+    }
+}
+```
+
+✅ Good:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController {
+
+    @GetMapping
+    fun getArticles(
+        @RequestHeader("X-API-Version", required = false) apiVersion: String?
+    ): ResponseEntity<List<Article>> {
+        val version = apiVersion ?: "2024-01-20"
+        val articles = articleService.getArticles(version)
+        return ResponseEntity.ok()
+            .header("X-API-Version", version)
+            .body(articles)
+    }
+}
+```
+
+- 검증 포인트: Writing 모드에 URL 경로 버전 금지 규칙 명시 없음(MISSING), Review 체크리스트의 "No version in URL path (`/v1/`, `/v2/`, etc.)" 및 "API version delivered via `X-API-Version` header, not URL path" 항목
+
+---
+
+### TC-5-11: X-API-Version 헤더 ISO 8601 날짜 형식
+
+- 규칙: "✅ **필수**: `X-API-Version` 헤더에 ISO 8601 (`YYYY-MM-DD`) 형식의 날짜로 버전을 지정한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```
+# 숫자 버전 — 금지
+X-API-Version: 1
+X-API-Version: 2.0
+X-API-Version: v3
+
+# 비표준 날짜 형식 — 금지
+X-API-Version: 20240120
+X-API-Version: Jan 20, 2024
+X-API-Version: 2024/01/20
+```
+
+✅ Good:
+```
+X-API-Version: 2024-01-20
+X-API-Version: 2025-06-15
+```
+
+```kotlin
+@GetMapping("/articles")
+fun getArticles(
+    @RequestHeader("X-API-Version", required = false) apiVersion: String?
+): ResponseEntity<List<Article>> {
+    val version = apiVersion ?: "2024-01-20"  // ISO 8601 날짜 형식
+    val articles = articleService.getArticles(version)
+    return ResponseEntity.ok()
+        .header("X-API-Version", version)
+        .body(articles)
+}
+```
+
+- 검증 포인트: Writing 모드의 API Version Header Handling 코드에서 `"2024-01-20"` 형식 사용, Review 체크리스트의 "X-API-Version value uses ISO 8601 date format (YYYY-MM-DD)" 항목
+
+---
+
+### TC-5-12: Deprecation/Sunset/Link 응답 헤더
+
+- 규칙: "✅ **필수**: Deprecated된 API에는 응답 헤더로 알림을 제공한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: MISSING
+
+❌ Bad:
+```kotlin
+@RestController
+@RequestMapping("/users/posts")
+class DeprecatedPostController {
+
+    // Deprecated 엔드포인트이지만 아무런 헤더 없이 응답 — 금지
+    @GetMapping
+    fun getPosts(): ResponseEntity<List<Post>> {
+        return ResponseEntity.ok(postService.findAll())
+    }
+}
+```
+
+✅ Good:
+```kotlin
+@RestController
+@RequestMapping("/users/posts")
+class DeprecatedPostController {
+
+    @GetMapping
+    fun getPosts(): ResponseEntity<List<Post>> {
+        val posts = postService.findAll()
+        val headers = HttpHeaders()
+        addDeprecationHeaders(
+            headers,
+            sunsetDate = "Sat, 01 Jan 2025 00:00:00 GMT",
+            successorUrl = "https://api.example.com/users/articles"
+        )
+        return ResponseEntity.ok().headers(headers).body(posts)
+    }
+}
+
+fun addDeprecationHeaders(headers: HttpHeaders, sunsetDate: String, successorUrl: String) {
+    headers.set("Deprecation", "true")
+    headers.set("Sunset", sunsetDate)
+    headers.set("Link", "<$successorUrl>; rel=\"successor-version\"")
+}
+
+// 응답:
+// HTTP/1.1 200 OK
+// Deprecation: true
+// Sunset: Sat, 01 Jan 2025 00:00:00 GMT
+// Link: <https://api.example.com/users/articles>; rel="successor-version"
+```
+
+- 검증 포인트: Writing 모드의 Deprecation Header Handling 코드에서 Deprecation/Sunset/Link 헤더 설정 예시(COVERED), Review 체크리스트에 Deprecation 헤더 검증 항목 없음(MISSING)
+
+---
+
+### TC-5-13: Deprecation 헤더 형식 검증
+
+- 규칙: "✅ **필수**: Deprecated된 API에는 응답 헤더로 알림을 제공한다." (헤더 형식 검증)
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: MISSING
+
+❌ Bad:
+```
+# Deprecation 헤더 형식 오류
+Deprecation: yes
+Sunset: 2025-01-01
+Link: https://api.example.com/users/articles
+```
+
+✅ Good:
+```
+Deprecation: true
+Sunset: Sat, 01 Jan 2025 00:00:00 GMT
+Link: <https://api.example.com/users/articles>; rel="successor-version"
+```
+
+- 검증 포인트: Writing 모드의 `addDeprecationHeaders` 코드에서 `"Deprecation"` 값은 `"true"`, `"Sunset"` 값은 HTTP-date 형식, `"Link"` 값은 `<URL>; rel="successor-version"` 형식. Review 모드에 Deprecation 헤더 형식 체크 없음(MISSING)
+
+---
+
+### TC-5-14: X-RateLimit-* 헤더
+
+- 규칙: "✅ **필수**: 속도 제한이 적용되는 모든 응답에 다음 헤더를 포함한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@GetMapping("/articles")
+fun getArticles(): ResponseEntity<List<Article>> {
+    // 속도 제한 헤더 없이 응답 — 누락
+    return ResponseEntity.ok(articleService.findAll())
+}
+```
+
+✅ Good:
+```kotlin
+@GetMapping("/articles")
+fun getArticles(): ResponseEntity<List<Article>> {
+    val articles = articleService.findAll()
+    val headers = HttpHeaders()
+    addRateLimitHeaders(headers, limit = 100, remaining = 99, resetAt = Instant.now().plusSeconds(3600))
+    return ResponseEntity.ok().headers(headers).body(articles)
+}
+
+fun addRateLimitHeaders(headers: HttpHeaders, limit: Int, remaining: Int, resetAt: Instant) {
+    val resetUnix = resetAt.epochSecond
+    val resetDelta = resetAt.epochSecond - Instant.now().epochSecond
+
+    // Legacy headers
+    headers.set("X-RateLimit-Limit", limit.toString())
+    headers.set("X-RateLimit-Remaining", remaining.toString())
+    headers.set("X-RateLimit-Reset", resetUnix.toString())
+
+    // IETF standard headers
+    headers.set("RateLimit", "limit=$limit, remaining=$remaining, reset=$resetDelta")
+    headers.set("RateLimit-Policy", "$limit;w=3600")
+}
+
+// 응답:
+// HTTP/1.1 200 OK
+// X-RateLimit-Limit: 100
+// X-RateLimit-Remaining: 99
+// X-RateLimit-Reset: 1742342450
+// RateLimit: limit=100, remaining=99, reset=50
+// RateLimit-Policy: 100;w=3600
+```
+
+- 검증 포인트: Writing 모드의 Rate Limiting 섹션에 `addRateLimitHeaders` 함수 코드 예시, Review 체크리스트의 "Rate limit response includes X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset headers" 및 "Rate limit response includes RateLimit, RateLimit-Policy headers" 항목
+
+---
+
+### TC-5-15: 429 Retry-After + Problem Details
+
+- 규칙: "✅ **필수**: 429 응답에 `Retry-After` 헤더를 포함한다." / "✅ **필수**: 429 응답 본문은 RFC 7807 Problem Details 구조를 사용한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+// Retry-After 헤더 없음 + 비표준 에러 본문
+fun rateLimitExceeded(): ResponseEntity<Map<String, Any>> {
+    return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(mapOf(
+            "error" to "Rate limit exceeded",
+            "message" to "Too many requests. Try again later."
+        ))
+}
+```
+
+✅ Good:
+```kotlin
+fun rateLimitExceededResponse(retryAfterSeconds: Long): ResponseEntity<ProblemDetail> {
+    val headers = HttpHeaders()
+    headers.set("Retry-After", retryAfterSeconds.toString())
+    addRateLimitHeaders(headers, limit = 100, remaining = 0, resetAt = Instant.now().plusSeconds(retryAfterSeconds))
+
+    return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+        .headers(headers)
+        .contentType(MediaType.parseMediaType("application/problem+json"))
+        .body(ProblemDetail(
+            type = "https://api.example.com/errors/too-many-requests",
+            title = "Rate limit exceeded",
+            status = 429,
+            detail = "You have exceeded the allowed request limit. Please retry after $retryAfterSeconds seconds."
+        ))
+}
+
+// 응답:
+// HTTP/1.1 429 Too Many Requests
+// Content-Type: application/problem+json
+// Retry-After: 50
+// X-RateLimit-Limit: 100
+// X-RateLimit-Remaining: 0
+// X-RateLimit-Reset: 1742342450
+// RateLimit: limit=100, remaining=0, reset=50
+// RateLimit-Policy: 100;w=3600
+//
+// {
+//   "type": "https://api.example.com/errors/too-many-requests",
+//   "title": "Rate limit exceeded",
+//   "status": 429,
+//   "detail": "You have exceeded the allowed request limit. Please retry after 50 seconds."
+// }
+```
+
+- 검증 포인트: Writing 모드의 Rate Limiting 섹션에 429 응답 코드 예시(Retry-After + ProblemDetail), Review 체크리스트의 "429 response includes Retry-After header (delta-seconds format)" 및 "429 response body uses Problem Details structure" 항목
+
+---
+
+### TC-5-16: 클라이언트 429 수신 시 Retry-After 준수
+
+- 규칙: "✅ **필수**: 클라이언트는 429 응답 수신 시 `Retry-After` 헤더 값만큼 대기한 후 재시도한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+// 즉시 재시도 — 금지
+suspend fun fetchArticlesWithRetry(): List<Article> {
+    repeat(10) {
+        val response = httpClient.get("/articles")
+        if (response.status == HttpStatusCode.TooManyRequests) {
+            // Retry-After 무시하고 즉시 재시도
+            continue
+        }
+        return response.body()
+    }
+    throw RuntimeException("Max retries exceeded")
+}
+
+// 고정 간격 재시도 — 금지
+suspend fun fetchArticlesFixedInterval(): List<Article> {
+    repeat(10) {
+        val response = httpClient.get("/articles")
+        if (response.status == HttpStatusCode.TooManyRequests) {
+            delay(1000)  // Retry-After 무시하고 고정 1초 대기
+            continue
+        }
+        return response.body()
+    }
+    throw RuntimeException("Max retries exceeded")
+}
+```
+
+✅ Good:
+```kotlin
+suspend fun fetchArticlesWithRetry(maxRetries: Int = 3): List<Article> {
+    var attempt = 0
+    while (attempt < maxRetries) {
+        val response = httpClient.get("/articles")
+
+        if (response.status == HttpStatusCode.TooManyRequests) {
+            val retryAfter = response.headers["Retry-After"]?.toLongOrNull()
+            if (retryAfter != null) {
+                // Retry-After 헤더 값만큼 대기
+                delay(retryAfter * 1000)
+            } else {
+                // Retry-After 없으면 지수 백오프 + 지터
+                val backoff = minOf(60.0, 1.0 * 2.0.pow(attempt)).toLong()
+                val jitter = Random.nextDouble(0.0, 1.0).toLong()
+                delay((backoff + jitter) * 1000)
+            }
+            attempt++
+            continue
+        }
+
+        return response.body()
+    }
+    throw RuntimeException("Max retries ($maxRetries) exceeded")
+}
+```
+
+- 검증 포인트: Writing 모드의 "Client retry" 섹션에 "On 429, wait for the Retry-After header value before retrying" 명시 및 지수 백오프 공식, Review 체크리스트의 "Client retry respects Retry-After value (immediate retry forbidden)" 항목
+
+---
+
+### TC-5-17: 장기 실행 작업 201 + 도메인 리소스
+
+- 규칙: "✅ **필수**: 장기 실행 작업 요청 시 도메인 리소스를 즉시 생성하고 `201 Created` + `Location` 헤더를 반환한다." / "✅ **필수**: 도메인 리소스에 `status` 필드를 포함하여 처리 상태를 표현한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+@PostMapping("/reports")
+fun generateReport(@RequestBody request: GenerateReportRequest): ResponseEntity<Report> {
+    // 작업 완료까지 동기적으로 대기 — 타임아웃 위험
+    val report = reportService.generateSync(request)  // 수 분 소요 가능
+    return ResponseEntity.ok(report)
+}
+
+// 또는 202 Accepted + 별도 operations 리소스 — 금지
+@PostMapping("/reports")
+fun generateReport(@RequestBody request: GenerateReportRequest): ResponseEntity<Map<String, String>> {
+    val operationId = reportService.startAsync(request)
+    return ResponseEntity.accepted().body(mapOf("operationId" to operationId))
+    // GET /operations/{operationId} 로 조회 — 범용 operations 패턴
+}
+```
+
+✅ Good:
+```kotlin
+@PostMapping("/reports")
+fun generateReport(@RequestBody request: GenerateReportRequest): ResponseEntity<Report> {
+    // 도메인 리소스를 즉시 생성하고 비동기 처리 시작
+    val report = reportService.createAndStartAsync(request)
+    val location = URI.create("/reports/${report.id}")
+    return ResponseEntity.created(location).body(report)
+}
+
+// 응답:
+// HTTP/1.1 201 Created
+// Location: /reports/123
+//
+// {
+//   "id": "123",
+//   "status": "PENDING",
+//   "createdAt": "2024-01-20T10:00:00Z",
+//   "updatedAt": "2024-01-20T10:00:00Z"
+// }
+
+// 폴링:
+// GET /reports/123 → { "id": "123", "status": "IN_PROGRESS", ... }
+// GET /reports/123 → { "id": "123", "status": "COMPLETED", "downloadUrl": "...", ... }
+// GET /reports/123 → { "id": "123", "status": "FAILED", "error": { "type": "...", ... } }
+```
+
+- 검증 포인트: Writing 모드의 HTTP Method to Status Code Mapping 표 "POST (long-running) | 201 Created + Location header | Long-running task — domain resource created immediately with status field", Review 체크리스트의 "Long-running task returns 201 Created + Location header" 및 "Domain resource has status field" 항목
+
+---
+
+### TC-5-18: 범용 /operations 리소스 금지
+
+- 규칙: "❌ **금지**: 별도의 범용 `/operations` 리소스를 사용하지 않는다. 도메인 리소스 자체에서 상태를 추적한다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: COVERED
+
+❌ Bad:
+```kotlin
+// 범용 operations 엔드포인트 — 금지
+@RestController
+@RequestMapping("/operations")
+class OperationController {
+
+    @GetMapping("/{operationId}")
+    fun getOperation(@PathVariable operationId: String): ResponseEntity<Operation> {
+        val operation = operationService.findById(operationId)
+        return ResponseEntity.ok(operation)
+    }
+}
+
+data class Operation(
+    val id: String,
+    val type: String,           // "REPORT_GENERATION", "DATA_IMPORT"
+    val status: String,         // "PENDING", "IN_PROGRESS", "COMPLETED"
+    val resourceId: String?,    // 생성된 리소스 ID
+    val createdAt: Instant
+)
+
+// 클라이언트:
+// POST /reports → 202 Accepted { "operationId": "op-123" }
+// GET /operations/op-123 → { "status": "COMPLETED", "resourceId": "report-456" }
+// GET /reports/report-456 → { ... }
+```
+
+✅ Good:
+```kotlin
+// 도메인 리소스 자체에서 상태 추적
+@RestController
+@RequestMapping("/reports")
+class ReportController {
+
+    @PostMapping
+    fun generateReport(@RequestBody request: GenerateReportRequest): ResponseEntity<Report> {
+        val report = reportService.createAndStartAsync(request)
+        val location = URI.create("/reports/${report.id}")
+        return ResponseEntity.created(location).body(report)
+    }
+
+    @GetMapping("/{id}")
+    fun getReport(@PathVariable id: String): ResponseEntity<Report> {
+        val report = reportService.findById(id)
+        return ResponseEntity.ok(report)
+    }
+}
+
+data class Report(
+    val id: String,
+    val status: ReportStatus,   // PENDING, IN_PROGRESS, COMPLETED, FAILED
+    val downloadUrl: String? = null,
+    val error: ProblemDetail? = null,
+    val createdAt: Instant,
+    val updatedAt: Instant
+)
+
+// 클라이언트:
+// POST /reports → 201 Created { "id": "123", "status": "PENDING" }
+// GET /reports/123 → { "id": "123", "status": "COMPLETED", "downloadUrl": "..." }
+```
+
+- 검증 포인트: Writing 모드에 `/operations` 금지 규칙 명시 없음(MISSING), Review 체크리스트의 "No generic `/operations` endpoint — status tracked on the domain resource itself" 항목
+
+---
+
+## 섹션 6: 인증 및 보안
+
+### TC-6-01: 인증 토큰 Authorization 헤더 사용
+
+- 규칙: "✅ **필수**: 인증 토큰은 `Authorization` 헤더를 사용한다. 쿼리 파라미터나 요청 본문에 포함하지 않는다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+// 쿼리 파라미터로 토큰 전달 — 금지
+@GetMapping("/articles")
+fun getArticles(@RequestParam token: String): ResponseEntity<List<Article>> {
+    authService.verify(token)
+    return ResponseEntity.ok(articleService.findAll())
+}
+
+// GET /articles?token=eyJhbGciOiJSUzI1NiJ9...
+
+// 요청 본문에 토큰 포함 — 금지
+@PostMapping("/articles:search")
+fun searchArticles(@RequestBody request: SearchRequest): ResponseEntity<List<Article>> {
+    authService.verify(request.token)
+    return ResponseEntity.ok(articleService.search(request))
+}
+```
+
+✅ Good:
+```kotlin
+@RestController
+@RequestMapping("/articles")
+class ArticleController(
+    private val articleService: ArticleService
+) {
+
+    @GetMapping
+    fun getArticles(): ResponseEntity<List<Article>> {
+        // Authorization 헤더는 Spring Security 필터에서 처리
+        return ResponseEntity.ok(articleService.findAll())
+    }
+}
+
+// 요청:
+// GET /articles
+// Authorization: Bearer eyJhbGciOiJSUzI1NiJ9...
+```
+
+- 검증 포인트: Writing 모드의 Authentication 섹션에 "Auth header (Required: use Authorization header)" 및 `Authorization: Bearer ...` / `Authorization: ApiKey ...` 예시, Review 체크리스트의 "Auth token delivered via Authorization header (query parameter forbidden)" 항목
+
+---
+
+### TC-6-02: API Key 쿼리 파라미터 전달 금지
+
+- 규칙: "❌ **금지**: API Key를 쿼리 파라미터로 전달하지 않는다. URL은 서버 로그에 기록될 수 있다."
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: MISSING / Review: COVERED
+
+❌ Bad:
+```
+GET /articles?apiKey=secret-key-12345
+GET /articles?api_key=secret-key-12345
+GET /articles?key=secret-key-12345
+```
+
+```kotlin
+@GetMapping("/articles")
+fun getArticles(@RequestParam apiKey: String): ResponseEntity<List<Article>> {
+    // URL 쿼리 파라미터로 API Key 수신 — 금지
+    // 서버 로그, 브라우저 히스토리, 프록시 로그 등에 노출 위험
+    apiKeyService.verify(apiKey)
+    return ResponseEntity.ok(articleService.findAll())
+}
+```
+
+✅ Good:
+```
+GET /articles
+Authorization: ApiKey secret-key-12345
+```
+
+```kotlin
+@GetMapping("/articles")
+fun getArticles(
+    @RequestHeader("Authorization") authorization: String
+): ResponseEntity<List<Article>> {
+    // Authorization 헤더에서 API Key 추출
+    val apiKey = authorization.removePrefix("ApiKey ").trim()
+    apiKeyService.verify(apiKey)
+    return ResponseEntity.ok(articleService.findAll())
+}
+```
+
+- 검증 포인트: Writing 모드에 API Key 쿼리 파라미터 전달 금지 명시 없음(MISSING), Review 체크리스트의 "Auth token delivered via Authorization header (query parameter forbidden)" 항목
+
+---
+
+### TC-6-03: 401 응답에 WWW-Authenticate 헤더
+
+- 규칙: "✅ **필수**: 401 응답에는 `WWW-Authenticate` 헤더를 포함한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+// WWW-Authenticate 헤더 없이 401 반환 — 금지
+@ExceptionHandler(AuthenticationException::class)
+fun handleAuthError(ex: AuthenticationException, request: HttpServletRequest): ResponseEntity<ProblemDetail> {
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+        .contentType(MediaType.parseMediaType("application/problem+json"))
+        .body(ProblemDetail(
+            type = "https://api.example.com/errors/unauthorized",
+            title = "Authentication required",
+            status = 401,
+            detail = ex.message ?: "Authentication is required.",
+            instance = request.requestURI
+        ))
+}
+```
+
+✅ Good:
+```kotlin
+@ExceptionHandler(AuthenticationException::class)
+fun handleAuthError(ex: AuthenticationException, request: HttpServletRequest): ResponseEntity<ProblemDetail> {
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+        .header("WWW-Authenticate", "Bearer realm=\"api\", error=\"token_expired\"")
+        .contentType(MediaType.parseMediaType("application/problem+json"))
+        .body(ProblemDetail(
+            type = "https://api.example.com/errors/unauthorized",
+            title = "Authentication required",
+            status = 401,
+            detail = ex.message ?: "The access token has expired.",
+            instance = request.requestURI
+        ))
+}
+```
+
+- 검증 포인트: Writing 모드의 Authentication Handling 코드에서 `.header("WWW-Authenticate", "Bearer realm=\"api\", error=\"token_expired\"")` 예시, Review 체크리스트의 "401 response includes WWW-Authenticate header" 항목
+
+---
+
+### TC-6-04: 401 vs 403 구분
+
+- 규칙: "✅ **필수**: 401(인증 실패) / 403(인가 실패)을 정확히 구분한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+// 인증 실패와 인가 실패를 모두 403으로 반환 — 잘못된 구분
+@ExceptionHandler(SecurityException::class)
+fun handleSecurity(ex: SecurityException): ResponseEntity<ProblemDetail> {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .contentType(MediaType.parseMediaType("application/problem+json"))
+        .body(ProblemDetail(
+            type = "https://api.example.com/errors/forbidden",
+            title = "Access denied",
+            status = 403,
+            detail = ex.message ?: "Access denied."
+        ))
+}
+```
+
+✅ Good:
+```kotlin
+// 401 — 인증 실패 (토큰 없음, 만료, 형식 오류)
+@ExceptionHandler(AuthenticationException::class)
+fun handleAuthenticationFailure(
+    ex: AuthenticationException,
+    request: HttpServletRequest
+): ResponseEntity<ProblemDetail> {
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+        .header("WWW-Authenticate", "Bearer realm=\"api\", error=\"token_expired\"")
+        .contentType(MediaType.parseMediaType("application/problem+json"))
+        .body(ProblemDetail(
+            type = "https://api.example.com/errors/unauthorized",
+            title = "Authentication required",
+            status = 401,
+            detail = "The access token has expired.",
+            instance = request.requestURI
+        ))
+}
+
+// 403 — 인가 실패 (인증은 됐지만 권한 없음)
+@ExceptionHandler(AccessDeniedException::class)
+fun handleAuthorizationFailure(
+    ex: AccessDeniedException,
+    request: HttpServletRequest
+): ResponseEntity<ProblemDetail> {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .contentType(MediaType.parseMediaType("application/problem+json"))
+        .body(ProblemDetail(
+            type = "https://api.example.com/errors/forbidden",
+            title = "Access denied",
+            status = 403,
+            detail = "You do not have permission to access this resource.",
+            instance = request.requestURI
+        ))
+}
+```
+
+- 검증 포인트: Writing 모드의 Authentication 섹션 401 vs 403 구분 표 및 코드 예시, Review 체크리스트의 "401 (authentication failure) / 403 (authorization failure) properly distinguished" 항목
+
+---
+
+### TC-6-05: Idempotency-Key 지원
+
+- 규칙: "✅ **필수**: 중복 실행 위험이 있는 POST 엔드포인트는 `Idempotency-Key` 헤더를 지원한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: COVERED / Review: COVERED
+
+❌ Bad:
+```kotlin
+// 결제 API에 Idempotency-Key 미지원 — 금지
+@PostMapping("/payments")
+fun createPayment(@RequestBody request: CreatePaymentRequest): ResponseEntity<Payment> {
+    // 네트워크 오류 후 클라이언트가 재시도하면 중복 결제 발생 가능
+    val payment = paymentService.create(request)
+    val location = URI.create("/payments/${payment.id}")
+    return ResponseEntity.created(location).body(payment)
+}
+```
+
+✅ Good:
+```kotlin
+@PostMapping("/payments")
+fun createPayment(
+    @RequestHeader("Idempotency-Key") idempotencyKey: String?,
+    @RequestBody request: CreatePaymentRequest
+): ResponseEntity<Payment> {
+    // 기존 결과 확인
+    idempotencyKey?.let { key ->
+        idempotencyStore.find(key)?.let { cached ->
+            return ResponseEntity.status(cached.statusCode).body(cached.body)
+        }
+    }
+
+    val payment = paymentService.create(request)
+    val location = URI.create("/payments/${payment.id}")
+
+    // 결과 저장 (TTL: 24시간)
+    idempotencyKey?.let { key ->
+        idempotencyStore.save(key, statusCode = 201, body = payment, ttl = Duration.ofHours(24))
+    }
+
+    return ResponseEntity.created(location).body(payment)
+}
+
+// 요청:
+// POST /payments
+// Idempotency-Key: a8098c1a-f86e-11da-bd1a-00112444be1e
+// Content-Type: application/json
+//
+// { "amount": 50000, "currency": "KRW", "recipientId": "user-456" }
+```
+
+- 검증 포인트: Writing 모드의 Idempotency-Key Handling 코드에서 `@RequestHeader("Idempotency-Key")` 처리 및 캐시 로직, Review 체크리스트의 "Idempotency-Key supported for duplicate-risk POST operations (payments, orders, etc.)" 항목
+
+---
+
+### TC-6-06: Idempotency-Key UUID v4
+
+- 규칙: "✅ **필수**: `Idempotency-Key` 값은 클라이언트가 생성한 UUID v4를 사용한다."
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: PARTIAL / Review: MISSING
+
+❌ Bad:
+```
+# 순차적 정수 — 금지 (충돌 위험)
+Idempotency-Key: 1
+Idempotency-Key: 2
+
+# 짧은 문자열 — 금지 (충돌 위험)
+Idempotency-Key: order-123
+
+# 타임스탬프 — 금지 (충돌 위험)
+Idempotency-Key: 1705744800000
+
+# UUID v1 (MAC 주소 기반) — 부적절
+Idempotency-Key: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+```
+
+✅ Good:
+```
+# UUID v4 (랜덤 기반)
+Idempotency-Key: a8098c1a-f86e-11da-bd1a-00112444be1e
+Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000
+```
+
+```kotlin
+// 클라이언트 코드
+val idempotencyKey = UUID.randomUUID().toString()  // UUID v4 생성
+
+val response = httpClient.post("/orders") {
+    header("Idempotency-Key", idempotencyKey)
+    contentType(ContentType.Application.Json)
+    setBody(CreateOrderRequest(productId = "123", quantity = 2))
+}
+```
+
+- 검증 포인트: Writing 모드의 Idempotency-Key 코드 예시에 UUID 형태 값(`a8098c1a-f86e-11da-bd1a-00112444be1e`) 있으나 "UUID v4" 명시 없음(PARTIAL), Review 체크리스트에 UUID v4 검증 항목 없음(MISSING)

--- a/plugins/api/docs/superpowers/plans/2026-03-19-skill-performance-evaluation.md
+++ b/plugins/api/docs/superpowers/plans/2026-03-19-skill-performance-evaluation.md
@@ -1,0 +1,1279 @@
+# Skill Performance Evaluation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** RESTful API Guidelines 스킬(restful-api-guidelines.md)의 README 규칙 커버리지를 정량화하고 테스트 케이스로 검증하여 개선 보고서를 작성한다.
+
+**Architecture:** README의 모든 규칙을 추출 → 스킬과 매핑하여 커버리지 맵 작성 → 섹션별 bad/good 코드 테스트 케이스 작성 → 커버리지 수치 기반 보고서 작성 → Critical 문제 즉시 스킬에 반영.
+
+**Tech Stack:** Markdown 문서 작업. 파일 읽기/비교/작성. 자동화 테스트 없음 — 모든 검증은 README ↔ 스킬 텍스트 비교로 수행.
+
+---
+
+## 파일 구조
+
+| 파일 | 역할 |
+|------|------|
+| `docs/evaluation/coverage-map.md` | README 규칙 ↔ 스킬 커버 상태 매핑 테이블 |
+| `docs/evaluation/test-cases.md` | 섹션별 bad/good 코드 테스트 케이스 (~54개) |
+| `docs/evaluation/report.md` | 커버리지 수치, Critical/Minor 목록, 개선 권고사항 |
+| `.claude/skills/restful-api-guidelines.md` | 평가 후 Critical 문제 수정 반영 |
+
+---
+
+## 참고 파일
+
+- README: `/home/ppzxc/projects/restful-api-guidelines/README.md`
+- 스킬: `/home/ppzxc/projects/restful-api-guidelines/.claude/skills/restful-api-guidelines.md`
+- 스펙: `/home/ppzxc/projects/restful-api-guidelines/docs/superpowers/specs/2026-03-19-skill-performance-evaluation-design.md`
+
+---
+
+## 커버리지 판정 기준 (모든 태스크에서 공통 적용)
+
+| 상태 | 기준 |
+|------|------|
+| `COVERED` | 규칙의 핵심 요건이 스킬에 명시적 문장 또는 코드 예시로 표현됨 |
+| `PARTIAL` | 규칙이 언급되지만 반례(bad case), 예외 조건, 또는 적용 범위가 누락됨 (bad case는 위반 패턴이 존재하는 규칙에만 요구됨) |
+| `MISSING` | 스킬에서 해당 규칙을 찾을 수 없음 |
+
+심각도:
+- **Critical** = ✅필수 규칙이 Writing 또는 Review 모드에서 MISSING 또는 PARTIAL
+- **Minor** = ⚠️권장/❌금지 규칙 누락 또는 스킬 코드 예시 오류
+
+---
+
+## Task 1: 커버리지 맵 작성 (docs/evaluation/coverage-map.md)
+
+**Files:**
+- Read: `README.md` (규칙 추출)
+- Read: `.claude/skills/restful-api-guidelines.md` (커버 여부 확인)
+- Create: `docs/evaluation/coverage-map.md`
+
+README의 모든 ✅필수/⚠️권장/❌금지 규칙을 목록화하고 스킬의 Writing/Review 모드 각각에서 COVERED/PARTIAL/MISSING 상태를 기록한다.
+
+- [ ] **Step 1: README 섹션 2 규칙 추출 및 매핑**
+
+README 2.1~2.4(URL, HTTP 메서드, 상태코드, 쿼리파라미터, 헤더)의 모든 규칙을 추출한다.
+각 규칙을 스킬의 Code Writing Mode 및 Code Review Mode 체크리스트에서 검색하여 커버 상태를 판정한다.
+
+`docs/evaluation/coverage-map.md` 파일을 생성하고 다음 형식으로 섹션 2 규칙을 작성한다:
+
+```markdown
+# Coverage Map — RESTful API Guidelines Skill
+
+**평가 날짜:** 2026-03-19
+**README:** README.md
+**스킬:** .claude/skills/restful-api-guidelines.md
+
+---
+
+## 범례
+
+| 상태 | 의미 |
+|------|------|
+| COVERED | 규칙의 핵심 요건이 명시적 문장 또는 코드 예시로 표현됨 |
+| PARTIAL | 언급되지만 반례/예외/적용 범위 누락 |
+| MISSING | 스킬에서 찾을 수 없음 |
+
+---
+
+## 섹션 2: HTTP 기본 규칙
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
+|---|-----------|-----------|---------|--------|--------|
+| 2.1-1 | ✅필수 | URL 경로에 소문자 kebab-case 사용 | ? | ? | ? |
+| 2.1-2 | ✅필수 | 리소스 컬렉션 이름은 복수형 명사 | ? | ? | ? |
+| 2.1-3 | ❌금지 | URL에 동사 포함 금지 | ? | ? | ? |
+| 2.1-4 | ❌금지 | URL에 파일 확장자 포함 금지 | ? | ? | ? |
+| 2.1-5 | ✅필수 | URL 경로 세그먼트에 ASCII 영소문자/숫자/하이픈만 허용 | ? | ? | ? |
+| 2.1-6 | ✅필수 | 쿼리 파라미터 이름은 camelCase | ? | ? | ? |
+| 2.1-7 | ⚠️권장 | URL 2000자 이하 유지 | ? | ? | ? |
+| 2.2-1 | ✅필수 | GET 요청은 서버 상태 변경 안 함 | ? | ? | ? |
+| 2.2-2 | ✅필수 | PUT 요청은 멱등적으로 동작 | ? | ? | ? |
+| 2.2-3 | ⚠️권장 | 부분 수정에는 PUT 대신 PATCH 사용 | ? | ? | ? |
+| 2.2-4 | ❌금지 | GET/HEAD/DELETE 요청에 body 포함 금지 | ? | ? | ? |
+| 2.2-5 | ✅필수 | 표준 HTTP 상태 코드를 정확한 의미에 맞게 사용 | ? | ? | ? |
+| 2.2-6 | ✅필수 | 201 Created 응답에 Location 헤더 포함 | ? | ? | ? |
+| 2.2-7 | ❌금지 | 오류 상황에 200 OK 반환 금지 | ? | ? | ? |
+| 2.3-1 | ✅필수 | 동일 파라미터 반복으로 배열 값 전달 | ? | ? | ? |
+| 2.3-2 | ⚠️권장 | 쿼리 파라미터는 선택적으로 설계 | ? | ? | ? |
+| 2.3-3 | ⚠️권장 | 쿼리 파라미터에 민감한 정보 포함 금지 | ? | ? | ? |
+| 2.3-4 | ❌금지 | 서버 상태 변경에 쿼리 파라미터 사용 금지 | ? | ? | ? |
+| 2.4-1 | ✅필수 | 요청 본문 있을 때 Content-Type 헤더 포함 | ? | ? | ? |
+| 2.4-2 | ✅필수 | 응답 본문 있을 때 Content-Type 헤더 포함 | ? | ? | ? |
+| 2.4-3 | ⚠️권장 | 커스텀 헤더에 X- 접두사 사용 금지 (신규) | ? | ? | ? |
+| 2.4-4 | ❌금지 | 표준 HTTP 헤더 의미 재정의 금지 | ? | ? | ? |
+```
+
+`?` 값을 실제 스킬 파일을 확인하여 COVERED/PARTIAL/MISSING 중 하나로 채운다.
+
+- [ ] **Step 2: README 섹션 3 규칙 추출 및 매핑**
+
+README 3.1~3.4(리소스 스키마, 필드 변경 가능성, 생성/수정/대체, 에러 처리) 규칙을 추출하고 coverage-map.md에 추가한다.
+
+```markdown
+## 섹션 3: REST 원칙
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
+|---|-----------|-----------|---------|--------|--------|
+| 3.1-1 | ✅필수 | 모든 리소스는 고유 id 가짐 | ? | ? | ? |
+| 3.1-2 | ✅필수 | 리소스 스키마는 일관된 구조 유지 (id/createdAt/updatedAt) | ? | ? | ? |
+| 3.1-3 | ⚠️권장 | 리소스 식별자는 불투명한 문자열 | ? | ? | ? |
+| 3.1-4 | ❌금지 | 응답에 null 값 필드 포함 금지 | ? | ? | ? |
+| 3.2-1 | ✅필수 | 서버 관리 읽기 전용 필드(id/createdAt/updatedAt)를 요청 본문에 포함해도 무시 | ? | ? | ? |
+| 3.3-1 | ✅필수 | POST 생성 성공 시 201 Created + 생성된 리소스 반환 | ? | ? | ? |
+| 3.3-2 | ✅필수 | PUT은 리소스 전체 대체, 미포함 필드는 기본값/null | ? | ? | ? |
+| 3.3-3 | ✅필수 | DELETE 성공 시 204 No Content 반환 | ? | ? | ? |
+| 3.4-1 | ✅필수 | 모든 에러 응답은 RFC 7807/9457 구조 따름 | ? | ? | ? |
+| 3.4-2 | ✅필수 | 에러 응답 Content-Type은 application/problem+json | ? | ? | ? |
+| 3.4-3 | ⚠️권장 | 유효성 검사 실패 시 모든 오류 필드 한 번에 반환 | ? | ? | ? |
+| 3.4-4 | ❌금지 | 에러 응답에 스택 트레이스/내부 정보 노출 금지 | ? | ? | ? |
+```
+
+- [ ] **Step 3: README 섹션 4 규칙 추출 및 매핑**
+
+README 4.1~4.4(필드 네이밍, 타입 시스템, 날짜/시간, Enum) 규칙을 추출하고 coverage-map.md에 추가한다.
+
+```markdown
+## 섹션 4: JSON 규칙
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
+|---|-----------|-----------|---------|--------|--------|
+| 4.1-1 | ✅필수 | JSON 필드 이름은 camelCase | ? | ? | ? |
+| 4.1-2 | ✅필수 | 필드 이름은 영소문자로 시작 | ? | ? | ? |
+| 4.1-3 | ❌금지 | 필드 이름에 약어 남용 금지 | ? | ? | ? |
+| 4.2-1 | ✅필수 | Boolean은 JSON true/false 사용 | ? | ? | ? |
+| 4.2-2 | ✅필수 | Boolean 필드 이름에 is/has/can 접두사 | ? | ? | ? |
+| 4.2-3 | ✅필수 | 숫자 값은 JSON number 타입 | ? | ? | ? |
+| 4.2-4 | ⚠️권장 | 큰 정수(2^53 초과)는 문자열로 반환 | ? | ? | ? |
+| 4.3-1 | ✅필수 | 날짜/시간은 RFC 3339 형식 문자열 | ? | ? | ? |
+| 4.3-2 | ✅필수 | 시간대가 있으면 반드시 포함, UTC는 Z | ? | ? | ? |
+| 4.3-3 | ✅필수 | 서버 응답 시간 값은 모두 UTC(Z) | ? | ? | ? |
+| 4.3-4 | ✅필수 | 클라이언트가 오프셋 포함 전송 시 서버가 UTC로 변환하여 저장 | ? | ? | ? |
+| 4.3-5 | ❌금지 | Unix timestamp를 기본 시간 형식으로 사용 금지 | ? | ? | ? |
+| 4.4-1 | ✅필수 | Enum 값은 UPPER_SNAKE_CASE 문자열 | ? | ? | ? |
+| 4.4-2 | ⚠️권장 | 클라이언트가 알 수 없는 Enum 값 수신 가능하도록 설계 | ? | ? | ? |
+| 4.4-3 | ❌금지 | Enum 값으로 숫자나 불명확한 약어 사용 금지 | ? | ? | ? |
+```
+
+- [ ] **Step 4: README 섹션 5~6 규칙 추출 및 매핑**
+
+README 5.1~5.7, 6.1~6.3 규칙을 추출하고 coverage-map.md에 추가한다.
+
+```markdown
+## 섹션 5: 공통 API 패턴
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
+|---|-----------|-----------|---------|--------|--------|
+| 5.1-1 | ✅필수 | 액션은 리소스 URL 뒤에 :action 형태 | ? | ? | ? |
+| 5.1-2 | ✅필수 | 액션 엔드포인트에 POST 메서드 사용 | ? | ? | ? |
+| 5.2-1 | ✅필수 | 컬렉션 응답 본문은 top-level JSON array | ? | ? | ? |
+| 5.2-2 | ✅필수 | 다음 페이지 없을 때 Link 헤더에서 rel="next" 제외 | ? | ? | ? |
+| 5.3-1 | ✅필수 | 동일 파라미터 반복은 OR 조건 | ? | ? | ? |
+| 5.4-1 | ❌금지 | API 버전을 URL 경로에 포함 금지 | ? | ? | ? |
+| 5.4-2 | ✅필수 | X-API-Version 헤더에 ISO 8601 날짜 형식으로 버전 지정 | ? | ? | ? |
+| 5.4-3 | ✅필수 | 동일 버전 내 하위 호환성 유지 | ? | ? | ? |
+| 5.5-1 | ✅필수 | Deprecated API에 Deprecation/Sunset/Link 응답 헤더 제공 | ? | ? | ? |
+| 5.6-1 | ✅필수 | 속도 제한 응답에 X-RateLimit-* 헤더 포함 | ? | ? | ? |
+| 5.6-2 | ✅필수 | 429 응답에 Retry-After 헤더 포함 | ? | ? | ? |
+| 5.6-3 | ✅필수 | 429 응답 본문은 RFC 7807 Problem Details 구조 | ? | ? | ? |
+| 5.6-4 | ✅필수 | 클라이언트는 429 수신 시 Retry-After 값만큼 대기 후 재시도 | ? | ? | ? |
+| 5.7-1 | ✅필수 | 장기 실행 작업 시 도메인 리소스 즉시 생성 + 201 Created + Location 헤더 | ? | ? | ? |
+| 5.7-2 | ✅필수 | 도메인 리소스에 status 필드 포함 | ? | ? | ? |
+| 5.7-3 | ❌금지 | 범용 /operations 리소스 사용 금지 | ? | ? | ? |
+
+## 섹션 6: 인증 및 보안
+
+| # | 규범 수준 | 규칙 요약 | Writing | Review | 심각도 |
+|---|-----------|-----------|---------|--------|--------|
+| 6.1-1 | ✅필수 | 인증 토큰은 Authorization 헤더 사용 | ? | ? | ? |
+| 6.1-2 | ❌금지 | API Key를 쿼리 파라미터로 전달 금지 | ? | ? | ? |
+| 6.2-1 | ✅필수 | 401 응답에 WWW-Authenticate 헤더 포함 | ? | ? | ? |
+| 6.2-2 | ✅필수 | 401(인증 실패) / 403(인가 실패) 정확히 구분 | ? | ? | ? |
+| 6.3-1 | ✅필수 | 중복 실행 위험 있는 POST에 Idempotency-Key 지원 | ? | ? | ? |
+| 6.3-2 | ✅필수 | Idempotency-Key 값은 클라이언트 생성 UUID v4 | ? | ? | ? |
+```
+
+- [ ] **Step 5: 커버리지 합계 섹션 추가**
+
+coverage-map.md 하단에 집계 섹션을 추가한다:
+
+```markdown
+---
+
+## 커버리지 합계
+
+| 모드 | COVERED | PARTIAL | MISSING | 합계 |
+|------|---------|---------|---------|------|
+| Writing | N | N | N | N |
+| Review | N | N | N | N |
+
+## Critical 규칙 목록 (즉시 수정 대상)
+
+| # | 규칙 | 모드 | 상태 |
+|---|------|------|------|
+| ... | ... | ... | ... |
+```
+
+실제 판정 결과를 채워 넣는다.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add docs/evaluation/coverage-map.md
+git commit -m "docs: add skill coverage map for restful-api-guidelines"
+```
+
+---
+
+## Task 2: 테스트 케이스 작성 — 섹션 2~4 (docs/evaluation/test-cases.md)
+
+**Files:**
+- Read: `README.md` (규칙 원문)
+- Read: `.claude/skills/restful-api-guidelines.md` (검증 포인트 확인)
+- Read: `docs/evaluation/coverage-map.md` (PARTIAL/MISSING 항목 우선 작성)
+- Create: `docs/evaluation/test-cases.md`
+
+커버리지 맵에서 PARTIAL/MISSING으로 판정된 규칙에 대한 테스트 케이스를 우선 작성한다. COVERED 규칙도 스킬의 코드 예시가 올바른지 대표 케이스를 포함한다.
+
+- [ ] **Step 1: test-cases.md 파일 생성 및 섹션 2 케이스 작성**
+
+```markdown
+# Test Cases — RESTful API Guidelines Skill
+
+**평가 날짜:** 2026-03-19
+**형식:** TC-{섹션}-{순번}: {규칙명}
+
+각 케이스는 스킬이 해당 규칙을 올바르게 처리(생성/탐지)하는지 검증한다.
+
+---
+
+## 섹션 2: HTTP 기본 규칙
+
+### TC-2-01: URL 소문자 kebab-case
+
+- 규칙: "URL 경로에는 소문자 kebab-case를 사용한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```
+GET /userProfiles
+GET /UserProfiles
+GET /user_profiles
+```
+
+✅ Good:
+```
+GET /user-profiles
+```
+
+- 검증 포인트: Review 체크리스트 "Lowercase kebab-case used in paths" / Writing 코드 예시
+
+---
+
+### TC-2-02: 리소스 컬렉션 복수형 명사
+
+- 규칙: "리소스 컬렉션 이름은 복수형 명사를 사용한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```
+GET /article
+GET /user/123/comment
+```
+
+✅ Good:
+```
+GET /articles
+GET /users/123/comments
+```
+
+- 검증 포인트: Review 체크리스트 "Resource names are plural nouns"
+
+---
+
+### TC-2-03: URL에 동사 포함 금지
+
+- 규칙: "URL에 동사를 포함하지 않는다"
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```
+POST /createUser
+GET /getArticles
+DELETE /deleteComment/123
+```
+
+✅ Good:
+```
+POST /users
+GET /articles
+DELETE /comments/123
+```
+
+- 검증 포인트: Review 체크리스트 "No verbs in paths"
+
+---
+
+### TC-2-04: URL 파일 확장자 금지
+
+- 규칙: "URL에 파일 확장자(.json, .xml)를 포함하지 않는다"
+- 규범 수준: ❌금지
+- 대상 모드: Review
+- 스킬 커버: Review: [판정]
+
+❌ Bad:
+```
+GET /articles.json
+GET /users/123.xml
+```
+
+✅ Good:
+```
+GET /articles
+Accept: application/json
+```
+
+- 검증 포인트: Review 체크리스트 "No file extensions in URLs"
+
+---
+
+### TC-2-05: URL 길이 제한
+
+- 규칙: "URL은 2000자 이하로 유지한다"
+- 규범 수준: ⚠️권장
+- 대상 모드: Review
+- 스킬 커버: Review: [판정]
+
+❌ Bad:
+```
+GET /articles?filter1=v1&filter2=v2&...&filter50=v50  (2000자 초과)
+```
+
+✅ Good:
+```
+POST /articles/search
+Content-Type: application/json
+{"filter1": "v1", "filter2": "v2", ...}
+```
+
+- 검증 포인트: Review 체크리스트에 해당 항목 있는지 확인
+
+---
+
+### TC-2-06: 201 Created + Location 헤더
+
+- 규칙: "201 Created 응답에는 Location 헤더로 생성된 리소스의 URL을 포함한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad (Kotlin):
+```kotlin
+@PostMapping
+fun createArticle(@RequestBody request: CreateArticleRequest): ResponseEntity<Article> {
+    val article = articleService.create(request)
+    return ResponseEntity.ok(article)  // 200 반환, Location 없음
+}
+```
+
+✅ Good (Kotlin):
+```kotlin
+@PostMapping
+fun createArticle(@RequestBody request: CreateArticleRequest): ResponseEntity<Article> {
+    val article = articleService.create(request)
+    val location = URI.create("/articles/${article.id}")
+    return ResponseEntity.created(location).body(article)
+}
+```
+
+- 검증 포인트: Review 체크리스트 "POST create → 201 + Location header"
+
+---
+
+### TC-2-07: GET/HEAD/DELETE에 body 포함 금지
+
+- 규칙: "GET, HEAD, DELETE 요청에 요청 본문(body)을 포함하지 않는다"
+- 규범 수준: ❌금지
+- 대상 모드: Review
+- 스킬 커버: Review: [판정]
+
+❌ Bad:
+```kotlin
+@GetMapping("/articles")
+fun getArticles(@RequestBody filter: ArticleFilter): ResponseEntity<List<Article>> { ... }
+```
+
+✅ Good:
+```kotlin
+@GetMapping("/articles")
+fun getArticles(@RequestParam status: String?): ResponseEntity<List<Article>> { ... }
+```
+
+- 검증 포인트: Review 체크리스트에 해당 항목 있는지 확인
+
+---
+
+### TC-2-08: 오류 상황에 200 OK 반환 금지
+
+- 규칙: "오류 상황에 200 OK를 반환하지 않는다"
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```kotlin
+@GetMapping("/{id}")
+fun getArticle(@PathVariable id: String): ResponseEntity<Map<String, Any>> {
+    return ResponseEntity.ok(mapOf("error" to "not found"))  // 에러인데 200
+}
+```
+
+✅ Good:
+```kotlin
+@GetMapping("/{id}")
+fun getArticle(@PathVariable id: String): ResponseEntity<Article> {
+    return ResponseEntity.notFound().build()  // 404
+}
+```
+
+- 검증 포인트: Review 체크리스트 "200 not returned for error conditions"
+
+---
+
+### TC-2-09: 서버 상태 변경에 쿼리 파라미터 사용 금지
+
+- 규칙: "서버 상태를 변경하는 작업에 쿼리 파라미터를 사용하지 않는다"
+- 규범 수준: ❌금지
+- 대상 모드: Review
+- 스킬 커버: Review: [판정]
+
+❌ Bad:
+```
+POST /articles?action=publish&id=123
+```
+
+✅ Good:
+```
+POST /articles/123:publish
+```
+
+- 검증 포인트: Review 체크리스트에 해당 항목 있는지 확인
+```
+
+- [ ] **Step 2: 섹션 3 케이스 작성**
+
+test-cases.md에 섹션 3 케이스를 추가한다:
+
+```markdown
+## 섹션 3: REST 원칙
+
+### TC-3-01: null 값 필드 응답 포함 금지
+
+- 규칙: "응답에 null 값 필드를 포함하지 않는다"
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```json
+{
+  "id": "123",
+  "title": "제목",
+  "deletedAt": null
+}
+```
+
+✅ Good:
+```json
+{
+  "id": "123",
+  "title": "제목"
+}
+```
+
+- 검증 포인트: Review 체크리스트 "Null-valued fields excluded from response"
+
+---
+
+### TC-3-02: 읽기 전용 필드 요청 본문 무시
+
+- 규칙: "서버가 관리하는 읽기 전용 필드(id, createdAt, updatedAt)를 클라이언트가 요청 본문에 포함하더라도 이를 무시한다"
+- 규범 수준: ✅필수
+- 대상 모드: Review
+- 스킬 커버: Review: [판정]
+
+❌ Bad:
+```kotlin
+@PatchMapping("/{id}")
+fun updateArticle(@PathVariable id: String, @RequestBody request: ArticleRequest): ResponseEntity<Article> {
+    // request.createdAt을 그대로 저장 — 클라이언트가 제어할 수 없어야 함
+    return ResponseEntity.ok(articleService.update(id, request))
+}
+```
+
+✅ Good:
+```kotlin
+data class UpdateArticleRequest(
+    val title: String?,
+    val content: String?
+    // id, createdAt, updatedAt은 요청 DTO에 포함하지 않음
+)
+```
+
+- 검증 포인트: Review 체크리스트에 해당 항목 있는지 확인
+
+---
+
+### TC-3-03: RFC 7807 에러 응답 구조
+
+- 규칙: "모든 에러 응답은 RFC 7807 / RFC 9457 표준을 따른다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```kotlin
+return ResponseEntity.notFound().body(mapOf("message" to "Not found"))
+// Content-Type: application/json 사용, RFC 7807 구조 아님
+```
+
+✅ Good:
+```kotlin
+return ResponseEntity.status(404)
+    .contentType(MediaType.parseMediaType("application/problem+json"))
+    .body(ProblemDetail(
+        type = "https://api.example.com/errors/resource-not-found",
+        title = "리소스를 찾을 수 없음",
+        status = 404,
+        detail = "요청한 게시글을 찾을 수 없습니다.",
+        instance = "/articles/999"
+    ))
+```
+
+- 검증 포인트: Review 체크리스트 "Error responses use RFC 7807/9457 Problem Details structure"
+
+---
+
+### TC-3-04: DELETE 성공 시 204 No Content
+
+- 규칙: "삭제 성공 시 204 No Content를 반환한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```kotlin
+@DeleteMapping("/{id}")
+fun deleteArticle(@PathVariable id: String): ResponseEntity<Map<String, String>> {
+    articleService.delete(id)
+    return ResponseEntity.ok(mapOf("message" to "deleted"))  // body 있음, 200
+}
+```
+
+✅ Good:
+```kotlin
+@DeleteMapping("/{id}")
+fun deleteArticle(@PathVariable id: String): ResponseEntity<Void> {
+    articleService.delete(id)
+    return ResponseEntity.noContent().build()
+}
+```
+
+- 검증 포인트: Review 체크리스트 "DELETE success → 204 (no body)"
+```
+
+- [ ] **Step 3: 섹션 4 케이스 작성**
+
+test-cases.md에 섹션 4 케이스를 추가한다:
+
+```markdown
+## 섹션 4: JSON 규칙
+
+### TC-4-01: JSON 필드 이름 camelCase
+
+- 규칙: "JSON 필드 이름은 camelCase를 사용한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```json
+{
+  "user_id": "123",
+  "created_at": "2024-01-20T10:00:00Z",
+  "is_active": true
+}
+```
+
+✅ Good:
+```json
+{
+  "userId": "123",
+  "createdAt": "2024-01-20T10:00:00Z",
+  "isActive": true
+}
+```
+
+- 검증 포인트: Review 체크리스트 "All fields are camelCase"
+
+---
+
+### TC-4-02: 필드명 약어 금지
+
+- 규칙: "필드 이름에 약어를 남용하지 않는다"
+- 규범 수준: ❌금지
+- 대상 모드: Review
+- 스킬 커버: Review: [판정]
+
+❌ Bad:
+```json
+{
+  "usr": "john",
+  "ts": "2024-01-20T10:00:00Z",
+  "cnt": 5
+}
+```
+
+✅ Good:
+```json
+{
+  "username": "john",
+  "timestamp": "2024-01-20T10:00:00Z",
+  "count": 5
+}
+```
+
+- 검증 포인트: Review 체크리스트에 약어 금지 항목 있는지 확인
+
+---
+
+### TC-4-03: Boolean 필드 is/has/can 접두사
+
+- 규칙: "Boolean 필드 이름은 is, has, can 등의 접두사를 사용한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```json
+{
+  "active": true,
+  "permission": false,
+  "editable": true
+}
+```
+
+✅ Good:
+```json
+{
+  "isActive": true,
+  "hasPermission": false,
+  "canEdit": true
+}
+```
+
+- 검증 포인트: Review 체크리스트 "Boolean fields use is/has/can prefix"
+
+---
+
+### TC-4-04: 큰 정수 문자열 반환
+
+- 규칙: "JavaScript의 안전한 정수 범위(2^53 - 1)를 초과하는 큰 정수는 문자열로 반환한다"
+- 규범 수준: ⚠️권장
+- 대상 모드: Review
+- 스킬 커버: Review: [판정]
+
+❌ Bad:
+```json
+{
+  "snowflakeId": 9007199254740993
+}
+```
+
+✅ Good:
+```json
+{
+  "snowflakeId": "9007199254740993"
+}
+```
+
+- 검증 포인트: Review 체크리스트에 해당 항목 있는지 확인
+
+---
+
+### TC-4-05: 날짜/시간 RFC 3339 형식 및 UTC
+
+- 규칙: "서버 응답의 모든 시간 값은 UTC(Z)로 반환한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```json
+{
+  "createdAt": 1705744800000,
+  "updatedAt": "2024-01-20 10:00:00"
+}
+```
+
+✅ Good:
+```json
+{
+  "createdAt": "2024-01-20T10:00:00Z",
+  "updatedAt": "2024-01-20T15:30:00Z"
+}
+```
+
+- 검증 포인트: Review 체크리스트 "Date/time in RFC 3339 format" / "All time values in server response are UTC (Z)"
+
+---
+
+### TC-4-06: Enum UPPER_SNAKE_CASE
+
+- 규칙: "Enum 값은 UPPER_SNAKE_CASE 문자열을 사용한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```json
+{
+  "status": 1,
+  "priority": "hi"
+}
+```
+
+✅ Good:
+```json
+{
+  "status": "PUBLISHED",
+  "priority": "HIGH"
+}
+```
+
+- 검증 포인트: Review 체크리스트 "Enum values are UPPER_SNAKE_CASE"
+```
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add docs/evaluation/test-cases.md
+git commit -m "docs: add test cases for sections 2-4 (HTTP rules, REST, JSON)"
+```
+
+---
+
+## Task 3: 테스트 케이스 작성 — 섹션 5~6 (docs/evaluation/test-cases.md 계속)
+
+**Files:**
+- Read: `README.md`
+- Read: `.claude/skills/restful-api-guidelines.md`
+- Modify: `docs/evaluation/test-cases.md`
+
+- [ ] **Step 1: 섹션 5 케이스 작성**
+
+test-cases.md에 섹션 5(공통 API 패턴) 케이스를 추가한다:
+
+```markdown
+## 섹션 5: 공통 API 패턴
+
+### TC-5-01: 액션 패턴 :action 형태
+
+- 규칙: "액션은 리소스 URL 뒤에 :action 형태로 표현한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```
+POST /articles/publish/123
+POST /publishArticle
+```
+
+✅ Good:
+```
+POST /articles/123:publish
+```
+
+- 검증 포인트: Writing 코드 예시 `@PostMapping("/{id}:publish")` / Review 체크리스트 "No verbs in paths (actions use :action pattern)"
+
+---
+
+### TC-5-02: 컬렉션 응답 top-level array
+
+- 규칙: "컬렉션 조회 응답 본문은 리소스 배열(top-level JSON array)을 반환한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```json
+{
+  "data": [
+    { "id": "1", "title": "첫 번째 글" }
+  ],
+  "total": 100
+}
+```
+
+✅ Good:
+```
+HTTP/1.1 200 OK
+X-Total-Count: 100
+
+[
+  { "id": "1", "title": "첫 번째 글" }
+]
+```
+
+- 검증 포인트: Review 체크리스트 "Collection response body is a top-level array (no envelope)"
+
+---
+
+### TC-5-03: 커서 기반 페이지네이션 파라미터
+
+- 규칙: 쿼리 파라미터는 camelCase (pageSize, pageToken, orderBy)
+- 규범 수준: ✅필수 (쿼리 파라미터 camelCase)
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```
+GET /articles?page_size=20&page_token=abc
+```
+
+✅ Good:
+```
+GET /articles?pageSize=20&pageToken=abc
+```
+
+- 검증 포인트: Review 체크리스트 "Query parameters are camelCase (pageSize, pageToken, orderBy)"
+
+---
+
+### TC-5-04: API 버전 URL 경로 포함 금지
+
+- 규칙: "API 버전을 URL 경로에 포함하지 않는다"
+- 규범 수준: ❌금지
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```
+GET /v1/articles
+GET /v2/users/123
+```
+
+✅ Good:
+```
+GET /articles
+X-API-Version: 2024-01-20
+```
+
+- 검증 포인트: Review 체크리스트 "No version in URL path (/v1/, /v2/, etc.)"
+
+---
+
+### TC-5-05: 하위 호환/비호환 변경 분류
+
+- 규칙: 하위 호환 변경(선택 필드 추가, 새 엔드포인트 추가)과 비호환 변경(필드 삭제/변경, 필수 필드 추가) 구분
+- 규범 수준: ✅필수
+- 대상 모드: Review
+- 스킬 커버: Review: [판정]
+
+❌ Bad (비호환 변경을 버전 업 없이 수행):
+```json
+// Before
+{ "id": "1", "title": "제목" }
+
+// After — title 제거 (비호환 변경), 버전 업 없이 배포
+{ "id": "1", "name": "제목" }
+```
+
+✅ Good:
+```json
+// 비호환 변경 시 새 버전 일자로 X-API-Version 업데이트
+// X-API-Version: 2024-06-01
+{ "id": "1", "name": "제목" }
+```
+
+- 검증 포인트: Review 체크리스트에 하위 호환성 분류 항목 있는지 확인
+
+---
+
+### TC-5-06: Deprecation 응답 헤더
+
+- 규칙: "Deprecated된 API에는 응답 헤더로 알림을 제공한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+// Deprecation 헤더 없음
+```
+
+✅ Good:
+```
+HTTP/1.1 200 OK
+Deprecation: true
+Sunset: Sat, 01 Jan 2025 00:00:00 GMT
+Link: <https://api.example.com/articles>; rel="successor-version"
+```
+
+- 검증 포인트: Writing 코드 예시 `addDeprecationHeaders` 함수
+
+---
+
+### TC-5-07: 429 Retry-After + Problem Details
+
+- 규칙: "429 응답에 Retry-After 헤더를 포함한다" + "429 응답 본문은 RFC 7807 Problem Details 구조"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/json
+
+{ "message": "Too many requests" }
+```
+
+✅ Good:
+```
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/problem+json
+Retry-After: 50
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1742342450
+RateLimit: limit=100, remaining=0, reset=50
+RateLimit-Policy: 100;w=3600
+
+{
+  "type": "https://api.example.com/errors/too-many-requests",
+  "title": "속도 제한 초과",
+  "status": 429,
+  "detail": "허용된 요청 한도를 초과했습니다. 50초 후에 다시 시도해 주세요."
+}
+```
+
+- 검증 포인트: Review 체크리스트 "429 response includes Retry-After header" / "429 response body uses Problem Details structure"
+
+---
+
+### TC-5-08: 장기 실행 작업 201 + 도메인 리소스 status 필드
+
+- 규칙: "장기 실행 작업 요청 시 도메인 리소스를 즉시 생성하고 201 Created + Location 헤더를 반환한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```
+POST /reports → 202 Accepted
+{ "operationId": "op-123" }  // 범용 operation 객체
+```
+
+✅ Good:
+```
+POST /reports → 201 Created
+Location: /reports/123
+{ "id": "123", "status": "PENDING" }
+```
+
+- 검증 포인트: Review 체크리스트 "Long-running task returns 201 Created + Location header" / "No generic /operations endpoint"
+```
+
+- [ ] **Step 2: 섹션 6 케이스 작성**
+
+test-cases.md에 섹션 6(인증/보안) 케이스를 추가한다:
+
+```markdown
+## 섹션 6: 인증 및 보안
+
+### TC-6-01: 인증 토큰 Authorization 헤더 사용
+
+- 규칙: "인증 토큰은 Authorization 헤더를 사용한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```
+GET /articles?token=eyJhbGci...
+GET /articles?apiKey=secret-key
+```
+
+✅ Good:
+```
+GET /articles
+Authorization: Bearer eyJhbGci...
+```
+
+- 검증 포인트: Review 체크리스트 "Auth token delivered via Authorization header (query parameter forbidden)"
+
+---
+
+### TC-6-02: API Key 쿼리 파라미터 전달 금지
+
+- 규칙: "API Key를 쿼리 파라미터로 전달하지 않는다"
+- 규범 수준: ❌금지
+- 대상 모드: Review
+- 스킬 커버: Review: [판정]
+
+❌ Bad:
+```
+GET /articles?apiKey=your-api-key-here
+```
+
+✅ Good:
+```
+GET /articles
+Authorization: ApiKey your-api-key-here
+```
+
+- 검증 포인트: Review 체크리스트에 API Key 쿼리 파라미터 금지 항목 있는지 확인
+
+---
+
+### TC-6-03: 401 응답에 WWW-Authenticate 헤더
+
+- 규칙: "401 응답에는 WWW-Authenticate 헤더를 포함한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad (Kotlin):
+```kotlin
+return ResponseEntity.status(401)
+    .contentType(MediaType.parseMediaType("application/problem+json"))
+    .body(errorBody)
+// WWW-Authenticate 헤더 누락
+```
+
+✅ Good (Kotlin):
+```kotlin
+return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+    .header("WWW-Authenticate", "Bearer realm=\"api\", error=\"token_expired\"")
+    .contentType(MediaType.parseMediaType("application/problem+json"))
+    .body(errorBody)
+```
+
+- 검증 포인트: Review 체크리스트 "401 response includes WWW-Authenticate header"
+
+---
+
+### TC-6-04: 401 vs 403 구분
+
+- 규칙: 401은 인증 실패, 403은 인가 실패
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```kotlin
+// 토큰 만료인데 403 반환
+if (token.isExpired()) return ResponseEntity.status(403).body(error)
+// 권한 없는데 401 반환
+if (!user.hasPermission()) return ResponseEntity.status(401).body(error)
+```
+
+✅ Good:
+```kotlin
+// 토큰 없음/만료 → 401
+if (token == null || token.isExpired()) return ResponseEntity.status(401)...
+// 권한 없음 → 403
+if (!user.hasPermission(resource)) return ResponseEntity.status(403)...
+```
+
+- 검증 포인트: Review 체크리스트 "401 (authentication failure) / 403 (authorization failure) properly distinguished"
+
+---
+
+### TC-6-05: Idempotency-Key 지원
+
+- 규칙: "중복 실행 위험이 있는 POST 엔드포인트는 Idempotency-Key 헤더를 지원한다"
+- 규범 수준: ✅필수
+- 대상 모드: Both
+- 스킬 커버: Writing: [판정] / Review: [판정]
+
+❌ Bad:
+```kotlin
+@PostMapping("/orders")
+fun createOrder(@RequestBody request: CreateOrderRequest): ResponseEntity<Order> {
+    val order = orderService.create(request)
+    return ResponseEntity.created(URI.create("/orders/${order.id}")).body(order)
+    // Idempotency-Key 미지원 — 네트워크 오류 시 중복 주문 가능
+}
+```
+
+✅ Good:
+```kotlin
+@PostMapping("/orders")
+fun createOrder(
+    @RequestHeader("Idempotency-Key") idempotencyKey: String?,
+    @RequestBody request: CreateOrderRequest
+): ResponseEntity<Order> {
+    idempotencyKey?.let { key ->
+        idempotencyStore.find(key)?.let { return ResponseEntity.status(it.statusCode).body(it.body) }
+    }
+    val order = orderService.create(request)
+    idempotencyKey?.let { idempotencyStore.save(it, 201, order, Duration.ofHours(24)) }
+    return ResponseEntity.created(URI.create("/orders/${order.id}")).body(order)
+}
+```
+
+- 검증 포인트: Review 체크리스트 "Idempotency-Key supported for duplicate-risk POST operations"
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/evaluation/test-cases.md
+git commit -m "docs: add test cases for sections 5-6 (API patterns, auth/security)"
+```
+
+---
+
+## Task 4: 평가 보고서 작성 (docs/evaluation/report.md)
+
+**Files:**
+- Read: `docs/evaluation/coverage-map.md` (판정 결과)
+- Read: `docs/evaluation/test-cases.md` (스킬 커버 상태)
+- Create: `docs/evaluation/report.md`
+
+coverage-map.md와 test-cases.md에서 판정한 COVERED/PARTIAL/MISSING 결과를 집계하여 보고서를 작성한다.
+
+- [ ] **Step 1: 커버리지 수치 집계**
+
+coverage-map.md의 모든 규칙을 모드별로 집계한다:
+- Writing 모드: COVERED/PARTIAL/MISSING 개수
+- Review 모드: COVERED/PARTIAL/MISSING 개수
+
+- [ ] **Step 2: report.md 작성**
+
+```markdown
+# Skill 성능 평가 보고서
+
+**평가 날짜:** 2026-03-19
+**평가 대상:** `.claude/skills/restful-api-guidelines.md`
+**기준 문서:** `README.md`
+
+---
+
+## 커버리지 요약
+
+| 모드 | COVERED | PARTIAL | MISSING | 합계 | 커버율 |
+|------|---------|---------|---------|------|--------|
+| Writing | N | N | N | N | N% |
+| Review | N | N | N | N | N% |
+
+---
+
+## Critical 문제 (즉시 수정)
+
+> ✅필수 규칙이 MISSING 또는 PARTIAL인 항목
+
+| # | 규칙 ID | 규칙 요약 | 모드 | 상태 | 문제 설명 |
+|---|---------|-----------|------|------|-----------|
+| 1 | ... | ... | ... | ... | ... |
+
+---
+
+## Minor 문제 (단계적 수정)
+
+> ⚠️권장/❌금지 규칙 누락 또는 코드 예시 오류
+
+| # | 규칙 ID | 규칙 요약 | 모드 | 상태 | 문제 설명 |
+|---|---------|-----------|------|------|-----------|
+| 1 | ... | ... | ... | ... | ... |
+
+---
+
+## 개선 권고사항
+
+### 즉시 수정 (Critical)
+
+각 Critical 항목에 대해 스킬에 추가해야 할 내용을 구체적으로 기술한다.
+
+### 다음 단계 (Minor)
+
+Minor 항목을 우선순위 순으로 정렬하여 제시한다.
+
+---
+
+## 다음 단계
+
+- [ ] Critical 문제 스킬에 반영 (Task 5)
+- [ ] 스킬 변경 후 동일 테스트 케이스로 회귀 검증
+- [ ] report.md 커버리지 수치 업데이트
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/evaluation/report.md
+git commit -m "docs: add skill performance evaluation report"
+```
+
+---
+
+## Task 5: Critical 문제 스킬에 반영
+
+**Files:**
+- Read: `docs/evaluation/report.md` (Critical 목록)
+- Read: `.claude/skills/restful-api-guidelines.md`
+- Modify: `.claude/skills/restful-api-guidelines.md`
+
+report.md의 Critical 문제 목록을 하나씩 스킬 파일에 반영한다. 각 수정 후 해당 테스트 케이스를 다시 확인하여 해결됐는지 검증한다.
+
+- [ ] **Step 1: Critical 문제별 스킬 수정**
+
+report.md의 Critical 목록을 순서대로 처리한다:
+- Code Writing Mode에 누락된 규칙 → 해당 섹션에 설명 또는 코드 예시 추가
+- Code Review Mode 체크리스트에 누락된 항목 → 적절한 카테고리 아래에 체크리스트 항목 추가
+
+각 수정 후 해당 테스트 케이스의 "검증 포인트"를 스킬에서 다시 검색하여 커버 여부를 확인한다.
+
+- [ ] **Step 2: 회귀 검증**
+
+수정된 스킬을 기준으로 Critical 문제로 분류된 모든 테스트 케이스를 재검토한다:
+- 스킬 Writing Mode: 각 테스트 케이스의 ✅ Good 코드가 스킬 예시와 일치하거나 가이드라인에 따라 생성 가능한지 확인
+- 스킬 Review Mode: 각 테스트 케이스의 ❌ Bad 코드가 체크리스트 항목으로 탐지 가능한지 확인
+
+- [ ] **Step 3: report.md 커버리지 수치 업데이트**
+
+스킬 수정 후 변경된 COVERED/PARTIAL/MISSING 항목을 coverage-map.md와 report.md에 반영한다.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add .claude/skills/restful-api-guidelines.md docs/evaluation/coverage-map.md docs/evaluation/report.md
+git commit -m "fix: apply critical skill improvements from performance evaluation"
+```
+
+---
+
+## 검증 요약
+
+각 Task 완료 시 확인 사항:
+
+| Task | 완료 기준 |
+|------|-----------|
+| Task 1 | coverage-map.md에 모든 규칙의 COVERED/PARTIAL/MISSING 상태가 채워짐 |
+| Task 2 | 섹션 2~4의 모든 테스트 케이스에 스킬 커버 상태가 기재됨 |
+| Task 3 | 섹션 5~6의 모든 테스트 케이스에 스킬 커버 상태가 기재됨 |
+| Task 4 | report.md에 커버리지 수치, Critical/Minor 목록, 개선 권고사항이 완성됨 |
+| Task 5 | Critical 문제가 스킬에 반영되고 회귀 검증 완료, report.md 수치 업데이트됨 |

--- a/plugins/api/docs/superpowers/specs/2026-03-19-skill-performance-evaluation-design.md
+++ b/plugins/api/docs/superpowers/specs/2026-03-19-skill-performance-evaluation-design.md
@@ -1,0 +1,153 @@
+# RESTful API Guidelines Skill 성능 평가 설계
+
+**날짜:** 2026-03-19
+**목적:** Claude Code skill(restful-api-guidelines.md)이 README 가이드라인을 얼마나 잘 커버하는지 평가하고, 개선 우선순위를 도출한다.
+
+---
+
+## 배경
+
+`/home/ppzxc/projects/restful-api-guidelines/.claude/skills/restful-api-guidelines.md` 스킬은 Claude Code가 API 코드를 작성하거나 리뷰할 때 자동으로 활성화된다. 이 스킬에는 두 가지 모드가 있다:
+
+- **Code Writing Mode** — API 코드를 생성할 때 따라야 할 규칙 및 코드 예시
+- **Code Review Mode** — 기존 코드를 리뷰할 때 사용하는 체크리스트 및 위반 보고 형식
+
+이 두 모드가 `README.md`의 모든 규칙을 올바르게 반영하는지 체계적으로 평가한다.
+
+### 사전 파악된 주요 누락 후보
+
+스펙 작성 시점에 파악된 잠재적 누락 항목 (커버리지 맵에서 확인 필요):
+
+- README 2.1: URL 길이 제한 (2000자 이하)
+- README 2.3: 상태 변경 작업에 쿼리 파라미터 사용 금지
+- README 3.2: 요청 본문의 읽기 전용 필드 무시 규칙
+- README 4.1: 필드명 약어 금지 규칙
+- README 4.2: 큰 정수(2^53 초과) 문자열 반환
+- README 5.4: 하위 호환/비호환 변경 분류 기준
+- README 6.1: API Key를 쿼리 파라미터로 전달 금지
+
+---
+
+## 목표
+
+1. README ↔ 스킬 간 규칙 커버리지를 정량화한다.
+2. 테스트 케이스(bad/good 코드 쌍)로 스킬의 탐지/생성 능력을 검증한다.
+3. Code Writing Mode와 Code Review Mode를 각각 평가한다.
+4. 문제를 Critical/Minor로 분류하고 개선 권고사항을 제시한다.
+
+---
+
+## 산출물
+
+| 파일 | 설명 |
+|------|------|
+| `docs/evaluation/coverage-map.md` | README 규칙 ↔ 스킬 커버 여부 매핑 테이블 |
+| `docs/evaluation/test-cases.md` | 섹션별 bad/good 코드 테스트 케이스 (~50개) |
+| `docs/evaluation/report.md` | 커버리지 수치, Critical/Minor 문제 목록, 개선 권고사항 |
+
+---
+
+## 커버리지 매핑 방법론
+
+### 규범 수준 분류
+
+| 기호 | 수준 |
+|------|------|
+| ✅ 필수 | MUST / DO |
+| ⚠️ 권장 | SHOULD / MAY |
+| ❌ 금지 | MUST NOT / DO NOT |
+
+### 스킬 커버 상태 판정 기준
+
+| 상태 | 판정 기준 |
+|------|----------|
+| `COVERED` | 규칙의 핵심 요건이 스킬에 명시적 문장 또는 코드 예시로 표현됨 |
+| `PARTIAL` | 규칙이 언급되지만 반례(bad case), 예외 조건, 또는 적용 범위가 누락됨 (bad case는 위반 패턴이 존재하는 규칙에만 요구됨) |
+| `MISSING` | 스킬에서 해당 규칙을 찾을 수 없음 |
+
+### 스킬 모드별 커버리지 분리
+
+커버리지 맵은 두 모드를 분리하여 평가한다:
+
+- **Writing** — Code Writing Mode 섹션(코드 예시, 네이밍 규칙 등)에서 커버 여부
+- **Review** — Code Review Mode 체크리스트 항목에서 커버 여부
+
+### 심각도 분류 기준
+
+| 심각도 | 조건 |
+|--------|------|
+| **Critical** | ✅필수 규칙이 Writing 또는 Review 어느 모드에서든 `MISSING` 또는 `PARTIAL` |
+| **Minor** | ⚠️권장/❌금지 규칙이 누락되거나, 스킬 코드 예시가 잘못된 경우 |
+
+---
+
+## 테스트 케이스 구조
+
+```
+### TC-{섹션번호}-{순번}: {규칙명}
+
+- 규칙: README 원문 인용
+- 규범 수준: ✅필수 / ⚠️권장 / ❌금지
+- 대상 모드: Code Writing / Code Review / Both
+- 스킬 커버: COVERED / PARTIAL / MISSING
+  (대상 모드가 Both인 경우 "Writing: X / Review: Y" 형식으로 분리 기재)
+
+❌ Bad:
+[코드]
+
+✅ Good:
+[코드]
+
+- 검증 포인트: 스킬의 어느 체크리스트 항목 또는 코드 예시가 이를 처리해야 하는가
+```
+
+### 테스트 케이스 범위
+
+| 섹션 | 예상 케이스 수 |
+|------|--------------|
+| 2. HTTP 기본 규칙 (URL, 메서드, 상태코드, 헤더) | ~12개 |
+| 3. REST 원칙 (스키마, 필드, 에러처리) | ~8개 |
+| 4. JSON 규칙 (네이밍, 타입, 날짜, Enum) | ~10개 |
+| 5.1 액션 수행 | ~2개 |
+| 5.2 컬렉션/페이지네이션 | ~4개 |
+| 5.3 필터링/정렬 | ~3개 |
+| 5.4 API 버전 관리 | ~2개 |
+| 5.5 Deprecation | ~2개 |
+| 5.6 속도 제한 | ~3개 |
+| 5.7 장기 실행 작업 | ~2개 |
+| 6. 인증/보안 (Bearer, 401/403, Idempotency) | ~6개 |
+| **합계** | **~54개** |
+
+---
+
+## 평가 보고서 구조
+
+```markdown
+## 커버리지 요약
+
+| 모드 | COVERED | PARTIAL | MISSING | 합계 |
+|------|---------|---------|---------|------|
+| Writing | N | N | N | N |
+| Review | N | N | N | N |
+
+## Critical 문제
+1. [규칙명] — 모드: Writing/Review — 이유
+
+## Minor 문제
+1. [규칙명] — 모드: Writing/Review — 이유
+
+## 개선 권고사항
+### 즉시 수정 (Critical)
+### 다음 단계 (Minor)
+```
+
+---
+
+## 평가 후 액션
+
+| 분류 | 액션 |
+|------|------|
+| **Critical 문제** | 평가 완료 즉시 스킬 수정 및 PR 생성 |
+| **Minor 문제** | `report.md`의 우선순위 기준으로 다음 이슈에 반영 |
+| **회귀 검증** | 스킬 변경 후 동일 테스트 케이스로 재검증 (필수) |
+| **report.md 업데이트** | 스킬 변경 반영 후 커버리지 수치 재계산하여 업데이트 |

--- a/plugins/api/skills/restful-guidelines/SKILL.md
+++ b/plugins/api/skills/restful-guidelines/SKILL.md
@@ -92,9 +92,9 @@ GET, HEAD, DELETE must not include request bodies.
 - `Content-Type: application/json` for bodies
 - `Accept: application/json` for content negotiation
 - `Location` header on 201 Created
-- `X-Total-Count` for collection size
+- `Total-Count` for collection size
 - RFC 5988 `Link` header for pagination
-- Custom headers omit deprecated `X-` prefix (RFC 6648)
+- **No `X-` prefix on custom headers** (RFC 6648/BCP 178) — `X-` was intended for experimental headers but causes naming conflicts when they become standards. All new APIs MUST define custom headers without this prefix. Exception: legacy headers already standardized with `X-` (e.g., `X-Forwarded-For`) retain their names for compatibility
 
 ## CRUD Behavior
 
@@ -112,8 +112,10 @@ GET, HEAD, DELETE must not include request bodies.
 
 **Header versioning is REQUIRED:**
 ```
-X-API-Version: 2024-01-20   (ISO 8601 date format)
+Api-Version: 2024-01-20   (ISO 8601 date format)
 ```
+
+> Header name uses no `X-` prefix per RFC 6648/BCP 178.
 
 - Requests without version header receive the latest stable version
 - Responses always include the applied version
@@ -123,7 +125,7 @@ X-API-Version: 2024-01-20   (ISO 8601 date format)
 
 ## Deprecation
 
-Deprecated APIs MUST include these response headers:
+Deprecated APIs MUST include these response headers (RFC 9745, RFC 8594):
 
 ```
 Deprecation: true
@@ -138,3 +140,4 @@ Link: <https://api.example.com/new-resource>; rel="successor-version"
 - Resource identifiers are opaque strings — clients must not parse structure
 - Avoid storing sensitive data in query strings (they get logged)
 - `Cache-Control` header specifies caching strategy
+- Custom header names MUST NOT use `X-` prefix (RFC 6648/BCP 178) — applies to all new APIs; `X-Forwarded-For` and other headers already standardized with `X-` are grandfathered exceptions


### PR DESCRIPTION
## Summary
- `api:restful-guidelines` 스킬에서 RFC 6648/BCP 178 기반 커스텀 헤더 네이밍 적용
- `X-API-Version` → `Api-Version`, `X-Total-Count` → `Total-Count`
- Deprecation 섹션에 RFC 9745, RFC 8594 레퍼런스 추가
- Key Principles에 RFC 6648 원칙 명시

## Motivation
스킬이 "Custom headers omit deprecated X- prefix (RFC 6648)"라고 명시하면서
예시에서 `X-API-Version`, `X-Total-Count`를 사용하는 자기 모순 상태였음.
신규 프로젝트이므로 처음부터 RFC 6648을 준수해 일관성 확보.

## Changes
- `plugins/api/skills/restful-guidelines/SKILL.md`: 헤더 이름 수정 + RFC 인용 강화
- `docs/decisions/0003-adopt-rfc-6648-for-custom-http-header-naming.md`: MADR 결정 문서 추가
- `plugins/api/docs/`: 스킬 평가 문서 추가 (이전 세션 산출물)
- `.gitignore`: `docs/decisions/` 추적 허용

## Test plan
- [ ] SKILL.md에서 `X-`로 시작하는 헤더 권장 사례 없음 확인
- [ ] RFC 6648 인용이 Headers, API Versioning, Key Principles 3곳에 반영되었는지 확인
- [ ] MADR 문서 형식 및 내용 검토