### PR TITLE
feat(workflow): add feature-pipeline orchestrator skill (v0.0.9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,8 +32,8 @@
     {
       "name": "workflow",
       "source": "./plugins/workflow",
-      "description": "Workflow skills — multi-LLM cross-check with Gemini for planning and execution",
-      "version": "0.0.8"
+      "description": "Workflow skills — multi-LLM cross-check with Gemini for planning and execution, full feature pipeline from idea to committed code",
+      "version": "0.0.9"
     },
     {
       "name": "dev",

--- a/.claude/rules/workflow-rules.md
+++ b/.claude/rules/workflow-rules.md
@@ -1,0 +1,8 @@
+# Workflow 스킬 규칙
+
+feature-pipeline 스킬을 사용하거나 구현할 때 반드시 다음 제약을 따른다.
+
+✓ feature-pipeline이 생성/수정하는 plan은 `docs/plans/<slug>.md`에 저장할 것 [ADR-0011]
+✓ feature-pipeline plan의 behavioral task는 `[TDD]` 또는 `[TDD-EXEMPT: 사유]`를 반드시 명시할 것 [ADR-0011]
+✓ feature-pipeline plan의 tidying task는 `[TIDY]` 태그를 부착하고 `## Behavioral Phase`와 분리된 `## Tidying Phase` 섹션에 둘 것 [ADR-0011]
+✓ feature-pipeline은 gemini-crosscheck Skill을 직접 호출하지 않고 `mcp__gemini-cli__ask-gemini`로 review-only 검증만 수행할 것 (이중 실행 방지) [ADR-0011]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@
 | 작업 | 파일 |
 |------|------|
 | ADR 작성 / 규칙 수정 | `.claude/rules/rules-maintenance.md` |
+| workflow 스킬 사용 / 수정 | `.claude/rules/workflow-rules.md` |
 
 ### 참조
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
 | [api](./plugins/api) | v0.2.0 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
 | [docs](./plugins/docs) | v0.0.4 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
 | [git](./plugins/git) | v0.0.8 | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
-| [workflow](./plugins/workflow) | v0.0.8 | 워크플로우 스킬 — Gemini를 활용한 멀티 LLM 크로스체크 기반 계획 및 실행 |
+| [workflow](./plugins/workflow) | v0.0.9 | 워크플로우 스킬 — Gemini 멀티 LLM 크로스체크 + 아이디어에서 커밋까지 전체 파이프라인 오케스트레이션 |
 | [dev](./plugins/dev) | v0.0.1 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 
 ## 마켓플레이스 등록

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [api](./plugins/api) | v0.2.0 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
 | [docs](./plugins/docs) | v0.0.4 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
 | [git](./plugins/git) | v0.0.8 | Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
-| [workflow](./plugins/workflow) | v0.0.8 | Workflow skills — multi-LLM cross-check with Gemini for planning and execution |
+| [workflow](./plugins/workflow) | v0.0.9 | Workflow skills — Gemini multi-LLM cross-check + full feature pipeline orchestration (grill → plan → verify → execute) |
 | [dev](./plugins/dev) | v0.0.1 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 
 ## Marketplace Registration

--- a/docs/decisions/0011-add-feature-pipeline-orchestrator.md
+++ b/docs/decisions/0011-add-feature-pipeline-orchestrator.md
@@ -1,0 +1,72 @@
+# feature-pipeline 오케스트레이터 스킬 추가
+
+* Status: accepted
+* Date: 2026-05-13
+* Decision Makers: ppzxc
+* Consulted: Gemini gemini-3.1-pro-preview (cross-check)
+* Informed: —
+
+## Context and Problem Statement
+
+`workflow` 플러그인의 `gemini-crosscheck` 스킬은 brainstorm → crosscheck → plan → execute 전 흐름을 다루지만, 요구사항 채굴(grill-me) 단계를 포함하지 않는다. 또한 plan 산출이 대화 내 텍스트로 끝나 단계 간 파일 핸드오프가 없으며, behavioral task에서 TDD 강제력이 약하다. 사용자는 이 흐름을 매번 수동으로 오케스트레이션해야 했다.
+
+## Decision Drivers
+
+* grill-me → plan → crosscheck → execute 전 흐름을 단일 스킬로 묶어 수동 오케스트레이션 비용 제거
+* plan 파일(`docs/plans/<slug>.md`)을 중간 산출물로 저장하여 단계 간 명시적 핸드오프
+* behavioral task에 TDD를 기본값으로 강제하고 면제는 명시적 사유 요구
+* gemini-crosscheck의 이중 실행 문제(Skill 호출 시 Step 5 Execute까지 진행) 방지
+
+## Considered Options
+
+* (a) 단일 통합 스킬 `feature-pipeline` 추가
+* (b) `gemini-crosscheck`에 review-only 모드 파라미터 추가
+* (c) 사용자가 개별 스킬을 수동 체이닝 (현상 유지)
+
+## Decision Outcome
+
+Chosen option: "(a) 단일 통합 스킬 `feature-pipeline` 추가", because 기존 스킬 인터페이스를 변경하지 않고 오케스트레이션 레이어를 추가할 수 있으며, grill-me 단계까지 포함한 더 넓은 범위를 다룰 수 있다.
+
+옵션 (b)는 gemini-crosscheck SKILL.md를 수정해야 하며 하위 호환성 리스크가 있다. 옵션 (c)는 현재의 수동 오케스트레이션 문제를 해결하지 못한다.
+
+### Consequences
+
+* Good, because 아이디어 한 문장에서 PR까지 단일 호출로 처리 가능
+* Good, because plan 파일이 영구 산출물로 Git에 남아 의사결정 추적 가능
+* Good, because gemini-crosscheck Skill을 직접 호출하지 않고 inline ask-gemini를 사용하여 이중 실행 충돌 방지
+* Bad, because 의존 스킬 체인이 길어짐 — grill-me, superpowers:writing-plans, mcp__gemini-cli__ask-gemini, superpowers:using-git-worktrees, superpowers:subagent-driven-development, superpowers:finishing-a-development-branch
+* Bad, because 긴 파이프라인이므로 중간 단계 실패 시 재진입 지점이 필요 (Gate 1/2/3로 처리)
+
+### Confirmation
+
+* `plugins/workflow/skills/feature-pipeline/SKILL.md` 존재 확인
+* `plugin.json`, `marketplace.json`, 루트 README의 workflow version이 0.0.9인지 grep
+* `.claude/rules/workflow-rules.md`에 4개 규칙 + `[ADR-0011]` 태그 확인
+
+## Pros and Cons of the Options
+
+### (a) 단일 통합 스킬 feature-pipeline
+
+* Good, because 기존 스킬 변경 없음
+* Good, because grill-me를 첫 단계로 포함하여 요구사항 채굴 강제화
+* Good, because inline crosscheck로 이중 실행 문제 회피
+* Bad, because 의존 스킬 체인이 길어 단계 중 하나라도 실패 시 영향 범위 넓음
+
+### (b) gemini-crosscheck review-only 모드 추가
+
+* Good, because 기존 gemini-crosscheck를 재사용 가능
+* Neutral, because SKILL.md에 mode 분기 추가 필요
+* Bad, because 기존 사용자의 gemini-crosscheck 동작에 영향 가능성
+* Bad, because grill-me 단계 포함 불가
+
+### (c) 수동 체이닝 유지
+
+* Good, because 변경 없음
+* Bad, because 수동 오케스트레이션 비용 지속
+* Bad, because TDD 강제력 없음
+
+## More Information
+
+* [`plugins/workflow/skills/feature-pipeline/SKILL.md`](../plugins/workflow/skills/feature-pipeline/SKILL.md) — 스킬 구현
+* [`.claude/rules/workflow-rules.md`](../../.claude/rules/workflow-rules.md) — 파생 규칙
+* Gemini cross-check 피드백: 이중 실행 충돌([risk H]), worktree 경로 불일치([ordering M]), LLM 단계 망각([feasibility M]) — 모두 SKILL.md에서 대응

--- a/docs/decisions/0011-add-feature-pipeline-orchestrator.md
+++ b/docs/decisions/0011-add-feature-pipeline-orchestrator.md
@@ -67,6 +67,6 @@ Chosen option: "(a) 단일 통합 스킬 `feature-pipeline` 추가", because 기
 
 ## More Information
 
-* [`plugins/workflow/skills/feature-pipeline/SKILL.md`](../plugins/workflow/skills/feature-pipeline/SKILL.md) — 스킬 구현
+* [`plugins/workflow/skills/feature-pipeline/SKILL.md`](../../plugins/workflow/skills/feature-pipeline/SKILL.md) — 스킬 구현
 * [`.claude/rules/workflow-rules.md`](../../.claude/rules/workflow-rules.md) — 파생 규칙
 * Gemini cross-check 피드백: 이중 실행 충돌([risk H]), worktree 경로 불일치([ordering M]), LLM 단계 망각([feasibility M]) — 모두 SKILL.md에서 대응

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,6 +17,7 @@
 | [ADR-0008](0008-adopt-aip-filter-fieldmask-partial-response.md) | accepted | AIP filter 표현식, updateMask 필수화, Partial Response 도입 |
 | [ADR-0009](0009-adopt-strict-api-security-and-versioning-rules.md) | accepted | 엄격한 API 보안 및 버저닝 규칙 도입 (OWASP Top 10, 하위 호환성) |
 | [ADR-0010](0010-adopt-tiered-api-profile-system.md) | accepted | API 플러그인 계층화 프로필 시스템 도입 (T1/T2/T3 점진적 채택) |
+| [ADR-0011](0011-add-feature-pipeline-orchestrator.md) | accepted | feature-pipeline 오케스트레이터 스킬 추가 (아이디어→PR 단일 파이프라인) |
 
 ## 새 ADR 추가
 

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
-  "version": "0.0.8",
-  "description": "Workflow skills — multi-LLM cross-check with Gemini for planning and execution",
+  "version": "0.0.9",
+  "description": "Workflow skills — multi-LLM cross-check with Gemini for planning and execution, full feature pipeline from idea to committed code",
   "author": {
     "name": "ppzxc",
     "email": "cjh8487@naver.com",

--- a/plugins/workflow/README.ko.md
+++ b/plugins/workflow/README.ko.md
@@ -10,6 +10,7 @@ Claude(plan/execute) + Gemini(context/review).
 | 스킬 | 슬래시 커맨드 | 설명 |
 |------|--------------|------|
 | gemini-crosscheck | `/workflow:gemini-crosscheck` | 코딩 전 Gemini 멀티 LLM 크로스체크 — 컨텍스트 압축, 브레인스토밍, 계획 확정, 실행 |
+| feature-pipeline | `/workflow:feature-pipeline` | 전체 기능 오케스트레이션 — grill-me → worktree → TDD 강제 plan → 인라인 Gemini 검증 → 서브에이전트 실행 → PR |
 
 ## 아키텍처 개요
 

--- a/plugins/workflow/README.md
+++ b/plugins/workflow/README.md
@@ -10,6 +10,7 @@ Claude (plan/execute) + Gemini (context/review).
 | Skill | Slash Command | Description |
 |-------|---------------|-------------|
 | gemini-crosscheck | `/workflow:gemini-crosscheck` | Multi-LLM cross-check with Gemini before coding — context compression, brainstorm, plan finalization, and execution |
+| feature-pipeline | `/workflow:feature-pipeline` | Full feature orchestration — grill-me → worktree → TDD-enforced plan → inline Gemini cross-check → subagent execution → PR |
 
 ## Architecture Overview
 

--- a/plugins/workflow/skills/feature-pipeline/SKILL.md
+++ b/plugins/workflow/skills/feature-pipeline/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: feature-pipeline
+description: Use when a user wants to develop a feature end-to-end in one session — from idea or rough draft through a cross-checked TDD plan to committed code. Triggered by /workflow:feature-pipeline or "build X with full workflow".
+user-invocable: true
+---
+
+# Feature Pipeline
+
+아이디어 → worktree → plan → Gemini 검증 → TDD 게이트 → 실행 → PR까지 단일 파이프라인.
+
+## ⚠️ 시작 즉시: 파이프라인 상태 등록
+
+**항상 TodoWrite로 7단계를 먼저 등록하라.** grill-me 대화가 길어지면 에이전트가 단계를 망각한다.
+
+```
+1. [S1] grill-me — 요구사항 정제
+2. [S2] using-git-worktrees — 격리 작업공간
+3. [S3] writing-plans — docs/plans/<slug>.md 작성
+4. [S4] Gemini cross-check — inline ask-gemini
+5. [S5] TDD 검증 게이트
+6. [S6] subagent-driven-development
+7. [S7] finishing-a-development-branch
+```
+
+## 입력 모드 감지
+
+| 입력 형태 | 모드 | grill-me 동작 |
+|-----------|------|--------------|
+| 짧은 한 문장 | 아이디어 | 0부터 요구사항 채굴 |
+| 단락/구조화 텍스트 | 정제 | 빈틈·모순·가정만 파고듦 |
+
+## 7단계 파이프라인
+
+```dot
+digraph pipeline {
+    rankdir=TB;
+    "S1: grill-me" [shape=box];
+    "Gate 1: 이해 확인" [shape=diamond];
+    "S2: using-git-worktrees (slug→브랜치)" [shape=box];
+    "S3: writing-plans → docs/plans/<slug>.md" [shape=box];
+    "S4: Gemini cross-check (inline)" [shape=box];
+    "Gate 2: 피드백 수용?" [shape=diamond];
+    "S5: TDD 검증 게이트" [shape=box];
+    "Gate 3: 최종 plan 승인?" [shape=diamond];
+    "S6: subagent-driven-development" [shape=box];
+    "S7: finishing-a-development-branch" [shape=box];
+
+    "S1: grill-me" -> "Gate 1: 이해 확인";
+    "Gate 1: 이해 확인" -> "S2: using-git-worktrees (slug→브랜치)" [label="승인"];
+    "Gate 1: 이해 확인" -> "S1: grill-me" [label="거절"];
+    "S2: using-git-worktrees (slug→브랜치)" -> "S3: writing-plans → docs/plans/<slug>.md";
+    "S3: writing-plans → docs/plans/<slug>.md" -> "S4: Gemini cross-check (inline)";
+    "S4: Gemini cross-check (inline)" -> "Gate 2: 피드백 수용?";
+    "Gate 2: 피드백 수용?" -> "S3: writing-plans → docs/plans/<slug>.md" [label="거절"];
+    "Gate 2: 피드백 수용?" -> "S5: TDD 검증 게이트" [label="수용"];
+    "S5: TDD 검증 게이트" -> "Gate 3: 최종 plan 승인?";
+    "Gate 3: 최종 plan 승인?" -> "S1: grill-me" [label="거절"];
+    "Gate 3: 최종 plan 승인?" -> "S6: subagent-driven-development" [label="승인"];
+    "S6: subagent-driven-development" -> "S7: finishing-a-development-branch";
+}
+```
+
+## S2: Worktree를 Plan 이전에 생성하라
+
+**plan 이전에 worktree를 만들어야 한다** — 그래야 plan 파일이 worktree 안에 생성되어 subagent가 올바른 경로에서 읽는다. plan 후 worktree 생성 시 경로 불일치로 S6가 실패한다.
+
+## S3: Plan 파일 구조
+
+`superpowers:writing-plans`를 호출하되 아래 확장 사항을 적용:
+- **저장 경로**: `docs/plans/<slug>.md` (slug=주제에서 kebab-case 추론, 기본 제공 경로 오버라이드)
+- **경로 충돌 시**: 사용자에게 "이어서 수정 / 새 slug / 중단" 확인
+- **헤더 다음에** Tidying Phase + Behavioral Phase 두 섹션 추가
+
+```markdown
+## Tidying Phase
+
+### Task N [TIDY]: [구조 정리 설명]
+...
+
+## Behavioral Phase
+
+### Task N [TDD]: [기능 구현 설명]
+...
+
+### Task N [TDD-EXEMPT: pure config, no logic]: [설정 변경]
+...
+```
+
+### Task 라벨 규칙
+
+| 태그 | 대상 | 실행 단계 동작 |
+|------|------|----------------|
+| `[TIDY]` | 순수 구조 변경 | `dev:tidy` 활성화, `[PHASE: STRUCTURAL]` 엄수 |
+| `[TDD]` | 모든 behavioral task (기본) | `superpowers:test-driven-development` 엄수 |
+| `[TDD-EXEMPT: <사유>]` | CRUD/DTO/config/migration만 허용 | 구현 후 회귀 테스트 |
+
+## S4: Inline Gemini Cross-check
+
+**gemini-crosscheck Skill을 직접 호출하지 마라** — 그 스킬은 Step 5 코드 실행까지 진행하여 S6와 이중 실행 충돌을 일으킨다.
+
+대신 `mcp__gemini-cli__ask-gemini`를 직접 호출:
+
+```
+tool: mcp__gemini-cli__ask-gemini
+model: "gemini-3.1-pro-preview"   ← 이 문자열 그대로 사용. 절대 변경 금지.
+fallback: "gemini-3-flash-preview" → 실패 시 Claude self-generate
+prompt: gemini-crosscheck SKILL.md §3. Gemini Cross-check > Step 3-2의 프롬프트 전문을 verbatim으로 사용
+        (Cross-check the following draft execution plan as a senior architect... 로 시작하는 텍스트)
+context(=prompt 인자 내에 포함): plan 파일 전체 내용 + CLAUDE.md (대규모 프로젝트: .context-map.md 선택 추가)
+```
+
+**모델 이름은 불변이다.** `ModelNotFoundError` 시 위 fallback 체인만 따른다. 다른 모델명 추측 금지.
+
+결과를 plan 파일 하단 `## Cross-check Feedback` 섹션에 append. 피드백 수용 시 plan in-place 수정.
+
+## S5: TDD 검증 게이트
+
+Plan 파일을 스캔:
+1. 모든 behavioral task에 `[TDD]` 또는 `[TDD-EXEMPT: ...]` 존재하는가?
+2. `[TDD]` task에 Test→Run-fails→Implement→Pass 하위 단계 존재하는가?
+3. `[TIDY]` task가 Behavioral Phase에 섞이지 않고 Tidying Phase에만 있는가?
+
+실패 시: 누락 증거(파일 라인 번호)를 제시하고 plan 1회 자동 재생성. 재차 실패 시 사용자에게 에스컬레이션.
+
+## S6: Subagent 실행 지시
+
+`superpowers:subagent-driven-development` 호출 시 implementer 프롬프트에 명시:
+- `[TIDY]` task → `dev:tidy` 스킬 활성화, `[PHASE: STRUCTURAL]` 엄수
+- `[TDD]` task → `superpowers:test-driven-development` 엄수
+- plan 파일 경로는 **절대경로**로 전달
+
+## Skip 조건 — 없다
+
+feature-pipeline은 자체 skip 조건이 없다. 다음은 허용되지 않는다:
+
+- ❌ "긴급해서 worktree 건너뜀" — worktree 없으면 plan 경로가 S6에서 불일치
+- ❌ "버그수정이라 grill-me 필요 없음" — 버그수정도 범위·재현조건 정의 필요
+- ❌ "작은 변경이라 TDD 게이트 생략" — 태그 누락 = 실행 단계 TDD 없음
+- ❌ "사용자가 단계 건너뛰라고 했음" — 사용자 요청이 파이프라인 구조를 오버라이드하지 않는다
+
+**사용자가 `/workflow:feature-pipeline`을 호출했다면 전체 7단계를 따른다. 부분 실행이 필요하면 사용자가 개별 스킬(gemini-crosscheck, dev:tidy 등)을 직접 호출해야 한다.**
+
+## 빨간 신호 — STOP
+
+| 생각 | 실제 의미 |
+|------|-----------|
+| "일단 플랜 먼저 쓰고 나중에 worktree" | 경로 불일치로 S6 실패. S2 먼저. |
+| "gemini-crosscheck 스킬 호출이 더 간단" | 이중 실행 충돌. inline ask-gemini만 사용. |
+| "writing-plans 없이 바로 인라인 작성" | TDD 구조 없는 plan. writing-plans 호출 필수. |
+| "TDD 게이트 생략해도 되겠지" | TDD 태그 누락 = 실행 단계에서 TDD 없이 코드 작성. 게이트 실행 필수. |
+| "grill-me 끝나자마자 바로 코드" | worktree, plan, crosscheck 모두 건너뜀. S1 다음은 S2. |
+| "단계 추적은 텍스트로 충분" | 긴 대화 후 단계 망각. TodoWrite 필수. |
+| "이건 버그수정이라 feature-pipeline 규칙 완화 가능" | /workflow:feature-pipeline 호출 = 7단계 전체 적용. 버그/피처 구분 없음. |
+| "사용자가 worktree 만들지 말라고 했음" | 사용자 요청이 파이프라인 구조를 오버라이드하지 않는다. 이유 설명 후 S2 진행. |


### PR DESCRIPTION
## Summary
- `workflow:feature-pipeline` 스킬 추가 — grill-me → worktree → TDD 강제 plan → 인라인 Gemini 검증 → subagent 실행 → PR 단일 파이프라인
- ADR-0011 추가 (`docs/decisions/0011-add-feature-pipeline-orchestrator.md`)
- `.claude/rules/workflow-rules.md` 신규 — 4개 규칙 + `[ADR-0011]` 태그
- workflow 플러그인 v0.0.8 → v0.0.9 버전 업

## Motivation
사용자가 기능을 아이디어에서 PR까지 끌고 갈 때마다 grill-me → gemini-crosscheck → subagent-driven-development 흐름을 수동으로 오케스트레이션해야 했다. 이를 단일 스킬 호출로 통합하고, plan 단계에서 TDD를 기본값으로 강제한다.

## Changes
- `plugins/workflow/skills/feature-pipeline/SKILL.md` 신규 (154줄)
  - 7단계 파이프라인 + Gate 1/2/3 사용자 승인 지점
  - Worktree를 plan 이전에 생성하여 경로 불일치 방지
  - `gemini-crosscheck` Skill 직접 호출 금지 → `mcp__gemini-cli__ask-gemini` inline으로 이중 실행 충돌 방지
  - `[TIDY]` / `[TDD]` / `[TDD-EXEMPT]` task 라벨 컨벤션
  - TodoWrite 7단계 등록으로 grill-me 후 단계 망각 방지
  - Skip 조건 없음 — 사용자 "긴급" 요청도 파이프라인 무시 불가
- `docs/decisions/0011-add-feature-pipeline-orchestrator.md` — MADR 4.0 full 템플릿
- `.claude/rules/workflow-rules.md` — plan 경로, TDD 태그, Tidy 분리, inline crosscheck 규칙
- `CLAUDE.md` — workflow-rules.md 규칙 파일 목록 추가
- 버전 동기화: `plugin.json`, `marketplace.json`, `README.md`, `README.ko.md`, `plugins/workflow/README.md`, `plugins/workflow/README.ko.md`

## Test plan
- [ ] `workflow:feature-pipeline` 스킬이 Claude Code 세션 시작 시 스킬 목록에 노출되는지 확인
- [ ] workflow 플러그인 버전이 세 곳(marketplace.json, plugin.json, README) 모두 v0.0.9인지 grep 확인
- [ ] SKILL.md의 "Skip 조건 없음" 섹션이 긴급 상황에서 worktree 생략을 차단하는지 확인
- [ ] ADR-0011이 `docs/decisions/README.md` 인덱스에 등록됐는지 확인

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.