### PR TITLE
docs(decisions): docs 플러그인 스킬 및 평가 시스템 ADR 추가

### DIFF
--- a/docs/decisions/0001-docs-plugin-adr-madr-skills.md
+++ b/docs/decisions/0001-docs-plugin-adr-madr-skills.md
@@ -1,0 +1,53 @@
+# docs 플러그인에 ADR/MADR 스킬 추가
+
+## Status
+
+accepted
+
+## Context and Problem Statement
+
+아키텍처 의사결정을 공식 문서로 기록하는 표준 방법이 없어, 결정 사항이 브레인스토밍 스펙이나 대화 컨텍스트에만 남고 추적이 어렵다. ADR(Architecture Decision Records)과 MADR(Markdown Architectural Decision Records)은 이 문제를 해결하는 업계 표준 포맷이다. 이를 Claude Code 플러그인 스킬로 통합하면 스펙 작성 → 구현 계획 → 공식 결정 기록의 워크플로우가 완성된다.
+
+## Decision Drivers
+
+* 결정 사항의 추적 가능성 — 왜 그 결정을 내렸는지 나중에도 알 수 있어야 한다
+* 기존 플러그인 패턴과의 일관성 — `api`, `git` 플러그인 구조를 따라야 한다
+* 다른 스킬과의 연계 — brainstorming 스펙 완료 후 공식 ADR/MADR로 자연스럽게 이어져야 한다
+* Claude AI 친화적 포맷 — Claude가 컨텍스트를 잘 이해하고 초안을 잘 작성할 수 있어야 한다
+
+## Considered Options
+
+* Option A: 완전 독립형 스킬 2개 (`docs:adr`, `docs:madr` 각각)
+* Option B: 공유 워크플로우 + 포맷 분리 (base 스킬 + 포맷 스킨)
+* Option C: MADR이 ADR을 확장하는 상속 구조
+
+## Decision Outcome
+
+Chosen option: **Option A (완전 독립형 스킬 2개)**, because 현재 플러그인 시스템이 SKILL.md 단일 파일 기반으로 스킬 간 참조를 지원하지 않으며, ADR과 MADR은 포맷 철학이 달라 독립적으로 관리하는 것이 더 자연스럽기 때문이다.
+
+### Consequences
+
+* Good: 각 스킬이 독립적으로 발전 가능
+* Good: 기존 `git:commit` 패턴과 동일한 구조로 일관성 유지
+* Good: 한 스킬의 변경이 다른 스킬에 영향을 주지 않음
+* Bad: 워크플로우 로직 일부 중복 (번호 채번, 사용자 확인 절차)
+
+## Pros and Cons of the Options
+
+### Option A: 완전 독립형 스킬 2개
+
+* Good: 단순하고 자명한 구조
+* Good: 기존 플러그인 패턴과 완벽히 일치
+* Good: 독립적 진화 가능
+* Bad: 공통 워크플로우 로직 중복
+
+### Option B: 공유 워크플로우 + 포맷 분리
+
+* Good: DRY — 공통 로직 중복 없음
+* Bad: 현재 플러그인 시스템이 스킬 간 참조를 지원하지 않음
+* Bad: 구조 복잡도 증가
+
+### Option C: MADR이 ADR을 확장
+
+* Bad: 스킬 간 결합도 증가
+* Bad: MADR을 독립 호출할 수 없음

--- a/docs/decisions/0002-plugin-skill-evaluation-system.md
+++ b/docs/decisions/0002-plugin-skill-evaluation-system.md
@@ -1,0 +1,53 @@
+# 플러그인 스킬 성능 평가 시스템 구조
+
+## Status
+
+accepted
+
+## Context and Problem Statement
+
+git, docs 플러그인 스킬의 성능을 체계적으로 검증할 방법이 없다. api 플러그인에는 이미 독립 평가 시스템(test-cases.md + coverage-map.md + report.md)이 있으나, git/docs 스킬은 워크플로우 기반이라 api의 Writing/Review 모드 커버리지 기준이 맞지 않는다. Safety Rules 준수와 워크플로우 단계 정확도를 검증할 수 있는 별도 평가 체계가 필요하다.
+
+## Decision Drivers
+
+* api 평가 시스템 변경 없이 독립적으로 운영
+* 워크플로우 스킬 특성 반영 — Safety + Workflow 두 축 평가
+* 플러그인별 독립 발전 가능
+* 파일 구조 컨벤션을 api와 통일
+
+## Considered Options
+
+* Option A: 플러그인별 독립 평가 시스템
+* Option B: 공통 평가 템플릿 + 플러그인별 인스턴스
+* Option C: 평가 전용 스킬 추가
+
+## Decision Outcome
+
+Chosen option: **Option A (플러그인별 독립 평가 시스템)**, because 현재 플러그인 수(2개)에서 템플릿 추상화는 불필요하고, api와 동일한 파일 구조를 따르면 일관성이 충분히 확보되기 때문이다.
+
+### Consequences
+
+* Good: 플러그인 독립적, 각자 발전 가능
+* Good: api 패턴 준수로 구조 일관성 확보
+* Bad: 스킬마다 테스트케이스 직접 작성 필요
+
+## Pros and Cons of the Options
+
+### Option A: 플러그인별 독립 평가 시스템
+
+* Good: 단순하고 자명한 구조
+* Good: api 기존 패턴과 일치
+* Good: 플러그인 간 독립적 진화 가능
+* Bad: 공통 로직 중복 (커버율 계산 공식 등)
+
+### Option B: 공통 평가 템플릿 + 플러그인별 인스턴스
+
+* Good: DRY — 공통 구조 중복 없음
+* Bad: 현재 플러그인 수에서 오버엔지니어링
+* Bad: 템플릿-인스턴스 동기화 부담
+
+### Option C: 평가 전용 스킬 추가
+
+* Good: 자동화 가능성
+* Bad: 워크플로우 스킬은 수동 검토가 더 정확
+* Bad: 범위 대비 복잡도 과잉


### PR DESCRIPTION
## Summary
- ADR 0001: docs 플러그인에 ADR/MADR 스킬 추가 결정 기록
- ADR 0002: 플러그인 스킬 성능 평가 시스템 구조 결정 기록

## Motivation
아키텍처 의사결정을 공식 문서로 기록하는 표준이 없어, 결정 사항이 브레인스토밍 스펙이나 대화 컨텍스트에만 남고 추적이 어려운 문제를 해결하기 위해 ADR 문서를 추가합니다.

## Changes
- `docs/decisions/0001-docs-plugin-adr-madr-skills.md`: docs 플러그인 스킬을 독립형 2개 스킬(docs:adr, docs:madr)로 구현하는 결정 기록
- `docs/decisions/0002-plugin-skill-evaluation-system.md`: git/docs 플러그인 스킬 평가 시스템을 플러그인별 독립 시스템으로 구성하는 결정 기록

## Test plan
- [ ] 파일 경로 및 네이밍 컨벤션 준수 확인
- [ ] MADR 포맷(Status, Context, Decision Drivers, Considered Options, Decision Outcome) 완결성 확인
- [ ] 기존 docs/decisions/ 디렉토리 구조와 일관성 확인