### PR TITLE
chore(api): bump api plugin to v0.0.5 and marketplace to v0.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "Engineering guidelines and best practices for software development",
-    "version": "0.0.1"
+    "version": "0.0.2"
   },
   "plugins": [
     {
       "name": "api",
       "source": "./plugins/api",
       "description": "RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, and non-CRUD action endpoints",
-      "version": "0.0.4"
+      "version": "0.0.5"
     },
     {
       "name": "docs",

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,7 +8,7 @@
 
 | 플러그인 | 버전 | 설명 |
 |--------|------|------|
-| [api](./plugins/api) | v0.0.4 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
+| [api](./plugins/api) | v0.0.5 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
 | [docs](./plugins/docs) | v0.0.2 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 3.x) 아키텍처 결정 기록 |
 | [git](./plugins/git) | v0.0.4 | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 
 | Plugin | Version | Description |
 |--------|---------|-------------|
-| [api](./plugins/api) | v0.0.4 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
+| [api](./plugins/api) | v0.0.5 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
 | [docs](./plugins/docs) | v0.0.2 | Documentation decision records — ADR (Nygard format) and MADR (MADR 3.x) for architecture decisions |
 | [git](./plugins/git) | v0.0.4 | Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
 

--- a/plugins/api/.claude-plugin/plugin.json
+++ b/plugins/api/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "RESTful API design guidelines skill — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, and non-CRUD action endpoints",
   "author": {
     "name": "ppzxc",


### PR DESCRIPTION
## Summary
- `api` 플러그인 버전 `v0.0.4` → `v0.0.5`
- marketplace 전체 버전 `v0.0.1` → `v0.0.2`

## Motivation
마지막 버전 동기화(`63a91a7`) 이후 `api` 플러그인에 Non-CRUD action endpoint 관련 커밋 2개가 추가되어 버전을 범프합니다.

## Changes
- `plugins/api/.claude-plugin/plugin.json`: version `0.0.4` → `0.0.5`
- `.claude-plugin/marketplace.json`: api version `0.0.4` → `0.0.5`, metadata.version `0.0.1` → `0.0.2`
- `README.md`: api 버전 표기 업데이트
- `README.ko.md`: api 버전 표기 업데이트

## Test plan
- [ ] marketplace.json api 버전이 `0.0.5`인지 확인
- [ ] marketplace.json metadata.version이 `0.0.2`인지 확인
- [ ] README.md, README.ko.md 버전 표기 일치 확인