### PR TITLE
feat(api): Non-CRUD action endpoint 응답 상태 코드 및 collection-level action 가이드 (#33, #34)

### DIFF
--- a/plugins/api/skills/restful-guidelines/SKILL.md
+++ b/plugins/api/skills/restful-guidelines/SKILL.md
@@ -15,7 +15,7 @@ Keywords MUST, SHOULD, MAY follow RFC 2119/8174.
 
 - **kebab-case** for path segments: `/user-profiles`, `/product-categories/123`
 - **Plural nouns** for collections: `/articles` not `/article`
-- **No verbs in resource paths** — use HTTP methods for CRUD; non-CRUD actions use `POST /{resource}/{id}/{action}` or `POST /{resource}/{action}` for collection-level operations
+- **No verbs in resource paths** — use HTTP methods for CRUD; non-CRUD actions use `POST` with a verb sub-path (resource-level: `/{resource}/{id}/{action}`, collection-level: `/{resource}/{action}`)
 - **No file extensions** (`.json`, `.xml`)
 - **No trailing slash** — `/articles` not `/articles/`
 - **camelCase** for query parameters: `pageSize=20&sortOrder=desc`
@@ -38,15 +38,16 @@ Nest at most one sub-resource under a parent. For deeper relationships, promote 
 Some operations carry side-effects that go beyond simple field updates (e.g., refunds,
 notifications, state-machine transitions). Disguising them as PATCH masks intent and
 couples unrelated concerns. Use `POST` with a verb sub-path to make the operation explicit.
+This applies equally to collection-level operations where no specific resource identifier exists (`POST /{resource}/{action}`).
 
 | Action | ✅ Do | ❌ Don't | Why |
 |--------|-------|---------|-----|
 | Cancel an order | `POST /orders/{id}/cancel` | `PATCH /orders/{id}` with `{"status":"cancelled"}` | Cancellation triggers refund + notification — not a simple field update |
 | Approve a review | `POST /reviews/{id}/approve` | `PUT /reviews/{id}/approval` | Approval may trigger publishing, scoring, or downstream workflows |
-| Generate a report | `POST /reports/generate` | `GET /reports?generate=true` | Generation is a side-effect (async job), not a retrieval — use POST to make intent explicit |
+| Generate a report | `POST /reports/generate` | `GET /reports?generate=true` | Generation is a compute side-effect that may mutate state — not a safe retrieval |
 
 Adopted pattern: Stripe (`/charges/{id}/capture`), Shopify (`/orders/{id}/cancel`),
-GitHub (`/pulls/{number}/merge`).
+GitHub (`/pulls/{number}/merge`); collection-level: GitHub (`/repos/{owner}/{repo}/dispatches`).
 
 **Action response status codes:**
 


### PR DESCRIPTION
## Summary

- 이슈 #33: Non-CRUD action endpoint의 동기/비동기 응답 상태 코드 가이드 추가
- 이슈 #34: Non-CRUD actions 테이블에 collection-level action 예시 추가

## Motivation

PR #32에서 Non-CRUD action endpoint 패턴을 도입했으나, 두 가지 가이드가 부재했음:
- action endpoint가 동기/비동기에 따라 어떤 상태 코드를 반환해야 하는지 불명확
- 모든 예시가 단일 리소스 대상(`{id}` 포함)이었고, collection-level action(`{id}` 없음)에 대한 가이드 없음

업계 리더(Stripe, Shopify, GitHub, Azure, Twilio, PayPal) 및 RFC 9110 표준 조사 후 설계 확정.

## Changes

### 이슈 #33 — 응답 상태 코드 가이드
- `Status Codes` 섹션에 `202 Accepted` 추가 (async/deferred operations)
- Non-CRUD actions 섹션에 `Action response status codes` 테이블 추가
  - Sync action (리소스 업데이트) → `200 OK`
  - Sync action (응답 본문 없음) → `204 No Content`
  - Async action (fire-and-forget) → `202 Accepted`
- `Long-Running Operations` 섹션(`201 Created` + polling)과의 구분을 명시하는 cross-reference 추가

### 이슈 #34 — Collection-level action 예시
- URL Design 패턴 설명에 collection-level 패턴 명시: `POST /{resource}/{action}`
- Non-CRUD actions 소개 단락에 collection-level 적용 가능성 명시
- DO/DON'T 테이블에 `POST /reports/generate` 예시 추가
- `Adopted pattern` 출처에 collection-level 예시(GitHub `/repos/{owner}/{repo}/dispatches`) 추가

## Test plan

- [ ] SKILL.md 마크다운 테이블 렌더링 확인
- [ ] 이슈 #33 요구사항 대조: 동기 → 200, 비동기 → 202 가이드 존재 여부
- [ ] 이슈 #34 요구사항 대조: collection-level 예시 존재 여부
- [ ] `Long-Running Operations` 섹션과 충돌 없음 확인

Closes #33
Closes #34