### PR TITLE
docs: README 및 marketplace.json 최신화 — docs 플러그인 추가 및 버전 동기화

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,13 +15,19 @@
       "name": "api",
       "source": "./plugins/api",
       "description": "RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, and headers",
-      "version": "0.0.1"
+      "version": "0.0.3"
+    },
+    {
+      "name": "docs",
+      "source": "./plugins/docs",
+      "description": "Documentation decision records — ADR (Nygard format) and MADR (MADR 3.x) for architecture decisions",
+      "version": "0.0.2"
     },
     {
       "name": "git",
       "source": "./plugins/git",
       "description": "Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
-      "version": "0.0.3"
+      "version": "0.0.4"
     }
   ]
 }

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,10 +6,11 @@
 
 ## 플러그인 목록
 
-| 플러그인 | 설명 |
-|--------|-------------|
-| [api](./plugins/api) | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더 |
-| [git](./plugins/git) | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, PR 전체 흐름, worktree 정리 |
+| 플러그인 | 버전 | 설명 |
+|--------|------|------|
+| [api](./plugins/api) | v0.0.3 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더 |
+| [docs](./plugins/docs) | v0.0.2 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 3.x) 아키텍처 결정 기록 |
+| [git](./plugins/git) | v0.0.4 | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
 
 ## 마켓플레이스 등록
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ A collection of engineering guidelines for software development, as a Claude Cod
 
 ## Plugins
 
-| Plugin | Description |
-|--------|-------------|
-| [api](./plugins/api) | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers |
-| [git](./plugins/git) | Git workflow skills — safe commit, PR creation, PR review, squash merge, full PR lifecycle orchestration, and worktree cleanup |
+| Plugin | Version | Description |
+|--------|---------|-------------|
+| [api](./plugins/api) | v0.0.3 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers |
+| [docs](./plugins/docs) | v0.0.2 | Documentation decision records — ADR (Nygard format) and MADR (MADR 3.x) for architecture decisions |
+| [git](./plugins/git) | v0.0.4 | Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
 
 ## Marketplace Registration
 


### PR DESCRIPTION
## Summary
- 메인 README.md / README.ko.md에 `docs` 플러그인 추가 및 버전 컬럼 신설
- `.claude-plugin/marketplace.json` docs 플러그인 등록 및 api/git 버전 동기화

## Motivation
프로젝트에 `docs` 플러그인(adr, madr 스킬)이 추가되었지만 메인 README와 marketplace.json에 반영되지 않았음. 또한 api(0.0.1→0.0.3), git(0.0.3→0.0.4) 버전도 실제 plugin.json과 불일치 상태였음.

## Changes
- `README.md`: 플러그인 테이블에 Version 컬럼 추가, docs 플러그인 행 추가, git 설명에 issue creation 반영
- `README.ko.md`: 동일 변경 한국어 버전
- `.claude-plugin/marketplace.json`: docs 플러그인 엔트리 추가, api v0.0.3 / git v0.0.4 버전 갱신

## Test plan
- [ ] README.md 플러그인 테이블에 api, docs, git 3개 플러그인이 표시되는지 확인
- [ ] README.ko.md와 README.md 내용이 동일한 정보를 담고 있는지 확인
- [ ] marketplace.json 버전이 각 plugin.json 버전과 일치하는지 확인