### PR TITLE
fix(api): X- 접두사 헤더명 수정 및 RFC 참조 보강 (#21)

### DIFF
--- a/plugins/api/README.ko.md
+++ b/plugins/api/README.ko.md
@@ -8,6 +8,8 @@ RESTful API 설계 가이드라인입니다.
 
 ## 규범 수준 표기
 
+이 문서에서 사용하는 "MUST", "MUST NOT", "SHOULD", "MAY", "DO NOT" 키워드는 [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) 및 [RFC 8174](https://datatracker.ietf.org/doc/html/rfc8174)에 따라 해석한다.
+
 | 기호 | 수준 | 설명 |
 |------|------|------|
 | ✅ **필수** | MUST / DO | 반드시 준수해야 하는 규칙 |
@@ -261,17 +263,17 @@ Cache-Control: no-cache
 Cache-Control: max-age=3600
 ```
 
-⚠️ **권장**: 컬렉션 페이지네이션 응답에는 RFC 5988 `Link` 헤더를 사용한다.
+⚠️ **권장**: 컬렉션 페이지네이션 응답에는 RFC 8288 `Link` 헤더를 사용한다.
 
 ```
 Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next",
       <https://api.example.com/articles?pageSize=20>; rel="first"
 ```
 
-⚠️ **권장**: 전체 항목 수를 제공할 때 `X-Total-Count` 헤더를 사용한다.
+⚠️ **권장**: 전체 항목 수를 제공할 때 `Total-Count` 헤더를 사용한다.
 
 ```
-X-Total-Count: 100
+Total-Count: 100
 ```
 
 #### 커스텀 헤더
@@ -678,7 +680,7 @@ HTTP/1.1 200 OK
 Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next",
       <https://api.example.com/articles?pageSize=20>; rel="first",
       <https://api.example.com/articles?pageSize=20&pageToken=xyz>; rel="last"
-X-Total-Count: 100
+Total-Count: 100
 
 [
   { "id": "1", "title": "첫 번째 글" },
@@ -688,8 +690,8 @@ X-Total-Count: 100
 
 | 헤더 | 필수 여부 | 설명 |
 |------|-----------|------|
-| `Link` | ⚠️ 권장 | 페이지네이션 네비게이션 (RFC 5988) |
-| `X-Total-Count` | ⚠️ 권장 | 전체 항목 수 |
+| `Link` | ⚠️ 권장 | 페이지네이션 네비게이션 (RFC 8288) |
+| `Total-Count` | ⚠️ 권장 | 전체 항목 수 |
 
 | rel 값 | 설명 |
 |--------|------|
@@ -741,7 +743,7 @@ Link: <https://api.example.com/articles?pageSize=20&page=1>; rel="first",
       <https://api.example.com/articles?pageSize=20&page=1>; rel="prev",
       <https://api.example.com/articles?pageSize=20&page=3>; rel="next",
       <https://api.example.com/articles?pageSize=20&page=5>; rel="last"
-X-Total-Count: 100
+Total-Count: 100
 
 [
   { "id": "21", "title": "스물한 번째 글" },
@@ -820,17 +822,17 @@ GET /articles?orderBy=createdAt:desc,title:asc
 
 > **이유**: URL은 리소스 식별자다. `/v1/articles`와 `/v2/articles`는 같은 리소스인데 URL이 달라지므로 REST 원칙에 어긋난다. 또한 URL 버전은 클라이언트가 코드를 전면 교체해야 하는 부담을 준다. 헤더 버전은 클라이언트가 버전을 점진적으로 마이그레이션할 수 있고, 버전 미지정 시 서버가 기본 버전을 적용하는 유연성을 제공한다.
 
-✅ **필수**: `X-API-Version` 헤더에 ISO 8601 (`YYYY-MM-DD`) 형식의 날짜로 버전을 지정한다.
+✅ **필수**: `Api-Version` 헤더에 ISO 8601 (`YYYY-MM-DD`) 형식의 날짜로 버전을 지정한다.
 
 ```
-X-API-Version: 2024-01-20
+Api-Version: 2024-01-20
 ```
 
 ⚠️ **권장**: 버전 헤더가 없는 요청에는 최신 안정 버전을 적용하고, 응답에 적용된 버전을 명시한다.
 
 ```
 HTTP/1.1 200 OK
-X-API-Version: 2024-01-20
+Api-Version: 2024-01-20
 ```
 
 #### 하위 호환성
@@ -1118,6 +1120,8 @@ Idempotency-Key: a8098c1a-f86e-11da-bd1a-00112444be1e
 ## 참고 자료
 
 - [Microsoft Azure REST API Guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md)
+- [RFC 2119 - Key words for use in RFCs to Indicate Requirement Levels](https://datatracker.ietf.org/doc/html/rfc2119)
+- [RFC 8174 - Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words](https://datatracker.ietf.org/doc/html/rfc8174)
 - [RFC 3339 - Date and Time on the Internet](https://datatracker.ietf.org/doc/html/rfc3339)
 - [HTTP/1.1 (RFC 7231)](https://datatracker.ietf.org/doc/html/rfc7231)
 - [JSON:API Specification](https://jsonapi.org/)

--- a/plugins/api/README.md
+++ b/plugins/api/README.md
@@ -8,6 +8,8 @@ RESTful API design guidelines.
 
 ## Compliance Levels
 
+The key words "MUST", "MUST NOT", "SHOULD", "MAY", and "DO NOT" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) and [RFC 8174](https://datatracker.ietf.org/doc/html/rfc8174).
+
 | Symbol | Level | Description |
 |--------|-------|-------------|
 | ✅ **Required** | MUST / DO | Rules that must be followed |
@@ -261,17 +263,17 @@ Cache-Control: no-cache
 Cache-Control: max-age=3600
 ```
 
-⚠️ **Recommended**: Use the RFC 5988 `Link` header for collection pagination responses.
+⚠️ **Recommended**: Use the RFC 8288 `Link` header for collection pagination responses.
 
 ```
 Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next",
       <https://api.example.com/articles?pageSize=20>; rel="first"
 ```
 
-⚠️ **Recommended**: Use the `X-Total-Count` header when providing total item count.
+⚠️ **Recommended**: Use the `Total-Count` header when providing total item count.
 
 ```
-X-Total-Count: 100
+Total-Count: 100
 ```
 
 #### Custom Headers
@@ -678,7 +680,7 @@ HTTP/1.1 200 OK
 Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next",
       <https://api.example.com/articles?pageSize=20>; rel="first",
       <https://api.example.com/articles?pageSize=20&pageToken=xyz>; rel="last"
-X-Total-Count: 100
+Total-Count: 100
 
 [
   { "id": "1", "title": "First Article" },
@@ -688,8 +690,8 @@ X-Total-Count: 100
 
 | Header | Required | Description |
 |--------|----------|-------------|
-| `Link` | ⚠️ Recommended | Pagination navigation (RFC 5988) |
-| `X-Total-Count` | ⚠️ Recommended | Total item count |
+| `Link` | ⚠️ Recommended | Pagination navigation (RFC 8288) |
+| `Total-Count` | ⚠️ Recommended | Total item count |
 
 | rel value | Description |
 |-----------|-------------|
@@ -741,7 +743,7 @@ Link: <https://api.example.com/articles?pageSize=20&page=1>; rel="first",
       <https://api.example.com/articles?pageSize=20&page=1>; rel="prev",
       <https://api.example.com/articles?pageSize=20&page=3>; rel="next",
       <https://api.example.com/articles?pageSize=20&page=5>; rel="last"
-X-Total-Count: 100
+Total-Count: 100
 
 [
   { "id": "21", "title": "Article 21" },
@@ -820,17 +822,17 @@ GET /articles?orderBy=createdAt:desc,title:asc
 
 > **Reason**: A URL is a resource identifier. `/v1/articles` and `/v2/articles` represent the same resource but with different URLs, which violates REST principles. URL versioning also forces clients to rewrite their code entirely. Header versioning allows clients to migrate gradually and gives the server flexibility to apply a default version when no version header is specified.
 
-✅ **Required**: Specify the version in the `X-API-Version` header using ISO 8601 (`YYYY-MM-DD`) date format.
+✅ **Required**: Specify the version in the `Api-Version` header using ISO 8601 (`YYYY-MM-DD`) date format.
 
 ```
-X-API-Version: 2024-01-20
+Api-Version: 2024-01-20
 ```
 
 ⚠️ **Recommended**: Apply the latest stable version to requests without a version header, and include the applied version in the response.
 
 ```
 HTTP/1.1 200 OK
-X-API-Version: 2024-01-20
+Api-Version: 2024-01-20
 ```
 
 #### Backward Compatibility
@@ -1118,6 +1120,8 @@ Idempotency-Key: a8098c1a-f86e-11da-bd1a-00112444be1e
 ## References
 
 - [Microsoft Azure REST API Guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md)
+- [RFC 2119 - Key words for use in RFCs to Indicate Requirement Levels](https://datatracker.ietf.org/doc/html/rfc2119)
+- [RFC 8174 - Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words](https://datatracker.ietf.org/doc/html/rfc8174)
 - [RFC 3339 - Date and Time on the Internet](https://datatracker.ietf.org/doc/html/rfc3339)
 - [HTTP/1.1 (RFC 7231)](https://datatracker.ietf.org/doc/html/rfc7231)
 - [JSON:API Specification](https://jsonapi.org/)

--- a/plugins/api/docs/evaluation/coverage-map.md
+++ b/plugins/api/docs/evaluation/coverage-map.md
@@ -95,7 +95,7 @@
 | 5.2-2 | ✅필수 | 다음 페이지 없을 때 Link 헤더에서 rel="next" 제외 | COVERED | COVERED | — |
 | 5.3-1 | ✅필수 | 동일 파라미터 반복은 OR 조건 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 5.4-1 | ❌금지 | API 버전을 URL 경로에 포함 금지 | COVERED | COVERED | ~~Minor~~ Fixed |
-| 5.4-2 | ✅필수 | X-API-Version 헤더에 ISO 8601 날짜 형식으로 버전 지정 | COVERED | COVERED | — |
+| 5.4-2 | ✅필수 | Api-Version 헤더에 ISO 8601 날짜 형식으로 버전 지정 | COVERED | COVERED | — |
 | 5.4-3 | ✅필수 | 동일 버전 내 하위 호환성 유지 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 5.5-1 | ✅필수 | Deprecated API에 Deprecation/Sunset/Link 응답 헤더 제공 | COVERED | COVERED | ~~Critical~~ Fixed |
 | 5.6-1 | ✅필수 | 속도 제한 응답에 X-RateLimit-* 헤더 포함 | COVERED | COVERED | — |
@@ -247,7 +247,7 @@
 | 5.2-2 | COVERED | `nextPageToken` null 시 Link에 next 미포함하는 buildLinkHeader 코드 있음 |
 | 5.3-1 | MISSING | OR 조건 규칙이 Writing 모드에 없음 |
 | 5.4-1 | COVERED | "URL 경로에 버전 금지" 규칙 추가 (Minor 개선) |
-| 5.4-2 | COVERED | X-API-Version 헤더 코드 예시 있음 (ISO 8601 날짜 형식 "2024-01-20") |
+| 5.4-2 | COVERED | Api-Version 헤더 코드 예시 있음 (ISO 8601 날짜 형식 "2024-01-20") |
 | 5.4-3 | MISSING | 하위 호환성 유지 규칙 없음 |
 | 5.5-1 | COVERED | Deprecation/Sunset/Link 헤더 설정 코드 예시 있음. 커버리지 출처: Writing Mode 본문이 아닌 Code Examples 부록의 Kotlin 코드 예시에서 확인됨. |
 | 5.6-1 | COVERED | addRateLimitHeaders 함수에 X-RateLimit-* 헤더 설정 코드 있음 |
@@ -322,8 +322,8 @@
 | 5.2-1 | COVERED | "Collection response body is a top-level array" 체크리스트 항목 |
 | 5.2-2 | COVERED | "rel=next excluded from Link header when no next page" 체크리스트 항목 |
 | 5.3-1 | COVERED | "Repeated same parameter treated as OR condition" 체크리스트 항목 |
-| 5.4-1 | COVERED | "No version in URL path" + "API version delivered via X-API-Version header, not URL path" 체크리스트 항목 |
-| 5.4-2 | COVERED | "X-API-Version value uses ISO 8601 date format" 체크리스트 항목 |
+| 5.4-1 | COVERED | "No version in URL path" + "API version delivered via Api-Version header, not URL path" 체크리스트 항목 |
+| 5.4-2 | COVERED | "Api-Version value uses ISO 8601 date format" 체크리스트 항목 |
 | 5.4-3 | MISSING | 하위 호환성 유지 체크 없음 |
 | 5.5-1 | MISSING | Deprecation 헤더 체크 항목 없음 |
 | 5.6-1 | COVERED | Rate Limiting 체크리스트에 X-RateLimit-* 헤더 항목 있음 |

--- a/plugins/api/docs/evaluation/test-cases.md
+++ b/plugins/api/docs/evaluation/test-cases.md
@@ -1383,7 +1383,7 @@ class ArticleController {
         val result = articleService.getArticles(pageSize, pageToken)
         val headers = HttpHeaders()
         buildLinkHeader(result, pageSize).let { headers.set("Link", it) }
-        result.totalCount?.let { headers.set("X-Total-Count", it.toString()) }
+        result.totalCount?.let { headers.set("Total-Count", it.toString()) }
         return ResponseEntity.ok().headers(headers).body(result.items)
     }
 }
@@ -1391,7 +1391,7 @@ class ArticleController {
 // 응답:
 // HTTP/1.1 200 OK
 // Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next"
-// X-Total-Count: 100
+// Total-Count: 100
 //
 // [
 //   { "id": "1", "title": "첫 번째 글" },
@@ -1472,9 +1472,9 @@ GET /articles?orderBy=createdAt:desc
 
 ---
 
-### TC-5-06: X-Total-Count 헤더
+### TC-5-06: Total-Count 헤더
 
-- 규칙: "⚠️ **권장**: 전체 항목 수를 제공할 때 `X-Total-Count` 헤더를 사용한다."
+- 규칙: "⚠️ **권장**: 전체 항목 수를 제공할 때 `Total-Count` 헤더를 사용한다."
 - 규범 수준: ⚠️권장
 - 대상 모드: Both
 - 스킬 커버: Writing: COVERED / Review: COVERED
@@ -1502,19 +1502,19 @@ fun getArticles(
     val result = articleService.getArticles(pageSize, pageToken)
     val headers = HttpHeaders()
     buildLinkHeader(result, pageSize).let { headers.set("Link", it) }
-    result.totalCount?.let { headers.set("X-Total-Count", it.toString()) }
+    result.totalCount?.let { headers.set("Total-Count", it.toString()) }
     return ResponseEntity.ok().headers(headers).body(result.items)
 }
 
 // 응답:
 // HTTP/1.1 200 OK
-// X-Total-Count: 100
+// Total-Count: 100
 // Link: <...>; rel="next"
 //
 // [ { "id": "1", ... }, { "id": "2", ... } ]
 ```
 
-- 검증 포인트: Writing 모드의 Collection/Pagination Pattern에 `X-Total-Count: 100` 헤더 예시 및 코드에서 `headers.set("X-Total-Count", ...)`, Review 체크리스트의 "X-Total-Count header used when providing total item count" 항목
+- 검증 포인트: Writing 모드의 Collection/Pagination Pattern에 `Total-Count: 100` 헤더 예시 및 코드에서 `headers.set("Total-Count", ...)`, Review 체크리스트의 "Total-Count header used when providing total item count" 항목
 
 ---
 
@@ -1650,24 +1650,24 @@ class ArticleController {
 
     @GetMapping
     fun getArticles(
-        @RequestHeader("X-API-Version", required = false) apiVersion: String?
+        @RequestHeader("Api-Version", required = false) apiVersion: String?
     ): ResponseEntity<List<Article>> {
         val version = apiVersion ?: "2024-01-20"
         val articles = articleService.getArticles(version)
         return ResponseEntity.ok()
-            .header("X-API-Version", version)
+            .header("Api-Version", version)
             .body(articles)
     }
 }
 ```
 
-- 검증 포인트: Writing 모드에 URL 경로 버전 금지 규칙 명시 없음(MISSING), Review 체크리스트의 "No version in URL path (`/v1/`, `/v2/`, etc.)" 및 "API version delivered via `X-API-Version` header, not URL path" 항목
+- 검증 포인트: Writing 모드에 URL 경로 버전 금지 규칙 명시 없음(MISSING), Review 체크리스트의 "No version in URL path (`/v1/`, `/v2/`, etc.)" 및 "API version delivered via `Api-Version` header, not URL path" 항목
 
 ---
 
-### TC-5-11: X-API-Version 헤더 ISO 8601 날짜 형식
+### TC-5-11: Api-Version 헤더 ISO 8601 날짜 형식
 
-- 규칙: "✅ **필수**: `X-API-Version` 헤더에 ISO 8601 (`YYYY-MM-DD`) 형식의 날짜로 버전을 지정한다."
+- 규칙: "✅ **필수**: `Api-Version` 헤더에 ISO 8601 (`YYYY-MM-DD`) 형식의 날짜로 버전을 지정한다."
 - 규범 수준: ✅필수
 - 대상 모드: Both
 - 스킬 커버: Writing: COVERED / Review: COVERED
@@ -1675,36 +1675,36 @@ class ArticleController {
 ❌ Bad:
 ```
 # 숫자 버전 — 금지
-X-API-Version: 1
-X-API-Version: 2.0
-X-API-Version: v3
+Api-Version: 1
+Api-Version: 2.0
+Api-Version: v3
 
 # 비표준 날짜 형식 — 금지
-X-API-Version: 20240120
-X-API-Version: Jan 20, 2024
-X-API-Version: 2024/01/20
+Api-Version: 20240120
+Api-Version: Jan 20, 2024
+Api-Version: 2024/01/20
 ```
 
 ✅ Good:
 ```
-X-API-Version: 2024-01-20
-X-API-Version: 2025-06-15
+Api-Version: 2024-01-20
+Api-Version: 2025-06-15
 ```
 
 ```kotlin
 @GetMapping("/articles")
 fun getArticles(
-    @RequestHeader("X-API-Version", required = false) apiVersion: String?
+    @RequestHeader("Api-Version", required = false) apiVersion: String?
 ): ResponseEntity<List<Article>> {
     val version = apiVersion ?: "2024-01-20"  // ISO 8601 날짜 형식
     val articles = articleService.getArticles(version)
     return ResponseEntity.ok()
-        .header("X-API-Version", version)
+        .header("Api-Version", version)
         .body(articles)
 }
 ```
 
-- 검증 포인트: Writing 모드의 API Version Header Handling 코드에서 `"2024-01-20"` 형식 사용, Review 체크리스트의 "X-API-Version value uses ISO 8601 date format (YYYY-MM-DD)" 항목
+- 검증 포인트: Writing 모드의 API Version Header Handling 코드에서 `"2024-01-20"` 형식 사용, Review 체크리스트의 "Api-Version value uses ISO 8601 date format (YYYY-MM-DD)" 항목
 
 ---
 

--- a/plugins/api/docs/superpowers/plans/2026-03-19-skill-performance-evaluation.md
+++ b/plugins/api/docs/superpowers/plans/2026-03-19-skill-performance-evaluation.md
@@ -172,7 +172,7 @@ README 5.1~5.7, 6.1~6.3 규칙을 추출하고 coverage-map.md에 추가한다.
 | 5.2-2 | ✅필수 | 다음 페이지 없을 때 Link 헤더에서 rel="next" 제외 | ? | ? | ? |
 | 5.3-1 | ✅필수 | 동일 파라미터 반복은 OR 조건 | ? | ? | ? |
 | 5.4-1 | ❌금지 | API 버전을 URL 경로에 포함 금지 | ? | ? | ? |
-| 5.4-2 | ✅필수 | X-API-Version 헤더에 ISO 8601 날짜 형식으로 버전 지정 | ? | ? | ? |
+| 5.4-2 | ✅필수 | Api-Version 헤더에 ISO 8601 날짜 형식으로 버전 지정 | ? | ? | ? |
 | 5.4-3 | ✅필수 | 동일 버전 내 하위 호환성 유지 | ? | ? | ? |
 | 5.5-1 | ✅필수 | Deprecated API에 Deprecation/Sunset/Link 응답 헤더 제공 | ? | ? | ? |
 | 5.6-1 | ✅필수 | 속도 제한 응답에 X-RateLimit-* 헤더 포함 | ? | ? | ? |
@@ -827,7 +827,7 @@ POST /articles/123:publish
 ✅ Good:
 ```
 HTTP/1.1 200 OK
-X-Total-Count: 100
+Total-Count: 100
 
 [
   { "id": "1", "title": "첫 번째 글" }
@@ -875,7 +875,7 @@ GET /v2/users/123
 ✅ Good:
 ```
 GET /articles
-X-API-Version: 2024-01-20
+Api-Version: 2024-01-20
 ```
 
 - 검증 포인트: Review 체크리스트 "No version in URL path (/v1/, /v2/, etc.)"
@@ -900,8 +900,8 @@ X-API-Version: 2024-01-20
 
 ✅ Good:
 ```json
-// 비호환 변경 시 새 버전 일자로 X-API-Version 업데이트
-// X-API-Version: 2024-06-01
+// 비호환 변경 시 새 버전 일자로 Api-Version 업데이트
+// Api-Version: 2024-06-01
 { "id": "1", "name": "제목" }
 ```
 

--- a/plugins/api/skills/restful-guidelines/SKILL.md
+++ b/plugins/api/skills/restful-guidelines/SKILL.md
@@ -7,6 +7,8 @@ user-invocable: true
 
 Source: https://github.com/ppzxc/restful-api-guidelines
 
+Keywords MUST, SHOULD, MAY follow RFC 2119/8174.
+
 ---
 
 ## URL Design
@@ -67,6 +69,7 @@ GET, HEAD, DELETE must not include request bodies.
 - **camelCase** field names: `userId`, `createdAt`, `isActive`
 - Never snake_case or abbreviations
 - Omit null/missing fields entirely (do not send `"field": null`)
+- Date/time values as RFC 3339 strings; server responses in UTC (`Z`)
 - Standard resource fields: `id`, `createdAt` (create-only), `updatedAt` (read-only)
 - Servers must ignore read-only fields in request bodies
 
@@ -93,7 +96,7 @@ GET, HEAD, DELETE must not include request bodies.
 - `Accept: application/json` for content negotiation
 - `Location` header on 201 Created
 - `Total-Count` for collection size
-- RFC 5988 `Link` header for pagination
+- RFC 8288 `Link` header for pagination
 - **No `X-` prefix on custom headers** (RFC 6648/BCP 178) — `X-` was intended for experimental headers but causes naming conflicts when they become standards. All new APIs MUST define custom headers without this prefix. Exception: legacy headers already standardized with `X-` (e.g., `X-Forwarded-For`) retain their names for compatibility
 
 ## CRUD Behavior


### PR DESCRIPTION
## Summary
- `X-API-Version` → `Api-Version`, `X-Total-Count` → `Total-Count` 변경 (RFC 6648 X- 접두사 금지 규칙 준수)
- RFC 2119/8174 Compliance Levels 참조 추가 (README, SKILL.md)
- RFC 5988 → RFC 8288 업데이트 (obsolete 참조 수정)
- SKILL.md에 RFC 3339 date/time 규칙 추가
- evaluation docs 전체에 헤더명 일괄 반영

## Test plan
- [ ] README.md/README.ko.md에서 `X-API-Version`, `X-Total-Count` 검색 시 0건 확인
- [ ] SKILL.md에 RFC 2119/8174 키워드 선언 존재 확인
- [ ] evaluation docs에서 헤더명 일관성 확인

Closes #21