### PR TITLE
docs(api): bump version to 0.2.1 and tier guidelines

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "api",
       "source": "./plugins/api",
       "description": "RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, and non-CRUD action endpoints",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "name": "docs",

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,7 +8,7 @@
 
 | 플러그인 | 버전 | 설명 |
 |--------|------|------|
-| [api](./plugins/api) | v0.2.0 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
+| [api](./plugins/api) | v0.2.1 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
 | [docs](./plugins/docs) | v0.0.4 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
 | [git](./plugins/git) | v0.0.8 | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
 | [workflow](./plugins/workflow) | v0.0.13 | 워크플로우 스킬 — Gemini 멀티 LLM 크로스체크 + 아이디어에서 커밋까지 전체 파이프라인 오케스트레이션 |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 
 | Plugin | Version | Description |
 |--------|---------|-------------|
-| [api](./plugins/api) | v0.2.0 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
+| [api](./plugins/api) | v0.2.1 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
 | [docs](./plugins/docs) | v0.0.4 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
 | [git](./plugins/git) | v0.0.8 | Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
 | [workflow](./plugins/workflow) | v0.0.13 | Workflow skills — Gemini multi-LLM cross-check + full feature pipeline orchestration (grill → plan → verify → execute) |

--- a/plugins/api/.claude-plugin/plugin.json
+++ b/plugins/api/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "RESTful API design guidelines skill — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, and non-CRUD action endpoints",
   "author": {
     "name": "ppzxc",

--- a/plugins/api/README.ko.md
+++ b/plugins/api/README.ko.md
@@ -1,4 +1,4 @@
-# RESTful API Guidelines
+# RESTful API 설계 가이드라인
 
 > [English](README.md)
 
@@ -6,43 +6,48 @@ RESTful API 설계 가이드라인이다.
 
 ---
 
+## 프로필 가이드 (Profile Guide)
+
+각 규칙에는 `[T1]`, `[T2]`, `[T3]` 태그가 붙어 있다. 사용자가 프로필을 지정하면 해당 티어(Tier) 이하의 규칙만 적용한다.
+
+| 프로필 | 포함 티어 | 대상 | 규칙 수 |
+|--------|-----------|------|---------|
+| **Essential** | T1 전용 | 모든 API — 첫날부터 적용 | ~87 |
+| **Standard** | T1 + T2 | 프로덕션 운영 단계 | ~121 |
+| **Full** | T1 + T2 + T3 | 대규모/엔터프라이즈 API | ~146 |
+
+**티어 분류 기준 (ADR-0010):**
+- **T1 (Essential):** 후행 도입 시 하위 호환성 파괴 위험 / 보안 필수 / HTTP 표준 / API 계약의 근간
+- **T2 (Standard):** 프로덕션 운영 편의, 후행 도입 가능
+- **T3 (Full):** 엔터프라이즈/고급 패턴, 특정 도메인 한정
+
+---
+
 ## 목차
 
 1. [개요](#1-개요)
    - [규범 수준 표기](#규범-수준-표기)
-2. [REST Basics](#2-rest-basics)
-   - [URL 설계](#21-url-설계)
-   - [HTTP 메서드 & 상태 코드](#22-http-메서드--상태-코드)
-   - [쿼리 파라미터](#23-쿼리-파라미터)
-   - [HTTP 헤더](#24-http-헤더)
-   - [JSON 데이터 포맷](#25-json-데이터-포맷)
-   - [에러 응답](#26-에러-응답)
-3. [REST Design](#3-rest-design)
-   - [리소스 스키마 & 필드 규칙](#31-리소스-스키마--필드-규칙)
-   - [CRUD 처리](#32-crud-처리)
-   - [액션](#33-액션)
-   - [컬렉션 & 페이지네이션](#34-컬렉션--페이지네이션)
-   - [필터링 & 정렬](#35-필터링--정렬)
-   - [Partial Response](#36-partial-response)
-   - [Expand/Embed](#37-expandembed)
-   - [Bulk Operations](#38-bulk-operations)
-4. [API 운영](#4-api-운영)
-   - [4.1 API 버전 관리](#41-api-버전-관리)
-   - [4.2 Deprecation](#42-deprecation)
-   - [4.3 속도 제한](#43-속도-제한)
-   - [4.4 장기 실행 작업](#44-장기-실행-작업)
-   - [4.5 Idempotency-Key](#45-idempotency-key)
-5. [인증 & 보안](#5-인증--보안)
-   - [5.1 인증 방식](#51-인증-방식)
-   - [5.2 401 vs 403 구분](#52-401-vs-403-구분)
-   - [5.3 Webhooks](#53-webhooks)
-6. [Health Check](#6-health-check)
-7. [OpenAPI Specification](#7-openapi-specification)
-   - [7.1 API First](#71-api-first)
-   - [7.2 스펙 품질](#72-스펙-품질)
-   - [7.3 스키마 매핑](#73-스키마-매핑)
-   - [7.4 확장 & 검증](#74-확장--검증)
-8. [참고 자료](#7-참고-자료)
+2. [URL 설계](#2-url-설계)
+3. [HTTP 메서드 & 상태 코드](#3-http-메서드--상태-코드)
+4. [HTTP 헤더](#4-http-헤더)
+5. [JSON 데이터 포맷](#5-json-데이터-포맷)
+6. [에러 응답](#6-에러-응답)
+7. [리소스 스키마 & 필드 규칙](#7-리소스-스키마--필드-규칙)
+8. [CRUD 처리](#8-crud-처리)
+9. [액션](#9-액션)
+10. [컬렉션 & 페이지네이션](#10-컬렉션--페이지네이션)
+11. [필터링 & 정렬](#11-필터링--정렬)
+12. [Partial Response & 리소스 확장](#12-partial-response--리소스-확장)
+13. [일괄 작업 (Bulk Operations)](#13-일괄-작업-bulk-operations)
+14. [API 버전 관리](#14-api-버전-관리)
+15. [Deprecation](#15-deprecation)
+16. [속도 제한 & 재시도](#16-속도-제한--재시도)
+17. [캐싱](#17-캐싱)
+18. [장기 실행 작업](#18-장기-실행-작업)
+19. [Idempotency-Key](#19-idempotency-key)
+20. [OpenAPI 스펙](#20-openapi-스펙)
+21. [인증 & 보안](#21-인증--보안)
+22. [참고 자료](#22-참고-자료)
 
 ---
 
@@ -55,13 +60,8 @@ RESTful API 설계 가이드라인이다.
   - 직관적으로 이해 가능해야 한다.
   - 오류 발생 시 명확한 메시지를 제공해야 한다.
   - 버전이 바뀌어도 하위 호환성을 유지해야 한다.
-- Roy Fielding의 RESTful 원칙 ([Architectural Styles and the Design of Network-based Software Architectures](https://roy.gbiv.com/pubs/dissertation/fielding_dissertation.pdf))을 참고한다.
+- Roy Fielding의 RESTful 원칙을 따른다.
   - HATEOAS는 구현하지 않는다.
-
-### 적용 범위
-
-- 조직 내 신규 개발되는 모든 HTTP/HTTPS API
-- 기존 API 개선 시 가능한 한 적용
 
 ### 규범 수준 표기
 
@@ -75,1528 +75,304 @@ RESTful API 설계 가이드라인이다.
 
 ---
 
-## 2. REST Basics
+## 2. URL 설계
 
-### 2.1 URL 설계
+- **리소스 중심 설계** — API는 리소스(명사)를 중심으로 설계한다. URL 경로는 리소스 계층 구조를 표현하며, 행위는 HTTP 메서드와 커스텀 메서드로 표현한다.
+- 모든 리소스는 최소한 GET(조회)을 지원해야 한다. `[T1]`
+- **표준 메서드**(GET, POST, PATCH, DELETE)를 우선하며, 표준 메서드로 표현할 수 없는 경우에만 커스텀 메서드를 사용한다. `[T1]`
+- 데이터베이스 구조를 API 스키마에 그대로 노출하지 않는다. `[T1]`
 
-#### 기본 구조
+- **kebab-case** 사용: `/user-profiles`, `/product-categories/123`. `[T1]`
+- 컬렉션 이름은 **복수형 명사** 사용: `/articles` (O), `/article` (X). `[T1]`
+- **경로에 동사 포함 금지** — CRUD는 HTTP 메서드로, 그 외의 액션은 `POST`와 콜론(`:`) 구문을 사용한다 (리소스 수준: `/{resource}/{id}:{action}`, 컬렉션 수준: `/{resource}:{action}`). `[T1]`
+- **파일 확장자 금지** (`.json`, `.xml`). `[T1]`
+- **Trailing slash 금지** — `/articles/` 대신 `/articles`를 사용한다. `[T1]`
+- **camelCase** 쿼리 파라미터 사용: `pageSize=20&sortOrder=desc`. `[T1]`
+- 경로 세그먼트에는 ASCII 영소문자, 숫자, 하이픈만 사용한다. `[T1]`
+- 배열 값은 파라미터 이름을 반복하여 전달한다: `?tag=tech&tag=design`. `[T1]`
+- **서브리소스 중첩 제한** — 최대 1단계까지만 중첩한다: `/{parent}/{parentId}/{child}/{childId}`. `[T2]`
 
-```
-https://{host}/{service-root}/{resource}/{id}
-https://{host}/{service-root}/{resource}/{id}/{sub-resource}/{sub-id}
-```
-
-예시:
-
-```
-# 단일 리소스
-GET https://api.example.com/orders/550e8400-e29b-41d4-a716-446655440000
-
-# 중첩 서브리소스 (최대 깊이)
-GET https://api.example.com/orders/550e8400-e29b-41d4-a716-446655440000/items/6ba7b810-9dad-11d1-80b4-00c04fd430c8
-```
-
-#### URL 케이싱
-
-✅ **필수**: URL 경로에는 소문자 kebab-case를 사용한다.
-
-```
-# Good
-GET /user-profiles
-GET /product-categories/123
-
-# Bad
-GET /userProfiles
-GET /UserProfiles
-GET /user_profiles
-```
-
-✅ **필수**: 리소스 컬렉션 이름은 복수형 명사를 사용한다.
-
-```
-# Good
-GET /articles
-GET /users/123/comments
-
-# Bad
-GET /article
-GET /user/123/comment
-```
-
-❌ **금지**: URL에 동사를 포함하지 않는다. 액션은 HTTP 메서드로 표현한다.
-
-```
-# Bad
-POST /createUser
-GET /getArticles
-DELETE /deleteComment/123
-
-# Good
-POST /users
-GET /articles
-DELETE /comments/123
-```
-
-❌ **금지**: URL에 파일 확장자(`.json`, `.xml`)를 포함하지 않는다. 콘텐츠 협상은 `Accept` 헤더를 사용한다.
-
-#### URL 중첩 깊이
-
-✅ **필수**: URL 중첩은 최대 2단계(리소스/ID/서브리소스/ID)까지 허용한다.
-
-| 깊이 | 패턴 | 예시 | 허용 |
-|------|------|------|------|
-| 0 | `/{resource}` | `/articles` | ✅ |
-| 1 | `/{resource}/{id}` | `/articles/123` | ✅ |
-| 2 | `/{resource}/{id}/{sub}` | `/articles/123/comments` | ✅ |
-| 2 | `/{resource}/{id}/{sub}/{subId}` | `/articles/123/comments/456` | ✅ |
-| 3+ | `/{a}/{id}/{b}/{id}/{c}` | — | ❌ |
-
-❌ **금지**: 3단계 이상 중첩하지 않는다. 깊은 관계는 최상위 리소스로 승격한다.
+**중첩 깊이 규칙:** `[T2]`
+부모 아래에 최대 하나의 서브리소스만 중첩한다. 더 깊은 관계는 최상위 경로로 승격시킨다.
 
 | 상황 | ✅ Do | ❌ Don't |
-|------|-------|---------|
+|-----------|-------|---------|
 | 주문 내 항목 | `/orders/{orderId}/items/{itemId}` | `/users/{userId}/orders/{orderId}/items/{itemId}` |
-| 주문 항목의 리뷰 | `/order-items/{itemId}/reviews/{reviewId}` | `/users/{userId}/orders/{orderId}/items/{itemId}/reviews/{reviewId}` |
+| 주문 항목의 리뷰 | `/order-items/{orderItemId}/reviews/{reviewId}` | `/users/{userId}/orders/{orderId}/items/{itemId}/reviews/{reviewId}` |
 
 ---
 
-#### 허용 문자
+## 3. HTTP 메서드 & 상태 코드
 
-✅ **필수**: URL 경로 세그먼트에는 ASCII 영소문자, 숫자, 하이픈(`-`)만 사용한다.
+| 메서드 | 용도 | 멱등성 | 안전성 |
+|--------|---------|-----------|------|
+| GET | 조회 | ✅ | ✅ |
+| POST | 생성 / 커스텀 메서드 실행 | ❌ | ❌ |
+| PUT | 전체 내용 대체 (파일/바이너리 업로드 등) | ✅ | ❌ |
+| PATCH | 부분 수정 (기본 수정 메서드) | ❌ | ❌ |
+| DELETE | 삭제 | ✅ | ❌ |
+| HEAD | 메타데이터만 조회 (본문 없음) | ✅ | ✅ |
+| OPTIONS | 허용된 메서드/CORS 정보 조회 | ✅ | ✅ |
 
-✅ **필수**: 쿼리 파라미터 이름은 camelCase를 사용한다.
+- **HEAD:** 클라이언트는 전체 본문을 다운로드하지 않고 리소스 존재 여부나 수정 시각을 확인하기 위해 HEAD를 사용해야 한다. `[T2]`
+- **OPTIONS:** 서버는 CORS 프리플라이트를 위해 OPTIONS를 지원해야 하며, `Allow` 헤더를 통해 지원 메서드를 명시해야 한다. `[T2]`
+- GET, HEAD, DELETE 요청에는 요청 본문(body)을 포함하지 않는다. `[T1]`
 
-```
-# Good
-GET /articles?pageSize=20&sortOrder=desc
+**2xx 성공:**
+- `200 OK` — 표준 성공. `[T1]`
+- `201 Created` — 생성 성공; `Location` 헤더에 새 리소스 URL을 포함한다. `[T1]`
+- `202 Accepted` — 요청 접수됨, 처리 미완료; 비동기 작업 등에 사용한다. `[T2]`
+- `204 No Content` — 성공했으나 응답 본문 없음 (DELETE 등). `[T1]`
 
-# Bad
-GET /articles?page_size=20&sort_order=desc
-```
+**4xx 클라이언트 오류:**
+- `400 Bad Request` — 잘못된 요청, 유효성 검사 실패. `[T1]`
+- `401 Unauthorized` — 인증 누락 또는 만료. `[T1]`
+- `403 Forbidden` — 인증되었으나 권한 없음. `[T1]`
+- `404 Not Found` — 리소스 존재하지 않음. `[T1]`
+- `409 Conflict` — 리소스 중복 (ID 중복 또는 유니크 제약 위반). `[T1]`
+- `412 Precondition Failed` — `If-Match` ETag 불일치 (조건부 요청 실패). `[T1]`
+- `422 Unprocessable Entity` — 의미론적 유효성 검사 실패. `[T1]`
+- `429 Too Many Requests` — 속도 제한 초과. `[T1]`
 
----
-
-#### URL 길이
-
-⚠️ **권장**: URL은 2000자 이하로 유지한다. 그 이상이 필요한 경우 쿼리 파라미터를 요청 본문으로 이동하는 것을 고려한다.
-
----
-
-### 2.2 HTTP 메서드 & 상태 코드
-
-#### HTTP 메서드
-
-| 메서드 | 의미 | 멱등성 | 안전성 |
-|--------|------|--------|--------|
-| GET | 리소스 조회 | ✅ | ✅ |
-| POST | 리소스 생성 또는 액션 수행 | ❌ | ❌ |
-| PUT | 리소스 완전 대체 | ✅ | ❌ |
-| PATCH | 리소스 부분 수정 | ❌ | ❌ |
-| DELETE | 리소스 삭제 | ✅ | ❌ |
-| HEAD | 헤더만 조회 | ✅ | ✅ |
-
-✅ **필수**: GET 요청은 서버 상태를 변경하지 않는다.
-
-✅ **필수**: PUT 요청은 멱등적으로 동작한다 — 같은 요청을 여러 번 보내도 결과가 동일해야 한다.
-
-⚠️ **권장**: 부분 수정에는 PUT 대신 PATCH를 사용한다.
-
-❌ **금지**: GET, HEAD, DELETE 요청에 요청 본문(body)을 포함하지 않는다.
-
-#### 상태 코드
-
-✅ **필수**: 아래 표준 HTTP 상태 코드를 정확한 의미에 맞게 사용한다.
-
-**2xx 성공**
-
-| 코드 | 의미 | 사용 시점 |
-|------|------|-----------|
-| 200 OK | 성공 | GET, PUT, PATCH, POST(액션) 성공 |
-| 201 Created | 생성됨 | POST로 리소스 생성 성공 |
-| 204 No Content | 내용 없음 | DELETE 성공, 응답 본문 없음 |
-
-**4xx 클라이언트 오류**
-
-| 코드 | 의미 | 사용 시점 |
-|------|------|-----------|
-| 400 Bad Request | 잘못된 요청 | 요청 형식 오류, 유효성 검사 실패 |
-| 401 Unauthorized | 인증 필요 | 인증 토큰 없음 또는 만료 |
-| 403 Forbidden | 접근 금지 | 인증은 되었지만 권한 없음 |
-| 404 Not Found | 찾을 수 없음 | 리소스 존재하지 않음 |
-| 409 Conflict | 충돌 | 중복 리소스, 낙관적 잠금 실패 |
-| 422 Unprocessable Entity | 처리 불가 | 의미론적 유효성 검사 실패 |
-| 429 Too Many Requests | 요청 과다 | 속도 제한 초과 |
-
-**5xx 서버 오류**
-
-| 코드 | 의미 | 사용 시점 |
-|------|------|-----------|
-| 500 Internal Server Error | 서버 오류 | 예기치 못한 서버 오류 |
-| 503 Service Unavailable | 서비스 불가 | 일시적 서버 과부하 또는 유지보수 |
-
-✅ **필수**: 201 Created 응답에는 `Location` 헤더로 생성된 리소스의 URL을 포함한다.
-
-```
-HTTP/1.1 201 Created
-Location: https://api.example.com/users/articles/456
-Content-Type: application/json
-
-{
-  "id": "456",
-  "title": "새 글 제목"
-}
-```
-
-❌ **금지**: 오류 상황에 200 OK를 반환하지 않는다.
+**5xx 서버 오류:**
+- `500 Internal Server Error` — 서버 내부 오류. `[T1]`
+- `503 Service Unavailable` — 일시적 서비스 중단. `[T1]`
 
 ---
 
-### 2.3 쿼리 파라미터
+## 4. HTTP 헤더
 
-✅ **필수**: 쿼리 파라미터 이름은 camelCase를 사용한다.
-
-✅ **필수**: 동일한 파라미터 이름을 반복하여 배열 값을 전달한다.
-
-```
-GET /articles?tag=tech&tag=design
-```
-
-⚠️ **권장**: 쿼리 파라미터는 선택적(optional)으로 설계한다. 필수 값은 경로(path)에 포함한다.
-
-⚠️ **권장**: 쿼리 파라미터에 민감한 정보(비밀번호, 토큰 등)를 포함하지 않는다. 이는 서버 로그에 기록될 수 있다.
-
-❌ **금지**: 서버 상태를 변경하는 작업에 쿼리 파라미터를 사용하지 않는다.
+- 본문이 있는 경우 `Content-Type: application/json` 필수. `[T1]`
+- 콘텐츠 협상을 위해 `Accept: application/json` 사용. `[T1]`
+- 201 Created 응답 시 `Location` 헤더 필수. `[T1]`
+- 컬렉션 크기 제공 시 `Total-Count` 헤더 사용. `[T2]`
+- 페이지네이션 네비게이션을 위해 RFC 8288 `Link` 헤더 사용. `[T2]`
+- **커스텀 헤더에 `X-` 접두사 금지** (RFC 6648) — 모든 신규 커스텀 헤더는 접두사 없이 정의한다. `[T1]`
+- 캐싱 전략 명시를 위해 `Cache-Control` 헤더 사용. `[T2]`
+- **Request-Id 헤더:** 서버는 모든 응답에 고유한 요청 식별자(UUID v4)를 포함해야 한다. `[T1]`
+- **ETag:** 리소스 버전을 나타내는 불투명 문자열; 서버 응답에 포함한다. `[T1]`
+- **If-Match:** 클라이언트는 낙관적 동시성 제어를 위해 수정/삭제 요청 시 ETag 값을 전송한다. `[T1]`
 
 ---
 
-### 2.4 HTTP 헤더
+## 5. JSON 데이터 포맷
 
-#### 요청 헤더
+- **camelCase** 필드 이름 사용: `userId`, `createdAt`, `isActive`. `[T1]`
+- snake_case나 약어를 사용하지 않는다. `[T1]`
+- 값이 `null`이거나 없는 필드는 응답에서 완전히 제외한다. `[T1]`
+- 날짜/시간은 RFC 3339 문자열로 표현하며, 서버 응답은 항상 UTC(`Z`)를 사용한다. `[T1]`
+- 표준 리소스 필드: `id`, `createdAt` (생성 전용), `updatedAt` (읽기 전용). `[T1]`
+- 서버는 요청 본문에 포함된 읽기 전용 필드를 무시해야 한다. `[T1]`
 
-✅ **필수**: 요청 본문이 있는 경우 `Content-Type` 헤더를 포함한다.
-
-```
-Content-Type: application/json
-```
-
-⚠️ **권장**: 응답 형식 협상을 위해 `Accept` 헤더를 사용한다.
-
-```
-Accept: application/json
-```
-
-#### 응답 헤더
-
-✅ **필수**: 응답 본문이 있는 경우 `Content-Type` 헤더를 포함한다.
-
-⚠️ **권장**: 캐싱 전략을 명시하기 위해 `Cache-Control` 헤더를 사용한다.
-
-```
-Cache-Control: no-cache
-Cache-Control: max-age=3600
-```
-
-⚠️ **권장**: 컬렉션 페이지네이션 응답에는 RFC 8288 `Link` 헤더를 사용한다.
-
-```
-Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next",
-      <https://api.example.com/articles?pageSize=20>; rel="first"
-```
-
-⚠️ **권장**: 전체 항목 수를 제공할 때 `Total-Count` 헤더를 사용한다.
-
-```
-Total-Count: 100
-```
-
-#### 커스텀 헤더
-
-⚠️ **권장**: 커스텀 헤더 이름은 `X-` 접두사 없이 명확한 이름을 사용한다. RFC 6648(2012)에서 `X-` 접두사는 deprecated됐다.
-
-```
-Request-Id: abc-123
-Correlation-Id: xyz-789
-```
-
-> **참고**: `X-Request-Id`, `X-Correlation-Id` 등 기존에 사실상 표준처럼 굳어진 헤더는 레거시 호환을 위해 허용된다. 신규 커스텀 헤더에는 `X-` 접두사를 붙이지 않는다.
-
-#### 요청 추적
-
-✅ **필수**: 모든 응답에 `Request-Id` 헤더(UUID v4)를 포함한다.
-
-```
-Request-Id: 550e8400-e29b-41d4-a716-446655440000
-```
-
-- 클라이언트가 `Request-Id`를 전송하면 서버는 이를 수용하거나 새로 생성한다
-- 마이크로서비스 간 `Request-Id`를 전파하여 분산 추적에 활용한다
-- 모든 서비스 로그에 `Request-Id`를 포함하여 디버깅 상관관계를 확보한다
-- 에러 응답(RFC 9457)의 `traceId` 필드는 `Request-Id` 헤더 값과 일치해야 한다
-
-❌ **금지**: 표준 HTTP 헤더의 의미를 재정의하지 않는다.
+**상태 Enum 패턴 (AIP-216):** `[T1]`
+- 상태 필드 이름은 반드시 `state`로 한다 (`status` 아님).
+- 첫 번째 Enum 값은 항상 `STATE_UNSPECIFIED`여야 한다.
+- `state`는 OUTPUT_ONLY이며, 커스텀 메서드를 통해서만 전이된다.
 
 ---
 
-### 2.5 JSON 데이터 포맷
+## 6. 에러 응답
 
-#### 필드 네이밍
-
-✅ **필수**: JSON 필드 이름은 camelCase를 사용한다.
-
-```json
-// Good
-{
-  "userId": "123",
-  "createdAt": "2024-01-20T10:00:00Z",
-  "isActive": true
-}
-
-// Bad
-{
-  "user_id": "123",
-  "created_at": "2024-01-20T10:00:00Z",
-  "is_active": true
-}
-```
-
-✅ **필수**: 필드 이름은 영소문자로 시작한다.
-
-❌ **금지**: 필드 이름에 약어를 남용하지 않는다. 명확한 전체 단어를 우선한다.
-
-```json
-// Bad
-{
-  "usr": "john",
-  "ts": "2024-01-20T10:00:00Z",
-  "cnt": 5
-}
-
-// Good
-{
-  "username": "john",
-  "timestamp": "2024-01-20T10:00:00Z",
-  "count": 5
-}
-```
-
-#### 타입 시스템
-
-##### Boolean
-
-✅ **필수**: Boolean 값에는 JSON `true`/`false`를 사용한다. 문자열 `"true"`/`"false"` 또는 숫자 `1`/`0`을 사용하지 않는다.
-
-✅ **필수**: Boolean 필드 이름은 `is`, `has`, `can` 등의 접두사를 사용한다.
-
-```json
-{
-  "isActive": true,
-  "hasPermission": false,
-  "canEdit": true
-}
-```
-
-##### Number
-
-✅ **필수**: 숫자 값은 JSON number 타입을 사용한다.
-
-⚠️ **권장**: JavaScript의 안전한 정수 범위(2^53 - 1)를 초과하는 큰 정수는 문자열로 반환한다.
-
-```json
-{
-  "count": 42,
-  "price": 19.99,
-  "largeId": "9007199254740993"
-}
-```
-
-##### String
-
-⚠️ **권장**: 빈 문자열(`""`)과 `null`을 구분하여 사용한다. 의미 있는 "값 없음"에는 필드를 제외하고, 의도적으로 빈 값임을 나타낼 때만 빈 문자열을 사용한다.
-
-#### 날짜와 시간
-
-✅ **필수**: 모든 날짜/시간 값은 RFC 3339 형식(ISO 8601 프로파일)의 문자열로 표현한다.
-
-✅ **필수**: 시간대(timezone)가 있는 경우 반드시 포함한다. UTC인 경우 `Z`를 사용한다.
-
-✅ **필수**: 서버 응답의 모든 시간 값은 UTC(`Z`)로 반환한다. 클라이언트가 로컬 시간대로 변환한다.
-
-⚠️ **권장**: 클라이언트 요청의 시간 값도 UTC(`Z`)로 전송한다. 오프셋이 포함된 경우 서버가 UTC로 정규화하여 저장한다.
-
-⚠️ **권장**: 날짜만 필요한 필드(생년월일 등)는 `YYYY-MM-DD` 형식을 사용하며 시간대를 포함하지 않는다.
-
-❌ **금지**: Unix timestamp(epoch milliseconds/seconds)를 기본 시간 형식으로 사용하지 않는다.
-
-##### 서버 응답 예시
-
-```json
-{
-  "createdAt": "2024-01-20T10:00:00Z",
-  "scheduledAt": "2024-01-25T00:30:00Z",
-  "birthDate": "1990-05-15"
-}
-```
-
-##### 클라이언트 요청 예시
-
-```json
-// ⚠️ 권장: UTC
-{ "scheduledAt": "2024-01-25T00:30:00Z" }
-
-// 허용: 오프셋 포함 → 서버가 UTC로 정규화 저장
-{ "scheduledAt": "2024-01-25T09:30:00+09:00" }
-```
-
-##### 서버 정규화 규칙
-
-✅ **필수**: 클라이언트가 오프셋이 포함된 시간을 전송하면, 서버는 이를 UTC로 변환하여 저장한다. 에러를 반환하지 않는다.
-
-✅ **필수**: 서버가 정규화한 후의 응답은 항상 UTC(`Z`)로 반환한다.
-
-⚠️ **권장**: 시간대 정보가 비즈니스적으로 중요한 경우(예: 사용자의 원래 시간대 보존), 별도의 `timeZone` 필드를 사용한다.
-
-```json
-{
-  "scheduledAt": "2024-01-25T00:30:00Z",
-  "timeZone": "Asia/Seoul"
-}
-```
-
-#### Enum 처리
-
-✅ **필수**: Enum 값은 UPPER_SNAKE_CASE 문자열을 사용한다.
-
-```json
-{
-  "status": "PUBLISHED",
-  "priority": "HIGH"
-}
-```
-
-⚠️ **권장**: 클라이언트가 알 수 없는 Enum 값을 수신할 수 있도록 설계한다. 새로운 Enum 값이 추가될 때 기존 클라이언트가 깨지지 않도록 처리한다.
-
-❌ **금지**: Enum 값으로 숫자나 불명확한 약어를 사용하지 않는다.
-
-```json
-// Bad
-{
-  "status": 1,
-  "priority": "hi"
-}
-
-// Good
-{
-  "status": "PUBLISHED",
-  "priority": "HIGH"
-}
-```
-
----
-
-### 2.6 에러 응답
-
-#### 에러 응답 구조
-
-✅ **필수**: 모든 에러 응답은 RFC 7807 / RFC 9457 (Problem Details for HTTP APIs) 표준을 따른다.
-
-✅ **필수**: 에러 응답의 `Content-Type`은 `application/problem+json`을 사용한다.
-
-```json
-{
-  "type": "https://api.example.com/errors/resource-not-found",
-  "title": "리소스를 찾을 수 없음",
-  "status": 404,
-  "detail": "요청한 게시글을 찾을 수 없습니다.",
-  "instance": "/articles/999",
-  "traceId": "abc-123-xyz"
-}
-```
-
-| 필드 | 필수 여부 | 설명 |
-|------|-----------|------|
-| `type` | ✅ 필수 | 에러 유형을 식별하는 URI (문서 링크 역할, `about:blank` 허용) |
-| `title` | ✅ 필수 | 에러 유형의 짧은 요약 (사람이 읽을 수 있는 텍스트) |
-| `status` | ✅ 필수 | HTTP 상태 코드 (숫자) |
-| `detail` | ✅ 필수 | 이 요청에 대한 구체적인 에러 설명 (사용자가 이해할 수 있는 언어) |
-| `instance` | ⚠️ 권장 | 문제가 발생한 요청 경로 |
-| `errors` | ⚠️ 권장 | 확장 필드 — 필드 수준 유효성 검사 상세 목록 |
-| `traceId` | ⚠️ 권장 | 확장 필드 — `Request-Id` 응답 헤더 값과 일치해야 한다 |
-
-> **참조**: [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807), [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457)
-
-⚠️ **권장**: 유효성 검사 실패 시 모든 오류 필드를 한 번에 반환한다 (하나씩 반환하지 않는다).
+✅ **필수**: 모든 에러 응답은 RFC 7807 / RFC 9457 표준을 따르며 `application/problem+json`을 사용한다.
 
 ```json
 {
   "type": "https://api.example.com/errors/validation-failed",
-  "title": "유효성 검사 실패",
+  "title": "Validation Failed",
   "status": 400,
+  "code": "VALIDATION_ERROR",
   "detail": "요청 데이터 유효성 검사에 실패했습니다.",
-  "instance": "/articles",
-  "errors": [
-    { "field": "title", "message": "제목은 필수 입력값입니다." },
-    { "field": "content", "message": "본문은 10자 이상이어야 합니다." }
-  ],
-  "traceId": "abc-123-xyz"
-}
-```
-
-❌ **금지**: 에러 응답에 스택 트레이스, 내부 시스템 경로, DB 오류 메시지 등 내부 구현 정보를 노출하지 않는다.
-
----
-
-## 3. REST Design
-
-### 3.1 리소스 스키마 & 필드 규칙
-
-리소스는 서비스가 노출하는 핵심 엔티티다. 각 리소스는 고유한 URL을 통해 접근 가능해야 한다.
-
-✅ **필수**: 모든 리소스는 고유 식별자(`id`)를 가진다.
-
-✅ **필수**: 리소스 스키마는 일관된 구조를 유지한다.
-
-**표준 리소스 필드**
-
-| 필드 | 타입 | 설명 |
-|------|------|------|
-| `id` | string | 리소스 고유 식별자 |
-| `createdAt` | string (RFC 3339) | 생성 시각 |
-| `updatedAt` | string (RFC 3339) | 마지막 수정 시각 |
-
-예시:
-
-```json
-{
-  "id": "123",
-  "title": "RESTful API 설계",
-  "content": "...",
-  "createdAt": "2024-01-15T09:00:00Z",
-  "updatedAt": "2024-01-20T14:30:00Z"
-}
-```
-
-⚠️ **권장**: 리소스 식별자는 불투명한(opaque) 문자열로 설계한다. 클라이언트가 식별자 구조를 파싱하거나 의존하지 않도록 한다.
-
-❌ **금지**: 응답에 null 값 필드를 포함하지 않는다. 값이 없는 필드는 응답에서 제외한다.
-
-```json
-// Bad
-{
-  "id": "123",
-  "title": "제목",
-  "deletedAt": null
-}
-
-// Good
-{
-  "id": "123",
-  "title": "제목"
-}
-```
-
-#### 필드 변경 가능성
-
-필드는 생성 후 변경 가능 여부에 따라 분류된다.
-
-| 분류 | 설명 | 예시 |
-|------|------|------|
-| **생성 시 지정 (Create-only)** | 생성 시에만 설정 가능, 이후 변경 불가 | `id`, `createdAt` |
-| **읽기 전용 (Read-only)** | 서버가 관리, 클라이언트 수정 불가 | `updatedAt` |
-| **변경 가능 (Mutable)** | 클라이언트가 수정 가능 | `title`, `content` |
-
-✅ **필수**: 서버가 관리하는 읽기 전용 필드(`id`, `createdAt`, `updatedAt`)를 클라이언트가 요청 본문에 포함하더라도 이를 무시한다.
-
-⚠️ **권장**: API 문서에서 각 필드의 변경 가능성을 명시한다.
-
-#### 상태 Enum 패턴 (AIP-216)
-
-리소스의 수명주기 상태를 표현할 때는 전용 `state` 필드를 사용한다 (`status` 아님).
-
-✅ **필수**: 상태 필드 이름은 `state`로 한다 (`status`는 HTTP 상태 코드와 혼동됨).
-
-✅ **필수**: 첫 번째 Enum 값은 반드시 `STATE_UNSPECIFIED`여야 한다 (알 수 없는/기본 상태).
-
-✅ **필수**: `state` 필드는 `OUTPUT_ONLY` — 클라이언트가 PATCH로 직접 변경 금지.
-
-✅ **필수**: 상태 전이는 커스텀 메서드(예: `:activate`, `:deactivate`)로만 수행한다. `state` 필드를 직접 PATCH하는 것은 금지.
-
-⚠️ **권장**: 일반 패턴: `ACTIVE` / `INACTIVE`, `PENDING` / `RUNNING` / `SUCCEEDED` / `FAILED`.
-
-```json
-{
-  "id": "job-123",
-  "state": "RUNNING"
-}
-```
-
-```
-# 올바른 방법: 커스텀 메서드로 상태 전이
-POST /jobs/123:cancel
-
-# 금지: state 필드 직접 PATCH
-PATCH /jobs/123?updateMask=state
-{ "state": "CANCELLED" }   ← 금지
-```
-
----
-
-### 3.2 CRUD 처리
-
-#### POST — 리소스 생성
-
-✅ **필수**: 새 리소스 생성 성공 시 201 Created와 생성된 리소스를 반환한다.
-
-```
-POST /articles
-Content-Type: application/json
-
-{
-  "title": "새 글 제목",
-  "content": "본문 내용"
-}
-
----
-
-HTTP/1.1 201 Created
-Location: /articles/456
-Content-Type: application/json
-
-{
-  "id": "456",
-  "title": "새 글 제목",
-  "content": "본문 내용",
-  "createdAt": "2024-01-20T10:00:00Z",
-  "updatedAt": "2024-01-20T10:00:00Z"
-}
-```
-
-#### PUT — 리소스 완전 대체
-
-✅ **필수**: PUT 요청은 리소스 전체를 대체한다. 요청 본문에 포함되지 않은 변경 가능 필드는 기본값 또는 null로 처리한다.
-
-✅ **필수**: PUT 요청은 멱등적으로 동작해야 한다.
-
-#### PATCH — 부분 수정 (AIP-161)
-
-✅ **필수**: 모든 PATCH 요청은 수정할 필드를 지정하는 `updateMask` 쿼리 파라미터를 포함해야 한다.
-
-```
-PATCH /articles/456?updateMask=title,content
-Content-Type: application/json
-
-{
-  "title": "수정된 제목",
-  "content": "새 본문"
-}
-```
-
-✅ **필수**: `updateMask`에 명시된 필드만 수정한다. mask에 없는 필드는 변경하지 않는다.
-
-✅ **필수**: 200 OK와 수정된 전체 리소스를 반환한다.
-
-⚠️ **권장**: `updateMask=*`는 요청 본문에 포함된 모든 mutable 필드를 업데이트한다.
-
-✅ **필수**: 빈 `updateMask` → 400 Bad Request. 잘못된 필드 경로 → 400 Bad Request.
-
-⚠️ **권장**: 중첩 필드 경로에는 dot notation을 사용한다: `?updateMask=address.city`.
-
-**Field Behavior와 `updateMask` 상호작용:**
-
-| 필드 어노테이션 | mask에 포함 시 동작 |
-|---|---|
-| `OUTPUT_ONLY` | 무시 (에러 아님) |
-| `IMMUTABLE` | 값 변경 시 `400 Bad Request` |
-| `REQUIRED` | 요청 본문에 반드시 포함 |
-| `OPTIONAL` | 본문 생략 가능 (기존 값 유지) |
-
-#### DELETE — 리소스 삭제
-
-✅ **필수**: 삭제 성공 시 204 No Content를 반환한다.
-
-⚠️ **권장**: 이미 삭제된 리소스에 대한 재삭제 요청은 404 Not Found 또는 204 No Content를 반환한다. 서비스 특성에 따라 결정한다.
-
-⚠️ **권장**: 하위 리소스의 연쇄 삭제를 위해 `force` 쿼리 파라미터를 지원한다.
-
-```
-DELETE /projects/123?force=true
-```
-
-#### Soft Delete (AIP-164)
-
-즉시 영구 삭제 대신 복구 가능한 삭제가 필요한 리소스에 적용한다.
-
-✅ **필수**: `deleteTime` (삭제 시각)과 `expireTime` (영구 삭제 예정 시각) 필드를 추가한다 (둘 다 `OUTPUT_ONLY`).
-
-✅ **필수**: 복구 엔드포인트: `POST /{resource}/{id}:undelete`.
-
-✅ **필수**: List 응답은 기본적으로 soft-deleted 리소스를 제외한다. `?showDeleted=true`로 포함.
-
-⚠️ **권장**: Get은 soft-deleted 리소스를 정상 반환한다 (`deleteTime` 포함).
-
-⚠️ **권장**: 보존 기간(기본 30일) 이후 자동 영구 삭제.
-
-```
-# Soft delete
-DELETE /articles/123
-
-# 복구
-POST /articles/123:undelete
-
-# 삭제된 항목 포함 목록 조회
-GET /articles?showDeleted=true
-```
-
-#### Change Validation / Dry Run (AIP-163)
-
-실제 변경 없이 Create 또는 Update 요청을 사전 검증한다.
-
-⚠️ **권장**: `?validateOnly=true` 쿼리 파라미터를 지원한다.
-
-✅ **필수**: `validateOnly=true`이면 검증만 수행 — 리소스 변경 없음, 부수 효과 없음.
-
-✅ **필수**: 검증 성공 시 실제 실행과 유사한 응답 반환 (서버 생성 필드 제외 가능).
-
-✅ **필수**: 검증 실패 시 동일한 RFC 9457 에러 형식 반환.
-
-```
-# 생성 없이 검증만 수행
-POST /articles?validateOnly=true
-Content-Type: application/json
-
-{ "title": "새 글" }
-
----
-
-HTTP/1.1 200 OK
-{ "id": null, "title": "새 글" }   # id 미포함 (아직 생성 안 됨)
-```
-
----
-
-### 3.3 액션 (AIP-136)
-
-CRUD로 표현하기 어려운 동작(예: 승인, 전송, 잠금)에는 액션 패턴을 사용한다.
-
-✅ **필수**: 액션은 리소스 URL 뒤에 `:action` 형태로 표현한다.
-
-```
-POST /articles/123:publish
-POST /users/456:deactivate
-POST /orders/789:cancel
-```
-
-✅ **필수**: 액션 엔드포인트에는 POST 메서드를 사용한다.
-
-⚠️ **권장**: 액션 이름은 동사 원형을 사용한다 (publish, cancel, approve).
-
-**액션 응답 상태 코드:**
-
-| 시나리오 | 상태 코드 | 응답 본문 |
-|----------|-----------|-----------|
-| 동기 액션 — 리소스 변경 | `200 OK` | 변경된 리소스 |
-| 동기 액션 — 응답 본문 없음 | `204 No Content` | 없음 |
-| 비동기 액션 — fire-and-forget | `202 Accepted` | 없음 또는 최소 응답 |
-| 비동기 액션 — 폴링 가능 작업 생성 | `201 Created` + `Location` 헤더 | 생성된 작업 리소스 |
-
-**요청 예시:**
-
-```
-POST /articles/123:publish
-Content-Type: application/json
-
-{}
-
----
-
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "id": "123",
-  "status": "PUBLISHED",
-  "publishedAt": "2024-01-20T15:00:00Z"
-}
-```
-
----
-
-### 3.4 컬렉션 & 페이지네이션
-
-#### 컬렉션 응답 구조
-
-✅ **필수**: 컬렉션 조회 응답 본문은 리소스 배열(top-level JSON array)을 반환한다.
-
-```
-HTTP/1.1 200 OK
-Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next",
-      <https://api.example.com/articles?pageSize=20>; rel="first",
-      <https://api.example.com/articles?pageSize=20&pageToken=xyz>; rel="last"
-Total-Count: 100
-
-[
-  { "id": "1", "title": "첫 번째 글" },
-  { "id": "2", "title": "두 번째 글" }
-]
-```
-
-| 헤더 | 필수 여부 | 설명 |
-|------|-----------|------|
-| `Link` | ⚠️ 권장 | 페이지네이션 네비게이션 (RFC 8288) |
-| `Total-Count` | ⚠️ 권장 | 전체 항목 수 |
-
-| rel 값 | 설명 |
-|--------|------|
-| `next` | 다음 페이지 |
-| `prev` | 이전 페이지 |
-| `first` | 첫 번째 페이지 |
-| `last` | 마지막 페이지 |
-
-#### 빈 컬렉션 응답
-
-✅ **필수**: 컬렉션에 항목이 없을 때 `200 OK` + 빈 배열 `[]`을 반환한다. 빈 컬렉션에 `404 Not Found`를 사용하지 않는다.
-
-⚠️ **권장**: 빈 컬렉션에도 `Total-Count: 0` 헤더를 포함한다.
-
-```
-HTTP/1.1 200 OK
-Content-Type: application/json
-Total-Count: 0
-
-[]
-```
-
-> **참고**: 컬렉션 엔드포인트는 비어 있어도 리소스 자체는 존재한다 ([RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110)). `404 Not Found`는 엔드포인트 자체가 존재하지 않는다는 의미이지, 컬렉션이 비어 있다는 의미가 아니다.
-
-#### 커서 기반 페이지네이션 (권장)
-
-⚠️ **권장**: 대용량 데이터에는 오프셋 기반 대신 커서 기반 페이지네이션을 사용한다.
-
-**요청:**
-
-```
-GET /articles?pageSize=20&pageToken=eyJwYWdlIjoyf...
-```
-
-**응답:**
-
-```
-HTTP/1.1 200 OK
-Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next",
-      <https://api.example.com/articles?pageSize=20>; rel="first"
-
-[
-  { "id": "1", "title": "첫 번째 글" },
-  ...
-]
-```
-
-✅ **필수**: 다음 페이지가 없을 때 `Link` 헤더에서 `rel="next"`를 제외한다.
-
-✅ **필수**: `pageToken`은 불투명한 값이다. 클라이언트는 `pageToken`을 파싱하거나, 직접 조합하거나, 내부 형식에 대해 가정해서는 안 된다.
-
-✅ **필수**: 서버는 `pageToken`의 인코딩을 사전 고지 없이 변경할 수 있다.
-
-> **참고**: 이는 리소스 식별자의 불투명성 원칙과 동일하다 — 클라이언트가 구조적으로 의존해서는 안 되는 불투명한 문자열.
-
-#### 오프셋 기반 페이지네이션
-
-소규모 데이터셋에서는 오프셋 기반 페이지네이션도 허용된다.
-
-**요청:**
-
-```
-GET /articles?page=2&pageSize=20
-```
-
-**응답:**
-
-```
-HTTP/1.1 200 OK
-Link: <https://api.example.com/articles?pageSize=20&page=1>; rel="first",
-      <https://api.example.com/articles?pageSize=20&page=1>; rel="prev",
-      <https://api.example.com/articles?pageSize=20&page=3>; rel="next",
-      <https://api.example.com/articles?pageSize=20&page=5>; rel="last"
-Total-Count: 100
-
-[
-  { "id": "21", "title": "스물한 번째 글" },
-  ...
-]
-```
-
-⚠️ **권장**: 기본 페이지 크기(`pageSize`)는 20으로 설정한다.
-
-⚠️ **권장**: 최대 페이지 크기는 100으로 제한한다.
-
-✅ **필수**: `pageSize`가 1 미만이면 `400 Bad Request`를 반환한다.
-
-⚠️ **권장**: `pageSize`가 최대 허용값을 초과하면 에러 대신 최대값으로 자른다. 적용된 `pageSize`를 응답에 포함한다.
-
-```
-# 요청: pageSize=500 (최대값 100)
-# 서버가 pageSize=100으로 적용
-
-HTTP/1.1 200 OK
-Link: <https://api.example.com/articles?pageSize=100&pageToken=abc>; rel="next"
-
-[ ... 100개 항목 ... ]
-```
-
-#### 키셋 페이지네이션
-
-⚠️ **권장**: 대규모 데이터셋에서 일관된 성능이 중요한 경우 키셋 페이지네이션을 사용한다.
-
-키셋 페이지네이션은 마지막 항목의 정렬 키를 커서로 사용하여, 페이지 깊이와 무관하게 O(1) 조회 성능을 달성한다.
-
-**요청:**
-
-```
-GET /articles?pageSize=20&orderBy=createdAt:desc&after=eyJjcmVhdGVkQXQiOi...
-```
-
-**응답:**
-
-```
-HTTP/1.1 200 OK
-Link: <https://api.example.com/articles?pageSize=20&orderBy=createdAt:desc&after=eyJjcmVhdGVkQXQiOi...>; rel="next"
-
-[
-  { "id": "455", "createdAt": "2024-01-20T09:55:00Z" },
-  ...
-  { "id": "440", "createdAt": "2024-01-15T08:00:00Z" }
-]
-```
-
-✅ **필수**: 키셋 커서(`after`/`before`)는 불투명한 토큰이어야 한다 — 클라이언트가 직접 조합하면 안 된다.
-
-⚠️ **권장**: 복합 정렬 키는 불투명한 커서에 인코딩한다.
-
-> **트레이드오프**: 키셋 페이지네이션은 임의 페이지로 점프할 수 없다. 임의 페이지 접근이 필요하면 오프셋 페이지네이션을 사용한다.
-
----
-
-### 3.5 필터링 & 정렬
-
-#### 필터링
-
-✅ **필수**: `filter` 쿼리 파라미터에 구조화된 표현식 문자열을 사용한다 (AIP-160).
-
-**filter 표현식 문법:**
-
-```
-GET /articles?filter=status = "PUBLISHED" AND authorId = "user-123"
-```
-
-**연산자:**
-
-| 유형 | 연산자 | 예시 |
-|---|---|---|
-| 비교 | `=`, `!=`, `<`, `>`, `<=`, `>=` | `?filter=price >= 100` |
-| 논리 | `AND`, `OR`, `NOT` | `?filter=status = "ACTIVE" AND NOT archived = true` |
-| 그룹핑 | `( )` | `?filter=(status = "ACTIVE" OR status = "PENDING") AND price < 1000` |
-
-**값 타입:**
-
-- 문자열 및 타임스탬프: 큰따옴표 — `?filter=createdAt > "2024-01-01T00:00:00Z"`
-- 숫자: 따옴표 없이 — `?filter=price >= 100`
-- 불리언: `true` / `false` — `?filter=isPublished = true`
-- 중첩 필드: dot notation — `?filter=author.name = "Kim"`
-- 반복 필드 포함 여부: `has()` — `?filter=has(tags, "golang")`
-
-**예시:**
-
-```
-# 단일 조건
-GET /articles?filter=status = "PUBLISHED"
-
-# 복수 조건 (AND)
-GET /articles?filter=status = "PUBLISHED" AND authorId = "user-123"
-
-# OR 조건
-GET /articles?filter=status = "PUBLISHED" OR status = "DRAFT"
-
-# 그룹 복합 조건
-GET /articles?filter=(status = "PUBLISHED" OR status = "DRAFT") AND createdAt > "2024-01-01T00:00:00Z"
-
-# 부정
-GET /articles?filter=NOT status = "DELETED"
-
-# 날짜 범위
-GET /articles?filter=createdAt >= "2024-01-01T00:00:00Z" AND createdAt < "2024-02-01T00:00:00Z"
-
-# 숫자 범위
-GET /products?filter=price >= 100 AND price <= 500
-
-# 중첩 필드
-GET /articles?filter=author.name = "Kim"
-
-# 반복 필드 포함 여부
-GET /articles?filter=has(tags, "golang")
-```
-
-❌ **금지**: 개별 쿼리 파라미터로 필터링하지 않는다 (예: `?status=PUBLISHED`, `?createdAfter=...`).
-
-✅ **필수**: 유효하지 않은 filter 표현식 → 400 Bad Request (RFC 9457 에러 본문 포함).
-
-#### 정렬
-
-⚠️ **권장**: 정렬은 `orderBy` 파라미터를 사용하며, 필드명과 방향을 조합하여 표현한다.
-
-```
-GET /articles?orderBy=createdAt:desc
-GET /articles?orderBy=title:asc
-GET /articles?orderBy=createdAt:desc,title:asc
-```
-
-⚠️ **권장**: 기본 정렬 기준은 API 문서에 명시한다.
-
----
-
-### 3.6 Partial Response
-
-✅ **필수**: `fields` 쿼리 파라미터로 클라이언트가 응답에 포함할 필드를 선택할 수 있도록 지원한다 (AIP-157).
-
-```
-GET /articles/123?fields=id,title,author.name
-```
-
-✅ **필수**: `fields` 값과 무관하게 `id`는 항상 응답에 포함한다.
-
-⚠️ **권장**: 중첩 필드는 dot notation으로 선택한다.
-
-```
-GET /articles/123?fields=id,author.name,author.email
-```
-
-✅ **필수**: List 응답에서도 각 항목에 `fields` 필터를 적용한다.
-
-✅ **필수**: `INPUT_ONLY` 필드는 `fields` 파라미터와 무관하게 항상 응답에서 제외한다.
-
-⚠️ **권장**: ETag는 전체 리소스를 기준으로 한다 (partial view와 무관).
-
-✅ **필수**: `fields`에 존재하지 않는 필드명 → 400 Bad Request.
-
-**예시:**
-
-```
-GET /articles?fields=id,title,author.name
-
----
-
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-[
-  {
-    "id": "123",
-    "title": "REST API 설계",
-    "author": {
-      "name": "Kim"
+  "instance": "/users",
+  "traceId": "abc-123-xyz",
+  "details": [
+    {
+      "@type": "type.googleapis.com/google.rpc.BadRequest",
+      "fieldViolations": [
+        {
+          "field": "user.email",
+          "description": "올바른 이메일 주소 형식이 아닙니다."
+        }
+      ]
     }
-  }
-]
+  ]
+}
+```
+
+- **기계 판독 가능한 코드:** `code` 문자열 필드(UPPER_SNAKE_CASE)를 포함한다. `[T1]`
+- **필드 수준 에러 (AIP-193 방식):** 다형성 객체를 포함하는 `details` 배열을 사용한다. `[T1]`
+- 모든 유효성 검사 실패 항목을 한 번에 반환한다. `[T1]`
+- `traceId`는 `Request-Id` 응답 헤더 값과 일치해야 한다. `[T1]`
+- 내부 구현 상세 정보(스택 트레이스 등)를 노출하지 않는다. `[T1]`
+
+---
+
+## 7. 리소스 스키마 & 필드 규칙
+
+**필드 동작 어노테이션 (AIP-203):** `[T1]`
+OpenAPI 스펙의 `x-field-behavior` 확장을 사용하여 필드 동작을 선언한다.
+
+| 어노테이션 | 의미 |
+|-----------|---------|
+| `REQUIRED` | 클라이언트가 반드시 제공해야 함 |
+| `OUTPUT_ONLY` | 서버가 설정; 클라이언트는 제공 불가 (무시됨) |
+| `INPUT_ONLY` | 클라이언트가 제공; 응답에서는 제외됨 |
+| `IMMUTABLE` | 생성 후 변경 불가 |
+| `OPTIONAL` | 선택적으로 제공 가능 |
+| `IDENTIFIER` | 리소스 식별자; 변경 불가 |
+
+---
+
+## 8. CRUD 처리
+
+**표준 메서드 응답 규칙:**
+- POST (Create): `201 Created` + 전체 리소스 + `Location` 헤더. `[T1]`
+- PATCH (Update): 수정된 전체 리소스 반환. `[T1]`
+- DELETE: `204 No Content` (본문 없음). `[T1]`
+
+**PATCH (부분 수정 — 기본):** `[T1]`
+- `updateMask` 쿼리 파라미터 필수: 쉼표로 구분된 필드 경로 — `?updateMask=title,content`.
+- `updateMask`에 명시된 필드만 수정한다.
+- 빈 mask 또는 잘못된 필드 경로 → `400 Bad Request`.
+
+**낙관적 동시성 제어 (AIP-154):** `[T1]`
+- 리소스에 `etag` 필드를 포함한다 (OUTPUT_ONLY).
+- 수정/삭제 요청 시 `If-Match: {etag}` 헤더를 통해 전송한다.
+- ETag 불일치 시 `412 Precondition Failed`를 반환한다.
+
+---
+
+## 9. 액션
+
+**비 CRUD 액션 (AIP-136):** `[T1]`
+단순 필드 업데이트 이상의 부수 효과가 있는 작업은 콜론 구문과 `POST`를 사용한다.
+
+```
+POST /orders/{id}:cancel
+POST /reports:generate
 ```
 
 ---
 
-### 3.7 Expand/Embed
+## 10. 컬렉션 & 페이지네이션
 
-✅ **필수**: 연관된 리소스를 응답에 포함하기 위해 `expand` 쿼리 파라미터를 지원한다.
+- 컬렉션 응답은 **최상위 JSON 배열** `[]`을 반환한다. `[T1]`
+- **빈 컬렉션:** `200 OK` + `[]`를 반환하며, 절대 `404 Not Found`를 사용하지 않는다. `[T1]`
 
-```
-GET /articles/123?expand=author,comments.author
-```
-
-✅ **필수**: N+1 쿼리 폭발 및 DoS 공격(Unrestricted Resource Consumption)을 방지하기 위해, 서버는 단일 응답에서 반환되는 **전체 확장 엔티티 수**에 대해 엄격한 상한선(예: 최대 100개)을 강제해야 한다.
-
-✅ **필수**: 확장 요청이 최대 엔티티 제한을 초과하는 경우 `400 Bad Request`를 반환한다.
-
-⚠️ **권장**: 최대 확장 깊이는 3단계로 제한한다.
+**토큰 기반 페이지네이션 (AIP-158, 권장):** `[T2]`
+- `pageSize`와 `pageToken`(불투명 토큰)을 사용한다.
+- `Link` 헤더에 `rel="next"`, `prev`, `first` 등을 포함한다.
 
 ---
 
-### 3.8 Bulk Operations
+## 11. 필터링 & 정렬
 
-일괄 작업은 네트워크 오버헤드를 줄이기 위해 단일 요청으로 여러 리소스를 처리할 수 있게 한다.
+❌ 개별 쿼리 파라미터로 필터링하지 않는다.
 
-✅ **필수**: 리소스 컬렉션 URL 뒤에 콜론 기호를 사용한 커스텀 메서드로 일괄 작업을 표현한다.
+**필터 표현식 (AIP-160):** `[T1]`
+- 문법: `?filter=status = "ACTIVE" AND price >= 1000`.
+- 연산자: `=`, `!=`, `<`, `>`, `<=`, `>=`, `AND`, `OR`, `NOT`, `has()`.
+- 유효하지 않은 filter 표현식 → `400 Bad Request`.
 
-| 메서드 | 목표 | 엔드포인트 |
-|--------|------|------------|
-| `batchCreate` | 여러 리소스 생성 | `POST /{resources}:batchCreate` |
-| `batchGet` | ID로 여러 리소스 조회 | `POST /{resources}:batchGet` |
-| `batchUpdate` | 여러 리소스 수정 | `POST /{resources}:batchUpdate` |
-| `batchDelete` | 여러 리소스 삭제 | `POST /{resources}:batchDelete` |
-
-✅ **필수**: 요청 본문에는 처리할 항목 또는 ID 배열이 포함되어야 한다.
-
-✅ **필수**: 일괄 작업이 원자적(atomic, all-or-nothing)인지 또는 비원자적(부분 성공 허용)인지 명시해야 한다.
-
-✅ **필수**: 비원자적 작업의 경우, 응답은 항목별 성공 또는 실패를 표현할 수 있는 구조를 사용해야 한다(실패한 항목에 대해 RFC 9457 에러 객체 포함).
+**정렬:** `?orderBy=createdAt:desc,title:asc`. `[T2]`
 
 ---
 
-## 4. API 운영
+## 12. Partial Response & 리소스 확장
 
-### 4.1 API 버전 관리
+**Partial Response (AIP-157):** `[T2]`
+- `fields` 쿼리 파라미터 사용: `?fields=id,title,author.name`.
+- `id`는 항상 포함된다.
 
-#### 버전 표기
+**리소스 확장 (Expand/Embed):** `[T2]`
+- `expand` 쿼리 파라미터 사용: `?expand=author`.
+- **전체 엔티티 제한 필수:** 단일 응답에서 확장되는 전체 엔티티 수에 대한 하한선(예: 최대 100개)을 강제해야 한다. `[T1]`
+- 제한 초과 시 `400 Bad Request` 반환.
 
-❌ **금지**: API 버전을 URL 경로에 포함하지 않는다.
+---
 
-> **이유**: URL은 리소스 식별자다. `/v1/articles`와 `/v2/articles`는 같은 리소스인데 URL이 달라지므로 REST 원칙에 어긋난다. 또한 URL 버전은 클라이언트가 코드를 전면 교체해야 하는 부담을 준다. 헤더 버전은 클라이언트가 버전을 점진적으로 마이그레이션할 수 있고, 버전 미지정 시 서버가 기본 버전을 적용하는 유연성을 제공한다.
+## 13. 일괄 작업 (Bulk Operations)
 
-✅ **필수**: `Api-Version` 헤더에 ISO 8601 (`YYYY-MM-DD`) 형식의 날짜로 버전을 지정한다.
+✅ **필수**: 컬렉션 URL 뒤에 콜론 구문을 사용하여 커스텀 메서드로 표현한다. `[T3]`
+- `batchCreate`, `batchGet`, `batchUpdate`, `batchDelete`.
+- 원자적(atomic) 또는 비원자적 작업 여부를 명시한다.
 
+---
+
+## 14. API 버전 관리
+
+❌ **URL 경로에 버전을 포함하는 것은 금지된다.** `[T1]`
+
+✅ **헤더 버전 관리 필수:** `[T1]`
 ```
 Api-Version: 2024-01-20
 ```
 
-⚠️ **권장**: 버전 헤더가 없는 요청에는 최신 안정 버전을 적용하고, 응답에 적용된 버전을 명시한다.
-
-```
-HTTP/1.1 200 OK
-Api-Version: 2024-01-20
-```
-
-#### 하위 호환성
-
-✅ **필수**: 동일 버전 내에서 하위 호환성을 유지한다.
-
-**하위 비호환 변경** (새 `Api-Version` 날짜 필요):
-
-| 분류 | 예시 |
-|------|------|
-| 제거 | 엔드포인트, 필드, enum 값 제거 |
-| 이름 변경 | 필드 또는 엔드포인트 이름 변경 |
-| 타입 변경 | 필드 타입, 포맷 변경 (예: `string` → `int`) |
-| 제약 강화 | `optional` → `required`, 새 필수 필드 추가, 검증 규칙 추가 |
-| 의미 변경 | 상태 코드 의미 변경, 기본값 변경, 정렬 순서 변경 |
-
-**하위 호환 변경** (버전 업 불필요):
-
-| 분류 | 예시 |
-|------|------|
-| 추가 | 새 엔드포인트, 새 선택적 필드, 새 enum 값, 새 쿼리 파라미터 |
-| 완화 | `required` → `optional`, 검증 규칙 완화 |
-| 메타데이터 | 응답 속성 순서 변경, description 수정 |
-
-#### 호환성 원칙
-
-✅ **필수**: 클라이언트는 응답의 알 수 없는 필드를 무시해야 한다 (tolerant reader 패턴).
-
-✅ **필수**: 서버는 요청의 알 수 없는 필드를 무시해야 한다.
-
-✅ **필수**: Enum은 open-ended로 취급한다 — 클라이언트는 알 수 없는 enum 값을 정상 처리해야 한다.
-
-⚠️ **권장**: 버전 업 전 최소 6개월 이전 버전을 유지한다.
+- 버전 헤더가 없는 요청은 반드시 **`400 Bad Request`**를 반환해야 한다. `[T1]`
+- 응답에는 항상 적용된 버전이 포함된다. `[T1]`
+- 이전 버전은 최소 6개월 동안 유지한다. `[T2]`
 
 ---
 
-### 4.2 Deprecation
+## 15. Deprecation
 
-✅ **필수**: Deprecated된 API에는 응답 헤더로 알림을 제공한다.
-
-```
-Deprecation: true
-Sunset: Sat, 01 Jan 2025 00:00:00 GMT
-Link: <https://api.example.com/users/articles>; rel="successor-version"
-```
-
-⚠️ **권장**: Deprecation 공지는 종료일 최소 6개월 전에 알린다.
-
-⚠️ **권장**: Deprecated API 호출 시 `Deprecation`, `Sunset`, `Link` 헤더로 클라이언트에 공지한다.
-
-```
-HTTP/1.1 200 OK
-Deprecation: true
-Sunset: Sat, 01 Jan 2025 00:00:00 GMT
-Link: <https://api.example.com/users/articles>; rel="successor-version"
-
-[
-  { "id": "1", "title": "항목 1" },
-  ...
-]
-```
+- 응답 헤더 포함: `Deprecation: true`, `Sunset`, `Link`. `[T1]`
+- 종료일 최소 6개월 전에 공지해야 한다. `[T1]`
 
 ---
 
-### 4.3 속도 제한
+## 16. 속도 제한 & 재시도
 
-API 서버는 클라이언트별 요청 빈도를 제한하여 서비스 안정성을 보장한다.
-
-#### 응답 헤더
-
-✅ **필수**: 속도 제한이 적용되는 모든 응답에 다음 헤더를 포함한다.
-
-**레거시 헤더 (X-RateLimit-\*)**
-
-| 헤더 | 설명 | 예시 |
-|------|------|------|
-| `X-RateLimit-Limit` | 시간 창(window) 내 허용되는 최대 요청 수 | `100` |
-| `X-RateLimit-Remaining` | 현재 시간 창에서 남은 요청 수 | `99` |
-| `X-RateLimit-Reset` | 시간 창이 초기화되는 시각 (Unix timestamp, 초 단위) | `1742342450` |
-
-**IETF 표준 헤더 ([draft-ietf-httpapi-ratelimit-headers-10](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/), Internet-Draft, Standards Track)**
-
-| 헤더 | 설명 | 예시 |
-|------|------|------|
-| `RateLimit` | 현재 속도 제한 상태 (Structured Field) | `limit=100, remaining=99, reset=50` |
-| `RateLimit-Policy` | 적용 중인 속도 제한 정책 | `100;w=3600` |
-
-> **참고**: `RateLimit` 헤더의 `reset` 값은 시간 창 초기화까지 남은 **초(delta-seconds)**이며, `X-RateLimit-Reset`은 **Unix timestamp**이다. 혼동에 주의한다.
->
-> **`RateLimit-Policy` 구조**: `100;w=3600` — `100`은 허용 최대 요청 수, `w=3600`은 시간 창 크기(window, 초 단위). 모든 응답에 포함한다.
-
-**정상 응답 예시:**
-
-```
-HTTP/1.1 200 OK
-Content-Type: application/json
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 99
-X-RateLimit-Reset: 1742342450
-RateLimit: limit=100, remaining=99, reset=50
-RateLimit-Policy: 100;w=3600
-
-[
-  { "id": "1", "title": "항목 1" }
-]
-```
-
-#### 429 Too Many Requests 응답
-
-✅ **필수**: 속도 제한 초과 시 `429 Too Many Requests`를 반환한다.
-
-✅ **필수**: 429 응답에 `Retry-After` 헤더를 포함한다. 값은 재시도까지 대기해야 하는 초(delta-seconds)를 사용한다.
-
-✅ **필수**: 429 응답 본문은 RFC 7807/9457 Problem Details 구조를 사용한다.
-
-**429 응답 예시:**
-
-```
-HTTP/1.1 429 Too Many Requests
-Content-Type: application/problem+json
-Retry-After: 50
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 0
-X-RateLimit-Reset: 1742342450
-RateLimit: limit=100, remaining=0, reset=50
-RateLimit-Policy: 100;w=3600
-```
-
-```json
-{
-  "type": "https://api.example.com/errors/too-many-requests",
-  "title": "속도 제한 초과",
-  "status": 429,
-  "detail": "허용된 요청 한도를 초과했습니다. 50초 후에 다시 시도해 주세요."
-}
-```
-
-#### 클라이언트 재시도 전략
-
-✅ **필수**: 클라이언트는 429 응답 수신 시 `Retry-After` 헤더 값만큼 대기한 후 재시도한다.
-
-⚠️ **권장**: `Retry-After` 헤더가 없거나 기타 일시적 오류(503 등) 발생 시, 지수 백오프(exponential backoff) + 지터(jitter) 전략을 사용한다. `attempt`는 1부터 시작하는 재시도 횟수(1 = 첫 번째 재시도).
-
-```
-wait_time = min(maxDelay, baseDelay × 2^(attempt - 1)) + random(0, jitterRange)
-```
-
-예시: attempt=1 → `min(60, 1 × 2^0) + random(0,1)` = 1~2초
-
-| 파라미터 | 권장 값 | 설명 |
-|----------|---------|------|
-| `baseDelay` | 1초 | 첫 번째 재시도 대기 시간 |
-| `maxDelay` | 60초 | 최대 대기 시간 상한 |
-| `jitterRange` | 0 ~ 1초 | 무작위 지연 (thundering herd 방지) |
-| 최대 재시도 횟수 | 3 ~ 5회 | 무한 재시도 방지 |
-
-❌ **금지**: 429 응답 수신 시 즉시 재시도하거나 고정 간격으로 반복 재시도하지 않는다.
-
-❌ **금지**: `Retry-After` 헤더가 있을 때 해당 값을 무시하고 자체 대기 시간을 사용하지 않는다.
+- **응답 헤더:** `RateLimit: limit=N, remaining=N, reset=N`. `[T2]`
+- **429 Too Many Requests:** `Retry-After` 헤더와 RFC 9457 본문을 포함한다. `[T2]`
+- **클라이언트 재시도 전략:** 지수 백오프(Exponential Backoff)와 지터(Jitter)를 사용한다. `[T2]`
 
 ---
 
-### 4.4 장기 실행 작업
+## 17. 캐싱
 
-즉시 완료되지 않는 작업(보고서 생성, 데이터 가져오기 등)은 도메인 리소스를 즉시 생성하고 리소스의 상태 필드로 처리 진행 상황을 추적한다.
-
-✅ **필수**: 장기 실행 작업 요청 시 도메인 리소스를 즉시 생성하고 `201 Created` + `Location` 헤더를 반환한다.
-
-✅ **필수**: 도메인 리소스에 `status` 필드를 포함하여 처리 상태를 표현한다.
-
-⚠️ **권장**: 상태값은 다음을 사용한다.
-
-| 상태 | 설명 |
-|------|------|
-| `PENDING` | 작업 대기 중 |
-| `IN_PROGRESS` | 작업 처리 중 |
-| `COMPLETED` | 작업 완료 |
-| `FAILED` | 작업 실패 |
-
-⚠️ **권장**: `FAILED` 상태인 경우 리소스에 RFC 7807/9457 에러 구조를 포함한다.
-
-**예시:**
-
-```
-# 작업 시작 — 도메인 리소스 즉시 생성
-POST /reports  →  201 Created
-                  Location: /reports/123
-                  { "id": "123", "status": "PENDING" }
-
-# 상태 조회 (폴링)
-GET /reports/123  →  { "id": "123", "status": "IN_PROGRESS" }
-GET /reports/123  →  { "id": "123", "status": "COMPLETED", ... }
-GET /reports/123  →  { "id": "123", "status": "FAILED", "error": { ... } }
-```
-
-❌ **금지**: 별도의 범용 `/operations` 리소스를 사용하지 않는다. 도메인 리소스 자체에서 상태를 추적한다.
+- `Cache-Control` 헤더 사용. `[T2]`
+- 모든 변경 가능한 리소스에 대해 `ETag`를 제공한다. `[T2]`
 
 ---
 
-### 4.5 Idempotency-Key
+## 18. 장기 실행 작업
 
-POST는 멱등하지 않아 네트워크 오류 후 재시도하면 리소스가 중복 생성될 수 있다. 결제, 주문, 이메일 발송 등 중복 실행이 위험한 API에는 `Idempotency-Key` 헤더를 사용한다.
-
-✅ **필수**: 중복 실행 위험이 있는 POST 엔드포인트는 `Idempotency-Key` 헤더를 지원한다.
-
-```
-POST /orders
-Content-Type: application/json
-Idempotency-Key: a8098c1a-f86e-11da-bd1a-00112444be1e
-
-{
-  "productId": "123",
-  "quantity": 2
-}
-```
-
-**서버 동작:**
-- 처음 요청: 정상 처리 후 결과 저장
-- 같은 키로 재요청: 새로 처리하지 않고 저장된 결과 그대로 반환
-- 키가 다른 동일 요청: 별도 요청으로 처리
-
-✅ **필수**: `Idempotency-Key` 값은 클라이언트가 생성한 UUID v4를 사용한다.
-
-⚠️ **권장**: 동일 키로 재요청 시 원래 응답과 동일한 상태 코드 및 본문을 반환한다.
-
-⚠️ **권장**: `Idempotency-Key`의 유효 기간은 최소 24시간으로 설정한다.
-
-❌ **금지**: `Idempotency-Key` 없이 결제·주문 등 금전적 영향을 주는 POST 엔드포인트를 설계하지 않는다.
+- 요청 시 도메인 리소스를 즉시 생성하고 `201 Created` + `Location` 헤더를 반환한다. `[T3]`
+- `status` 필드 포함: `PENDING`, `IN_PROGRESS`, `COMPLETED`, `FAILED`. `[T3]`
 
 ---
 
-## 5. 인증 & 보안
+## 19. Idempotency-Key
 
-### 5.1 인증 방식
-
-#### Bearer Token (JWT)
-
-✅ **필수**: 인증 토큰은 `Authorization` 헤더를 사용한다. 쿼리 파라미터나 요청 본문에 포함하지 않는다.
-
-```
-Authorization: Bearer eyJhbGciOiJSUzI1NiJ9...
-```
-
-#### API Key
-
-⚠️ **권장**: API Key 인증은 `Authorization` 헤더를 사용한다.
-
-```
-Authorization: ApiKey your-api-key-here
-```
-
-❌ **금지**: API Key를 쿼리 파라미터로 전달하지 않는다. URL은 서버 로그에 기록될 수 있다.
-
-```
-# Bad
-GET /articles?apiKey=secret-key
-```
+- 중복 실행 위험이 있는 POST 엔드포인트에 `Idempotency-Key` 헤더를 지원한다. `[T3]`
+- UUID v4를 사용하며, 최소 24시간 동안 유효해야 한다. `[T3]`
 
 ---
 
-### 5.2 401 vs 403 구분
+## 20. OpenAPI 스펙
 
-| 상태 코드 | 의미 | 사용 시점 |
-|-----------|------|-----------|
-| `401 Unauthorized` | 인증 실패 | 토큰 없음, 토큰 만료, 토큰 형식 오류 |
-| `403 Forbidden` | 인가 실패 | 인증은 됐지만 해당 리소스/액션에 대한 권한 없음 |
-
-✅ **필수**: 401 응답에는 `WWW-Authenticate` 헤더를 포함한다.
-
-```
-HTTP/1.1 401 Unauthorized
-WWW-Authenticate: Bearer realm="api", error="token_expired"
-Content-Type: application/problem+json
-
-{
-  "type": "https://api.example.com/errors/unauthorized",
-  "title": "인증이 필요합니다",
-  "status": 401,
-  "detail": "액세스 토큰이 만료되었습니다."
-}
-```
-
-⚠️ **권장**: 403 응답에서 리소스의 존재 여부를 노출하지 않는다. 보안상 민감한 리소스는 존재하지 않는 것처럼 404로 응답할 수 있다.
-
-```
-HTTP/1.1 403 Forbidden
-Content-Type: application/problem+json
-
-{
-  "type": "https://api.example.com/errors/forbidden",
-  "title": "접근이 거부되었습니다",
-  "status": 403,
-  "detail": "이 리소스에 접근할 권한이 없습니다."
-}
-```
+- 모든 API는 OpenAPI 3.0+ 스펙을 단일 진실 원천(SSOT)으로 유지한다. `[T2]`
+- `description`과 `operationId`가 필수다. `[T2]`
+- CI에서 린터를 사용하여 스펙 준수 여부를 자동으로 검증해야 한다. `[T1]`
 
 ---
 
-### 5.3 Webhooks
+## 21. 인증 & 보안
 
-✅ **필수**: 웹훅 이벤트에 대해 일관된 페이로드 래퍼를 사용한다.
+- **HTTPS 필수.** `[T1]`
+- **보안 헤더 필수:** `X-Content-Type-Options: nosniff`, `Strict-Transport-Security`. `[T1]`
+- Bearer 토큰 또는 API Key 인증에 `Authorization` 헤더 사용. `[T1]`
 
-```json
-{
-  "id": "evt_123",
-  "type": "article.published",
-  "created": "2024-01-20T10:00:00Z",
-  "data": { ... }
-}
-```
+**BOLA (Broken Object Level Authorization) 방지:** `[T1]`
+- 서버는 모든 개별 리소스 접근(`/{resource}/{id}`)에 대해 소유권 및 권한을 검증해야 한다.
 
-✅ **필수**: 공유 비밀 키(Shared Secret)를 사용한 HMAC-SHA256으로 페이로드를 서명한다. 서명은 `X-Hub-Signature-256` 헤더에 포함한다.
-
-⚠️ **권장**: 웹훅 핸들러는 중복 이벤트를 안전하게 처리할 수 있도록 멱등성을 가져야 한다.
+**BOPA (Broken Object Property Authorization) 방지:** `[T1]`
+- 서버는 DTO 계층에서 허용 목록(Allowlist)을 사용해야 한다. `PATCH` 본문이나 `updateMask`를 통해 보호된 필드가 수정되지 않도록 방어한다.
 
 ---
 
-## 6. Health Check
+## 22. 참고 자료
 
-✅ **필수**: 서비스 가용성을 모니터링하기 위해 `GET /health` 엔드포인트를 제공한다.
-
-✅ **필수**: 서비스가 정상이면 `200 OK`와 `{"status": "UP"}`을 반환한다.
-
-⚠️ **권장**: 단순 생존 확인(liveness)과 준비 완료 확인(readiness)을 구분한다. 준비 완료 확인은 DB, 캐시 등 의존성 상태를 점검해야 한다.
-
----
-
-## 7. OpenAPI Specification
-
-### 7.1 API First
-
-✅ **필수**: 모든 API는 OpenAPI 3.0+ 스펙을 단일 진실 원천(SSOT)으로 유지한다.
-
-⚠️ **권장**: 구현 전 OpenAPI 스펙을 먼저 정의한다 (API First 접근법).
-
-### 7.2 스펙 품질
-
-✅ **필수**: 모든 엔드포인트, 파라미터, 스키마 속성에 `description` 필드를 포함한다.
-
-✅ **필수**: 모든 operation에 고유한 `operationId`를 부여한다 — 코드 생성 및 문서 자동화의 기반이 된다.
-
-⚠️ **권장**: 주요 스키마와 파라미터에 `example` 또는 `examples`를 포함하여 문서 가독성을 높인다.
-
-```yaml
-# Good
-paths:
-  /articles:
-    get:
-      operationId: listArticles
-      description: 페이지네이션된 게시글 목록을 조회한다.
-      parameters:
-        - name: pageSize
-          in: query
-          description: 페이지당 항목 수.
-          schema:
-            type: integer
-            example: 20
-```
-
-### 7.3 스키마 매핑
-
-✅ **필수**: 필드 동작을 OpenAPI 속성으로 매핑한다:
-
-| 필드 동작 | OpenAPI 속성 |
-|-----------|-------------|
-| 읽기 전용 (예: `id`, `createdAt`) | `readOnly: true` |
-| 생성 전용 (예: 한 번만 쓰는 필드) | `writeOnly: true` |
-| Nullable (명시적으로 필요한 경우만) | `nullable: true` (OpenAPI 3.0); `type: ["string", "null"]` (OpenAPI 3.1) |
-
-⚠️ **권장**: 필드 생략 원칙을 따른다 — `nullable` 사용을 최소화하고, `null` 대신 필드를 생략한다.
-
-✅ **필수**: RFC 9457 Problem Details를 공유 `$ref` 컴포넌트로 정의한다.
-
-```yaml
-components:
-  schemas:
-    ProblemDetail:
-      type: object
-      required: [type, title, status, detail]
-      properties:
-        type:
-          type: string
-          format: uri
-          description: 에러 유형을 식별하는 URI.
-          example: "https://api.example.com/errors/validation-failed"
-        title:
-          type: string
-          description: 에러 유형의 짧은 요약.
-        status:
-          type: integer
-          description: HTTP 상태 코드.
-        detail:
-          type: string
-          description: 구체적인 에러 설명.
-        instance:
-          type: string
-          description: 문제가 발생한 요청 경로.
-        traceId:
-          type: string
-          description: Request-Id 응답 헤더 값과 일치.
-```
-
-### 7.4 확장 & 검증
-
-⚠️ **권장**: 비공개 엔드포인트는 `x-internal: true` 확장으로 마킹한다.
-
-⚠️ **권장**: CI에서 Spectral, Zally 등 린터를 사용하여 스펙 가이드라인 준수를 자동 검증한다.
-
----
-
-## 8. 참고 자료
-
-**Google API Improvement Proposals (AIP):**
-
-- [AIP-121: Resource-oriented design](https://google.aip.dev/121)
-- [AIP-136: Custom methods](https://google.aip.dev/136)
-- [AIP-154: Resource freshness validation (ETags)](https://google.aip.dev/154)
-- [AIP-157: Partial responses](https://google.aip.dev/157)
-- [AIP-160: Filtering](https://google.aip.dev/160)
-- [AIP-161: Field masks](https://google.aip.dev/161)
-- [AIP-163: Change validation](https://google.aip.dev/163)
-- [AIP-164: Soft delete](https://google.aip.dev/164)
-- [AIP-203: Field behavior documentation](https://google.aip.dev/203)
-- [AIP-216: States](https://google.aip.dev/216)
-
-**RFCs & 표준:**
-
-- [RFC 2119 - Key words for use in RFCs to Indicate Requirement Levels](https://datatracker.ietf.org/doc/html/rfc2119)
-- [RFC 8174 - Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words](https://datatracker.ietf.org/doc/html/rfc8174)
-- [RFC 3339 - Date and Time on the Internet](https://datatracker.ietf.org/doc/html/rfc3339)
-- [RFC 9110: HTTP Semantics](https://datatracker.ietf.org/doc/html/rfc9110)
-- [RFC 8288 - Web Linking](https://datatracker.ietf.org/doc/html/rfc8288)
-- [RFC 6585 - Additional HTTP Status Codes (429)](https://datatracker.ietf.org/doc/html/rfc6585#section-4)
-- [RFC 8594: The Sunset HTTP Header Field](https://datatracker.ietf.org/doc/html/rfc8594)
-- [RFC 9745: The Deprecation HTTP Response Header Field](https://datatracker.ietf.org/doc/html/rfc9745)
-- [draft-ietf-httpapi-ratelimit-headers-10: RateLimit Header Fields for HTTP](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/)
-
-**업계 가이드라인 & 기타:**
-
-- [Microsoft Azure REST API Guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md)
-- [JSON:API Specification](https://jsonapi.org/)
-- [Architectural Styles and the Design of Network-based Software Architectures - Roy Fielding](https://roy.gbiv.com/pubs/dissertation/fielding_dissertation.pdf)
-- [Day1, 2-2. 그런 REST API로 괜찮은가](https://www.youtube.com/watch?v=RP_f5dMoHFc)
+- [Google API Improvement Proposals (AIP)](https://google.aip.dev)
+- [RFC 9457: Problem Details for HTTP APIs](https://datatracker.ietf.org/doc/html/rfc9457)
+- [OWASP API Security Top 10](https://owasp.org/www-project-api-security/)

--- a/plugins/api/README.md
+++ b/plugins/api/README.md
@@ -6,46 +6,48 @@ RESTful API design guidelines.
 
 ---
 
+## Profile Guide
+
+Each rule is tagged with `[T1]`, `[T2]`, or `[T3]`. When a profile is specified, only rules at that Tier or below are applied.
+
+| Profile | Tiers Included | Target | Rule Count |
+|--------|-----------|------|---------|
+| **Essential** | T1 only | All APIs — from day one | ~87 |
+| **Standard** | T1 + T2 | Production operation phase | ~121 |
+| **Full** | T1 + T2 + T3 | Large-scale/Enterprise APIs | ~146 |
+
+**Tier Criteria (ADR-0010):**
+- **T1 (Essential):** Breaking change risk if introduced later / Security mandatory / HTTP standards / API contract fundamentals
+- **T2 (Standard):** Production operation convenience, can be introduced later
+- **T3 (Full):** Enterprise/Advanced patterns, domain-specific
+
+---
+
 ## Table of Contents
 
 1. [Overview](#1-overview)
    - [Compliance Levels](#compliance-levels)
-2. [REST Basics](#2-rest-basics)
-   - [URL Design](#21-url-design)
-   - [HTTP Methods & Status Codes](#22-http-methods--status-codes)
-   - [Query Parameters](#23-query-parameters)
-   - [HTTP Headers](#24-http-headers)
-   - [JSON Data Format](#25-json-data-format)
-   - [Error Response](#26-error-response)
-3. [REST Design](#3-rest-design)
-   - [Resource Schema & Field Rules](#31-resource-schema--field-rules)
-   - [CRUD Operations](#32-crud-operations)
-   - [Actions](#33-actions)
-   - [Collections & Pagination](#34-collections--pagination)
-   - [Filtering & Sorting](#35-filtering--sorting)
-   - [Partial Response](#36-partial-response)
-   - [Expand/Embed](#37-expandembed)
-   - [Bulk Operations](#38-bulk-operations)
-4. [API Operations](#4-api-operations)
-   - [API Versioning](#41-api-versioning)
-   - [Deprecation](#42-deprecation)
-   - [Rate Limiting](#43-rate-limiting)
-   - [Long-Running Operations](#44-long-running-operations)
-   - [Idempotency-Key](#45-idempotency-key)
-5. [Authentication & Security](#5-authentication--security)
-   - [5.1 Authentication Methods](#51-authentication-methods)
-   - [5.2 Authorization & Access Control](#52-authorization--access-control)
-   - [5.3 Input Validation & Mass Assignment](#53-input-validation--mass-assignment)
-   - [5.4 Security Headers](#54-security-headers)
-   - [5.5 401 vs 403 Distinction](#55-401-vs-403-distinction)
-   - [5.6 Webhooks](#56-webhooks)
-6. [Health Check](#6-health-check)
-7. [OpenAPI Specification](#7-openapi-specification)
-   - [7.1 API First](#71-api-first)
-   - [7.2 Spec Quality](#72-spec-quality)
-   - [7.3 Schema Mapping](#73-schema-mapping)
-   - [7.4 Extensions & Validation](#74-extensions--validation)
-8. [References](#8-references)
+2. [URL Design](#2-url-design)
+3. [HTTP Methods & Status Codes](#3-http-methods--status-codes)
+4. [Headers](#4-headers)
+5. [JSON Format](#5-json-format)
+6. [Error Response](#6-error-response)
+7. [Resource Schema & Field Rules](#7-resource-schema--field-rules)
+8. [CRUD Behavior](#8-crud-behavior)
+9. [Actions](#9-actions)
+10. [Collections & Pagination](#10-collections--pagination)
+11. [Filtering & Sorting](#11-filtering--sorting)
+12. [Partial Response & Resource Expansion](#12-partial-response--resource-expansion)
+13. [Bulk Operations](#13-bulk-operations)
+14. [API Versioning](#14-api-versioning)
+15. [Deprecation](#15-deprecation)
+16. [Rate Limiting & Retries](#16-rate-limiting--retries)
+17. [Caching](#17-caching)
+18. [Long-Running Operations](#18-long-running-operations)
+19. [Idempotency-Key](#19-idempotency-key)
+20. [OpenAPI Specification](#20-openapi-specification)
+21. [Authentication & Security](#21-authentication--security)
+22. [References](#22-references)
 
 ---
 
@@ -58,13 +60,8 @@ RESTful API design guidelines.
   - They must be intuitively understandable.
   - They must provide clear messages when errors occur.
   - They must maintain backward compatibility across versions.
-- Follows Roy Fielding's RESTful principles ([Architectural Styles and the Design of Network-based Software Architectures](https://roy.gbiv.com/pubs/dissertation/fielding_dissertation.pdf)).
+- Follows Roy Fielding's RESTful principles.
   - HATEOAS is not implemented.
-
-### Scope
-
-- All new HTTP/HTTPS APIs developed within the organization
-- Applied as much as possible when improving existing APIs
 
 ### Compliance Levels
 
@@ -78,1542 +75,304 @@ The key words "MUST", "MUST NOT", "SHOULD", "MAY", and "DO NOT" in this document
 
 ---
 
-## 2. REST Basics
+## 2. URL Design
 
-### 2.1 URL Design
+- **Resource-oriented design** — APIs are designed around resources (nouns). URL paths express resource hierarchy; behavior is expressed via HTTP methods and custom methods.
+- Every resource MUST support at least GET (retrieval). `[T1]`
+- Prefer **standard methods** (GET, POST, PATCH, DELETE); use custom methods only when standard methods cannot express the operation. `[T1]`
+- Do not mirror database structure in API schema. `[T1]`
 
-#### Basic Structure
+- **kebab-case** for path segments: `/user-profiles`, `/product-categories/123`. `[T1]`
+- **Plural nouns** for collections: `/articles` not `/article`. `[T1]`
+- **No verbs in resource paths** — use HTTP methods for CRUD; non-CRUD actions use `POST` with colon syntax (resource-level: `/{resource}/{id}:{action}`, collection-level: `/{resource}:{action}`). `[T1]`
+- **No file extensions** (`.json`, `.xml`). `[T1]`
+- **No trailing slash** — `/articles` not `/articles/`. `[T1]`
+- **camelCase** for query parameters: `pageSize=20&sortOrder=desc`. `[T1]`
+- ASCII lowercase letters, numerals, and hyphens only in path segments. `[T1]`
+- Repeat parameter names for arrays: `?tag=tech&tag=design`. `[T1]`
+- **Single sub-resource nesting** — `/{parent}/{parentId}/{child}/{childId}` e.g., `/users/42/profiles/7`. `[T2]`
 
-```
-https://{host}/{service-root}/{resource}/{id}
-https://{host}/{service-root}/{resource}/{id}/{sub-resource}/{sub-id}
-```
-
-Example:
-
-```
-# Single resource
-GET https://api.example.com/orders/550e8400-e29b-41d4-a716-446655440000
-
-# Nested sub-resource (maximum depth)
-GET https://api.example.com/orders/550e8400-e29b-41d4-a716-446655440000/items/6ba7b810-9dad-11d1-80b4-00c04fd430c8
-```
-
-#### URL Casing
-
-✅ **Required**: Use lowercase kebab-case for URL paths.
-
-```
-# Good
-GET /user-profiles
-GET /product-categories/123
-
-# Bad
-GET /userProfiles
-GET /UserProfiles
-GET /user_profiles
-```
-
-✅ **Required**: Use plural nouns for resource collection names.
-
-```
-# Good
-GET /articles
-GET /users/123/comments
-
-# Bad
-GET /article
-GET /user/123/comment
-```
-
-❌ **Prohibited**: Do not include verbs in URLs. Express actions using HTTP methods.
-
-```
-# Bad
-POST /createUser
-GET /getArticles
-DELETE /deleteComment/123
-
-# Good
-POST /users
-GET /articles
-DELETE /comments/123
-```
-
-❌ **Prohibited**: Do not include file extensions (`.json`, `.xml`) in URLs. Use the `Accept` header for content negotiation.
-
-#### URL Nesting Depth
-
-✅ **Required**: Limit URL nesting to a maximum of 2 levels (`/{resource}/{id}/{sub-resource}/{subId}`).
-
-| Depth | Pattern | Example | Allowed |
-|-------|---------|---------|---------|
-| 0 | `/{resource}` | `/articles` | ✅ |
-| 1 | `/{resource}/{id}` | `/articles/123` | ✅ |
-| 2 | `/{resource}/{id}/{sub}` | `/articles/123/comments` | ✅ |
-| 2 | `/{resource}/{id}/{sub}/{subId}` | `/articles/123/comments/456` | ✅ |
-| 3+ | `/{a}/{id}/{b}/{id}/{c}` | — | ❌ |
-
-❌ **Prohibited**: Do not nest more than 2 levels deep. Promote deeply nested resources to top-level routes instead.
+**Nesting depth rule:** `[T2]`
+Nest at most one sub-resource under a parent. For deeper relationships, promote to a flat top-level route.
 
 | Situation | ✅ Do | ❌ Don't |
 |-----------|-------|---------|
-| Items under an order | `/orders/{orderId}/items/{itemId}` | `/users/{userId}/orders/{orderId}/items/{itemId}` |
-| Reviews on an order item | `/order-items/{itemId}/reviews/{reviewId}` | `/users/{userId}/orders/{orderId}/items/{itemId}/reviews/{reviewId}` |
-
-#### Allowed Characters
-
-✅ **Required**: Use only lowercase ASCII letters, digits, and hyphens (`-`) in URL path segments.
-
-✅ **Required**: Use camelCase for query parameter names.
-
-```
-# Good
-GET /articles?pageSize=20&sortOrder=desc
-
-# Bad
-GET /articles?page_size=20&sort_order=desc
-```
+| Order items under an order | `/orders/{orderId}/items/{itemId}` | `/users/{userId}/orders/{orderId}/items/{itemId}` |
+| Reviews on an order item | `/order-items/{orderItemId}/reviews/{reviewId}` | `/users/{userId}/orders/{orderId}/items/{itemId}/reviews/{reviewId}` |
 
 ---
 
-#### URL Length
+## 3. HTTP Methods & Status Codes
 
-⚠️ **Recommended**: Keep URLs under 2000 characters. If longer URLs are needed, consider moving query parameters to the request body.
+| Method | Purpose | Idempotent | Safe |
+|--------|---------|-----------|------|
+| GET | Retrieve | Yes | Yes |
+| POST | Create / execute custom method | No | No |
+| PUT | Full content replacement (file/binary upload) | Yes | No |
+| PATCH | Partial update (default update method) | No | No |
+| DELETE | Remove | Yes | No |
+| HEAD | Retrieve metadata only (no body) | Yes | Yes |
+| OPTIONS | Retrieve allowed methods/CORS info | Yes | Yes |
 
----
+- **HEAD:** Clients SHOULD use HEAD to check resource existence or last-modified time without downloading the full body. `[T2]`
+- **OPTIONS:** Servers MUST support OPTIONS for CORS preflight and SHOULD use it to describe supported methods via the `Allow` header. `[T2]`
+- GET, HEAD, DELETE must not include request bodies. `[T1]`
 
-### 2.2 HTTP Methods & Status Codes
+**2xx Success:**
+- `200 OK` — standard success. `[T1]`
+- `201 Created` — creation success; include `Location` header with new resource URL. `[T1]`
+- `202 Accepted` — request accepted, processing not complete; used for async or deferred operations. `[T2]`
+- `204 No Content` — success with no body (DELETE, etc.). `[T1]`
 
-#### HTTP Methods
+**4xx Client Error:**
+- `400 Bad Request` — malformed request, validation failure. `[T1]`
+- `401 Unauthorized` — missing/expired authentication. `[T1]`
+- `403 Forbidden` — authenticated but not authorized. `[T1]`
+- `404 Not Found` — resource doesn't exist. `[T1]`
+- `409 Conflict` — duplicate resource (same ID or unique constraint violation). `[T1]`
+- `412 Precondition Failed` — `If-Match` etag mismatch (conditional request failed). `[T1]`
+- `422 Unprocessable Entity` — semantic validation failure. `[T1]`
+- `429 Too Many Requests` — rate limit exceeded. `[T1]`
 
-| Method | Meaning | Idempotent | Safe |
-|--------|---------|------------|------|
-| GET | Retrieve a resource | ✅ | ✅ |
-| POST | Create a resource or perform an action | ❌ | ❌ |
-| PUT | Fully replace a resource | ✅ | ❌ |
-| PATCH | Partially update a resource | ❌ | ❌ |
-| DELETE | Delete a resource | ✅ | ❌ |
-| HEAD | Retrieve headers only | ✅ | ✅ |
-
-✅ **Required**: GET requests must not modify server state.
-
-✅ **Required**: PUT requests must be idempotent — sending the same request multiple times must produce the same result.
-
-⚠️ **Recommended**: Use PATCH instead of PUT for partial updates.
-
-❌ **Prohibited**: Do not include a request body in GET, HEAD, or DELETE requests.
-
-#### Status Codes
-
-✅ **Required**: Use the standard HTTP status codes below with their precise meanings.
-
-**2xx Success**
-
-| Code | Meaning | When to Use |
-|------|---------|-------------|
-| 200 OK | Success | Successful GET, PUT, PATCH, POST (action) |
-| 201 Created | Created | Successful resource creation via POST |
-| 204 No Content | No Content | Successful DELETE, no response body |
-
-**4xx Client Errors**
-
-| Code | Meaning | When to Use |
-|------|---------|-------------|
-| 400 Bad Request | Bad Request | Malformed request, validation failure |
-| 401 Unauthorized | Authentication Required | Missing or expired authentication token |
-| 403 Forbidden | Access Denied | Authenticated but lacks permission |
-| 404 Not Found | Not Found | Resource does not exist |
-| 409 Conflict | Conflict | Duplicate resource, optimistic lock failure |
-| 422 Unprocessable Entity | Unprocessable | Semantic validation failure |
-| 429 Too Many Requests | Too Many Requests | Rate limit exceeded |
-
-**5xx Server Errors**
-
-| Code | Meaning | When to Use |
-|------|---------|-------------|
-| 500 Internal Server Error | Server Error | Unexpected server error |
-| 503 Service Unavailable | Service Unavailable | Temporary server overload or maintenance |
-
-✅ **Required**: Include the URL of the created resource in the `Location` header for 201 Created responses.
-
-```
-HTTP/1.1 201 Created
-Location: https://api.example.com/users/articles/456
-Content-Type: application/json
-
-{
-  "id": "456",
-  "title": "New Article Title"
-}
-```
-
-❌ **Prohibited**: Do not return 200 OK for error situations.
+**5xx Server Error:**
+- `500 Internal Server Error` — unexpected failure. `[T1]`
+- `503 Service Unavailable` — temporary unavailability. `[T1]`
 
 ---
 
-### 2.3 Query Parameters
+## 4. Headers
 
-✅ **Required**: Use camelCase for query parameter names.
-
-✅ **Required**: Pass array values by repeating the same parameter name.
-
-```
-GET /articles?tag=tech&tag=design
-```
-
-⚠️ **Recommended**: Design query parameters as optional. Include required values in the path.
-
-⚠️ **Recommended**: Do not include sensitive information (passwords, tokens, etc.) in query parameters, as they may be recorded in server logs.
-
-❌ **Prohibited**: Do not use query parameters for operations that modify server state.
+- `Content-Type: application/json` for bodies. `[T1]`
+- `Accept: application/json` for content negotiation. `[T1]`
+- `Location` header on 201 Created. `[T1]`
+- `Total-Count` for collection size. `[T2]`
+- RFC 8288 `Link` header for pagination. `[T2]`
+- **No `X-` prefix on custom headers** (RFC 6648) — All new APIs MUST define custom headers without this prefix. `[T1]`
+- `Cache-Control` header specifies caching strategy. `[T2]`
+- `Request-Id` header — server MUST include a unique request identifier (UUID v4) in every response. `[T1]`
+- `ETag` — opaque string representing the resource version; server includes in responses. `[T1]`
+- `If-Match` — client sends etag value on Update/Delete requests for optimistic concurrency control. `[T1]`
 
 ---
 
-### 2.4 HTTP Headers
+## 5. JSON Format
 
-#### Request Headers
+- **camelCase** field names: `userId`, `createdAt`, `isActive`. `[T1]`
+- Never snake_case or abbreviations. `[T1]`
+- Omit null/missing fields entirely (do not send `"field": null`). `[T1]`
+- Date/time values as RFC 3339 strings; server responses in UTC (`Z`). `[T1]`
+- Standard resource fields: `id`, `createdAt` (create-only), `updatedAt` (read-only). `[T1]`
+- Servers must ignore read-only fields in request bodies. `[T1]`
 
-✅ **Required**: Include the `Content-Type` header when the request has a body.
-
-```
-Content-Type: application/json
-```
-
-⚠️ **Recommended**: Use the `Accept` header for response format negotiation.
-
-```
-Accept: application/json
-```
-
-#### Response Headers
-
-✅ **Required**: Include the `Content-Type` header when the response has a body.
-
-⚠️ **Recommended**: Use the `Cache-Control` header to specify caching strategy.
-
-```
-Cache-Control: no-cache
-Cache-Control: max-age=3600
-```
-
-⚠️ **Recommended**: Use the RFC 8288 `Link` header for collection pagination responses.
-
-```
-Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next",
-      <https://api.example.com/articles?pageSize=20>; rel="first"
-```
-
-⚠️ **Recommended**: Use the `Total-Count` header when providing total item count.
-
-```
-Total-Count: 100
-```
-
-#### Custom Headers
-
-⚠️ **Recommended**: Use clear names without the `X-` prefix for custom headers. The `X-` prefix was deprecated in RFC 6648 (2012).
-
-```
-Request-Id: abc-123
-Correlation-Id: xyz-789
-```
-
-> **Note**: Headers like `X-Request-Id` and `X-Correlation-Id` that have become de facto standards are allowed for legacy compatibility. Do not use the `X-` prefix for new custom headers.
-
-#### Request Tracing
-
-✅ **Required**: Include a `Request-Id` header (UUID v4) in every response for request tracing.
-
-```
-Request-Id: 550e8400-e29b-41d4-a716-446655440000
-```
-
-- If the client sends a `Request-Id` header, the server SHOULD adopt the value or generate a new one
-- Propagate `Request-Id` across microservices for distributed tracing
-- Include `Request-Id` in all service logs for debugging correlation
-- The `traceId` field in error responses (RFC 9457) MUST match the `Request-Id` header value
-
-❌ **Prohibited**: Do not redefine the meaning of standard HTTP headers.
+**State Enum Pattern (AIP-216):** `[T1]`
+- State field name MUST be `state` (not `status`).
+- First enum value MUST always be `STATE_UNSPECIFIED`.
+- `state` is OUTPUT_ONLY — state transitions via custom methods only.
 
 ---
 
-### 2.5 JSON Data Format
+## 6. Error Response
 
-#### Field Naming
-
-✅ **Required**: Use camelCase for JSON field names.
-
-```json
-// Good
-{
-  "userId": "123",
-  "createdAt": "2024-01-20T10:00:00Z",
-  "isActive": true
-}
-
-// Bad
-{
-  "user_id": "123",
-  "created_at": "2024-01-20T10:00:00Z",
-  "is_active": true
-}
-```
-
-✅ **Required**: Field names must start with a lowercase letter.
-
-❌ **Prohibited**: Do not overuse abbreviations in field names. Prefer clear, complete words.
-
-```json
-// Bad
-{
-  "usr": "john",
-  "ts": "2024-01-20T10:00:00Z",
-  "cnt": 5
-}
-
-// Good
-{
-  "username": "john",
-  "timestamp": "2024-01-20T10:00:00Z",
-  "count": 5
-}
-```
-
-#### Type System
-
-##### Boolean
-
-✅ **Required**: Use JSON `true`/`false` for boolean values. Do not use strings `"true"`/`"false"` or numbers `1`/`0`.
-
-✅ **Required**: Use prefixes like `is`, `has`, `can` for boolean field names.
-
-```json
-{
-  "isActive": true,
-  "hasPermission": false,
-  "canEdit": true
-}
-```
-
-##### Number
-
-✅ **Required**: Use JSON number type for numeric values.
-
-⚠️ **Recommended**: Return large integers that exceed JavaScript's safe integer range (2^53 - 1) as strings.
-
-```json
-{
-  "count": 42,
-  "price": 19.99,
-  "largeId": "9007199254740993"
-}
-```
-
-##### String
-
-⚠️ **Recommended**: Distinguish between empty string (`""`) and `null`. Omit the field for meaningful "no value" cases; use empty string only when the value is intentionally empty.
-
-#### Dates and Times
-
-✅ **Required**: Represent all date/time values as strings in RFC 3339 format (ISO 8601 profile).
-
-✅ **Required**: Always include the timezone when present. Use `Z` for UTC.
-
-✅ **Required**: Return all time values in server responses as UTC (`Z`). Clients handle conversion to local timezone.
-
-⚠️ **Recommended**: Send time values in client requests as UTC (`Z`). If an offset is included, the server normalizes to UTC before storing.
-
-⚠️ **Recommended**: Use `YYYY-MM-DD` format without timezone for date-only fields (e.g., date of birth).
-
-❌ **Prohibited**: Do not use Unix timestamps (epoch milliseconds/seconds) as the default time format.
-
-##### Server Response Example
-
-```json
-{
-  "createdAt": "2024-01-20T10:00:00Z",
-  "scheduledAt": "2024-01-25T00:30:00Z",
-  "birthDate": "1990-05-15"
-}
-```
-
-##### Client Request Example
-
-```json
-// ⚠️ Recommended: UTC
-{ "scheduledAt": "2024-01-25T00:30:00Z" }
-
-// Allowed: with offset → server normalizes to UTC before storing
-{ "scheduledAt": "2024-01-25T09:30:00+09:00" }
-```
-
-##### Server Normalization Rules
-
-✅ **Required**: When a client sends a time with an offset, the server converts it to UTC before storing. Do not return an error.
-
-✅ **Required**: Responses after server normalization must always be returned as UTC (`Z`).
-
-⚠️ **Recommended**: If timezone information is business-critical (e.g., preserving the user's original timezone), use a separate `timeZone` field.
-
-```json
-{
-  "scheduledAt": "2024-01-25T00:30:00Z",
-  "timeZone": "Asia/Seoul"
-}
-```
-
-#### Enum Handling
-
-✅ **Required**: Use UPPER_SNAKE_CASE strings for enum values.
-
-```json
-{
-  "status": "PUBLISHED",
-  "priority": "HIGH"
-}
-```
-
-⚠️ **Recommended**: Design for clients to receive unknown enum values. Handle new enum values being added without breaking existing clients.
-
-❌ **Prohibited**: Do not use numbers or unclear abbreviations for enum values.
-
-```json
-// Bad
-{
-  "status": 1,
-  "priority": "hi"
-}
-
-// Good
-{
-  "status": "PUBLISHED",
-  "priority": "HIGH"
-}
-```
-
----
-
-### 2.6 Error Response
-
-#### Error Response Structure
-
-✅ **Required**: All error responses must follow the RFC 7807 / RFC 9457 (Problem Details for HTTP APIs) standard.
-
-✅ **Required**: Use `application/problem+json` as the `Content-Type` for error responses.
-
-```json
-{
-  "type": "https://api.example.com/errors/resource-not-found",
-  "title": "Resource Not Found",
-  "status": 404,
-  "detail": "The requested article could not be found.",
-  "instance": "/articles/999",
-  "traceId": "abc-123-xyz"
-}
-```
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `type` | ✅ Required | URI identifying the error type (serves as documentation link; `about:blank` allowed) |
-| `title` | ✅ Required | Short, human-readable summary of the error type |
-| `status` | ✅ Required | HTTP status code (numeric) |
-| `detail` | ✅ Required | Specific error description for this request (in language the user can understand) |
-| `instance` | ⚠️ Recommended | Request path where the problem occurred |
-| `errors` | ⚠️ Recommended | Extension field — list of field-level validation error details |
-| `traceId` | ⚠️ Recommended | Extension field — MUST match `Request-Id` response header value |
-
-> **References**: [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807), [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457)
-
-⚠️ **Recommended**: Return all validation errors at once on validation failure (do not return one at a time).
+✅ **Required**: All error responses MUST follow RFC 7807 / RFC 9457 standard and use `application/problem+json`.
 
 ```json
 {
   "type": "https://api.example.com/errors/validation-failed",
   "title": "Validation Failed",
   "status": 400,
-  "detail": "Request data failed validation.",
-  "instance": "/articles",
-  "errors": [
-    { "field": "title", "message": "Title is required." },
-    { "field": "content", "message": "Content must be at least 10 characters." }
-  ],
-  "traceId": "abc-123-xyz"
-}
-```
-
-❌ **Prohibited**: Do not expose internal implementation details in error responses, such as stack traces, internal system paths, or database error messages.
-
----
-
-## 3. REST Design
-
-### 3.1 Resource Schema & Field Rules
-
-Resources are the core entities exposed by a service. Each resource must be accessible via a unique URL.
-
-✅ **Required**: Every resource must have a unique identifier (`id`).
-
-✅ **Required**: Resource schemas must maintain a consistent structure.
-
-**Standard Resource Fields**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string | Unique resource identifier |
-| `createdAt` | string (RFC 3339) | Creation timestamp |
-| `updatedAt` | string (RFC 3339) | Last modification timestamp |
-
-Example:
-
-```json
-{
-  "id": "123",
-  "title": "RESTful API Design",
-  "content": "...",
-  "createdAt": "2024-01-15T09:00:00Z",
-  "updatedAt": "2024-01-20T14:30:00Z"
-}
-```
-
-⚠️ **Recommended**: Design resource identifiers as opaque strings. Clients should not parse or depend on the structure of identifiers.
-
-❌ **Prohibited**: Do not include null-valued fields in responses. Omit fields with no value from the response.
-
-```json
-// Bad
-{
-  "id": "123",
-  "title": "Title",
-  "deletedAt": null
-}
-
-// Good
-{
-  "id": "123",
-  "title": "Title"
-}
-```
-
-#### Field Mutability
-
-Fields are classified by whether they can be changed after creation.
-
-| Classification | Description | Examples |
-|----------------|-------------|---------|
-| **Create-only** | Can only be set at creation, cannot be changed afterward | `id`, `createdAt` |
-| **Read-only** | Managed by the server, cannot be modified by clients | `updatedAt` |
-| **Mutable** | Can be modified by clients | `title`, `content` |
-
-✅ **Required**: Ignore server-managed read-only fields (`id`, `createdAt`, `updatedAt`) if included by the client in the request body.
-
-⚠️ **Recommended**: Document the mutability of each field in the API documentation.
-
-#### State Enum Pattern (AIP-216)
-
-Use a dedicated `state` field (not `status`) to represent the lifecycle state of a resource.
-
-✅ **Required**: Name the state field `state`, not `status`. (`status` conflicts with HTTP status codes.)
-
-✅ **Required**: The first enum value MUST be `STATE_UNSPECIFIED` (represents unknown or default state).
-
-✅ **Required**: The `state` field is `OUTPUT_ONLY` — clients MUST NOT set it directly via PATCH.
-
-✅ **Required**: State transitions MUST be performed via custom methods (e.g., `:activate`, `:deactivate`), not by patching the `state` field directly.
-
-⚠️ **Recommended**: Common patterns: `ACTIVE` / `INACTIVE`, `PENDING` / `RUNNING` / `SUCCEEDED` / `FAILED`.
-
-```json
-{
-  "id": "job-123",
-  "state": "RUNNING"
-}
-```
-
-```
-# Correct: state transition via custom method
-POST /jobs/123:cancel
-
-# Incorrect: directly patching state
-PATCH /jobs/123?updateMask=state
-{ "state": "CANCELLED" }   ← Prohibited
-```
-
----
-
-### 3.2 CRUD Operations
-
-#### POST — Create Resource
-
-✅ **Required**: Return 201 Created with the created resource upon successful resource creation.
-
-```
-POST /articles
-Content-Type: application/json
-
-{
-  "title": "New Article Title",
-  "content": "Article body content"
-}
-
----
-
-HTTP/1.1 201 Created
-Location: /articles/456
-Content-Type: application/json
-
-{
-  "id": "456",
-  "title": "New Article Title",
-  "content": "Article body content",
-  "createdAt": "2024-01-20T10:00:00Z",
-  "updatedAt": "2024-01-20T10:00:00Z"
-}
-```
-
-#### PUT — Full Resource Replacement
-
-✅ **Required**: PUT requests fully replace the resource. Mutable fields not included in the request body are treated as default or null values.
-
-✅ **Required**: PUT requests must be idempotent.
-
-#### PATCH — Partial Update (AIP-161)
-
-✅ **Required**: All PATCH requests MUST include the `updateMask` query parameter specifying which fields to update.
-
-```
-PATCH /articles/456?updateMask=title,content
-Content-Type: application/json
-
-{
-  "title": "Updated Title",
-  "content": "New content"
-}
-```
-
-✅ **Required**: Only the fields listed in `updateMask` are modified. Fields not in the mask remain unchanged.
-
-✅ **Required**: Return 200 OK with the updated full resource.
-
-⚠️ **Recommended**: Use `updateMask=*` to update all mutable fields present in the request body.
-
-✅ **Required**: Empty `updateMask` → 400 Bad Request. Unknown field path in `updateMask` → 400 Bad Request.
-
-⚠️ **Recommended**: Use dot notation for nested field paths: `?updateMask=address.city`.
-
-**Field Behavior interactions with `updateMask`:**
-
-| Field Annotation | Behavior when included in mask |
-|---|---|
-| `OUTPUT_ONLY` | Silently ignored — not an error |
-| `IMMUTABLE` | `400 Bad Request` if value is changed |
-| `REQUIRED` | Field must be present in request body |
-| `OPTIONAL` | May be omitted from body (retains current value) |
-
-#### DELETE — Delete Resource
-
-✅ **Required**: Return 204 No Content upon successful deletion.
-
-⚠️ **Recommended**: Return either 404 Not Found or 204 No Content for re-deletion of already-deleted resources. Decide based on service characteristics.
-
-⚠️ **Recommended**: Support the `force` query parameter for cascading deletion of child resources.
-
-```
-DELETE /projects/123?force=true
-```
-
-#### Soft Delete (AIP-164)
-
-For resources that require recovery capability instead of immediate permanent deletion:
-
-✅ **Required**: Add `deleteTime` (deletion timestamp) and `expireTime` (scheduled permanent deletion) fields, both `OUTPUT_ONLY`.
-
-✅ **Required**: Provide a restore endpoint: `POST /{resource}/{id}:undelete`.
-
-✅ **Required**: List responses exclude soft-deleted resources by default. Use `?showDeleted=true` to include them.
-
-⚠️ **Recommended**: Get returns soft-deleted resources normally (with `deleteTime` included).
-
-⚠️ **Recommended**: Permanently delete after a retention period (default 30 days).
-
-```
-# Soft delete
-DELETE /articles/123
-
-# Restore
-POST /articles/123:undelete
-
-# List including deleted
-GET /articles?showDeleted=true
-```
-
-#### Change Validation / Dry Run (AIP-163)
-
-Pre-validate Create or Update requests without applying changes:
-
-⚠️ **Recommended**: Support the `?validateOnly=true` query parameter.
-
-✅ **Required**: When `validateOnly=true`, perform validation only — no resource changes, no side effects.
-
-✅ **Required**: On validation success, return a response similar to actual execution (server-generated fields may be omitted).
-
-✅ **Required**: On validation failure, return the same RFC 9457 error format as a real request.
-
-```
-# Validate without creating
-POST /articles?validateOnly=true
-Content-Type: application/json
-
-{ "title": "New Article" }
-
----
-
-HTTP/1.1 200 OK
-{ "id": null, "title": "New Article" }   # id omitted (not yet created)
-```
-
----
-
-### 3.3 Actions (AIP-136)
-
-Use the action pattern for operations that are difficult to express as CRUD (e.g., approve, send, lock).
-
-✅ **Required**: Express actions as `:action` appended to the resource URL.
-
-```
-POST /articles/123:publish
-POST /users/456:deactivate
-POST /orders/789:cancel
-```
-
-✅ **Required**: Use the POST method for action endpoints.
-
-⚠️ **Recommended**: Use verb infinitives for action names (publish, cancel, approve).
-
-**Action Response Status Codes:**
-
-| Scenario | Status Code | Response Body |
-|----------|-------------|---------------|
-| Sync action — resource updated | `200 OK` | Updated resource |
-| Sync action — no response body | `204 No Content` | None |
-| Async action — fire-and-forget | `202 Accepted` | None or minimal acknowledgement |
-| Async action — pollable job created | `201 Created` + `Location` header | Created job resource |
-
-**Request Example:**
-
-```
-POST /articles/123:publish
-Content-Type: application/json
-
-{}
-
----
-
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "id": "123",
-  "status": "PUBLISHED",
-  "publishedAt": "2024-01-20T15:00:00Z"
-}
-```
-
----
-
-### 3.4 Collections & Pagination
-
-#### Collection Response Structure
-
-✅ **Required**: Return a resource array (top-level JSON array) as the collection response body.
-
-```
-HTTP/1.1 200 OK
-Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next",
-      <https://api.example.com/articles?pageSize=20>; rel="first",
-      <https://api.example.com/articles?pageSize=20&pageToken=xyz>; rel="last"
-Total-Count: 100
-
-[
-  { "id": "1", "title": "First Article" },
-  { "id": "2", "title": "Second Article" }
-]
-```
-
-| Header | Required | Description |
-|--------|----------|-------------|
-| `Link` | ⚠️ Recommended | Pagination navigation (RFC 8288) |
-| `Total-Count` | ⚠️ Recommended | Total item count |
-
-| rel value | Description |
-|-----------|-------------|
-| `next` | Next page |
-| `prev` | Previous page |
-| `first` | First page |
-| `last` | Last page |
-
-#### Empty Collection Response
-
-✅ **Required**: Return `200 OK` with an empty array `[]` when a collection has no items. Do not return `404 Not Found` for empty collections.
-
-⚠️ **Recommended**: Include the `Total-Count: 0` header for empty collections.
-
-```
-HTTP/1.1 200 OK
-Content-Type: application/json
-Total-Count: 0
-
-[]
-```
-
-> **Note**: A collection endpoint always exists as a resource even when empty ([RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110)). `404 Not Found` indicates the endpoint itself does not exist, not that the collection is empty.
-
-#### Cursor-Based Pagination (Recommended)
-
-⚠️ **Recommended**: Use cursor-based pagination instead of offset-based for large datasets.
-
-**Request:**
-
-```
-GET /articles?pageSize=20&pageToken=eyJwYWdlIjoyf...
-```
-
-**Response:**
-
-```
-HTTP/1.1 200 OK
-Link: <https://api.example.com/articles?pageSize=20&pageToken=abc>; rel="next",
-      <https://api.example.com/articles?pageSize=20>; rel="first"
-
-[
-  { "id": "1", "title": "First Article" },
-  ...
-]
-```
-
-✅ **Required**: Exclude `rel="next"` from the `Link` header when there is no next page.
-
-✅ **Required**: `pageToken` is an opaque value. Clients MUST NOT parse, construct, or make assumptions about its internal format.
-
-✅ **Required**: Servers MAY change the encoding of `pageToken` at any time without notice.
-
-> **Note**: This follows the same principle as resource identifiers — opaque strings that clients must not depend on structurally.
-
-#### Offset-Based Pagination
-
-Offset-based pagination is also acceptable for small datasets.
-
-**Request:**
-
-```
-GET /articles?page=2&pageSize=20
-```
-
-**Response:**
-
-```
-HTTP/1.1 200 OK
-Link: <https://api.example.com/articles?pageSize=20&page=1>; rel="first",
-      <https://api.example.com/articles?pageSize=20&page=1>; rel="prev",
-      <https://api.example.com/articles?pageSize=20&page=3>; rel="next",
-      <https://api.example.com/articles?pageSize=20&page=5>; rel="last"
-Total-Count: 100
-
-[
-  { "id": "21", "title": "Article 21" },
-  ...
-]
-```
-
-⚠️ **Recommended**: Set the default page size (`pageSize`) to 20.
-
-⚠️ **Recommended**: Limit the maximum page size to 100.
-
-✅ **Required**: Return `400 Bad Request` when `pageSize` is less than 1.
-
-⚠️ **Recommended**: When `pageSize` exceeds the maximum allowed value, cap it to the maximum rather than returning an error. Include the applied `pageSize` in the response.
-
-```
-# Request: pageSize=500 (max is 100)
-# Server applies pageSize=100
-
-HTTP/1.1 200 OK
-Link: <https://api.example.com/articles?pageSize=100&pageToken=abc>; rel="next"
-
-[ ... 100 items ... ]
-```
-
-#### Keyset Pagination
-
-⚠️ **Recommended**: Use keyset pagination for large datasets where consistent performance is critical.
-
-Keyset pagination uses the last item's sort key as a cursor, achieving O(1) lookup regardless of page depth.
-
-**Request:**
-
-```
-GET /articles?pageSize=20&orderBy=createdAt:desc&after=eyJjcmVhdGVkQXQiOi...
-```
-
-**Response:**
-
-```
-HTTP/1.1 200 OK
-Link: <https://api.example.com/articles?pageSize=20&orderBy=createdAt:desc&after=eyJjcmVhdGVkQXQiOi...>; rel="next"
-
-[
-  { "id": "455", "createdAt": "2024-01-20T09:55:00Z" },
-  ...
-  { "id": "440", "createdAt": "2024-01-15T08:00:00Z" }
-]
-```
-
-✅ **Required**: The keyset cursor (`after`/`before`) MUST be an opaque token — clients must not construct it manually.
-
-⚠️ **Recommended**: Encode compound sort keys into the opaque cursor.
-
-> **Trade-off**: Keyset pagination cannot jump to arbitrary pages. Use offset pagination when random page access is required.
-
----
-
-### 3.5 Filtering & Sorting
-
-#### Filtering
-
-✅ **Required**: Use the `filter` query parameter with a structured expression string (AIP-160).
-
-**Filter expression syntax:**
-
-```
-GET /articles?filter=status = "PUBLISHED" AND authorId = "user-123"
-```
-
-**Operators:**
-
-| Type | Operators | Example |
-|---|---|---|
-| Comparison | `=`, `!=`, `<`, `>`, `<=`, `>=` | `?filter=price >= 100` |
-| Logical | `AND`, `OR`, `NOT` | `?filter=status = "ACTIVE" AND NOT archived = true` |
-| Grouping | `( )` | `?filter=(status = "ACTIVE" OR status = "PENDING") AND price < 1000` |
-
-**Value types:**
-
-- Strings and timestamps: double-quoted — `?filter=createdAt > "2024-01-01T00:00:00Z"`
-- Numbers: unquoted — `?filter=price >= 100`
-- Booleans: `true` / `false` — `?filter=isPublished = true`
-- Nested fields: dot notation — `?filter=author.name = "Kim"`
-- Repeated field membership: `has()` — `?filter=has(tags, "golang")`
-
-**Examples:**
-
-```
-# Single condition
-GET /articles?filter=status = "PUBLISHED"
-
-# Multiple conditions (AND)
-GET /articles?filter=status = "PUBLISHED" AND authorId = "user-123"
-
-# OR condition
-GET /articles?filter=status = "PUBLISHED" OR status = "DRAFT"
-
-# Grouped complex condition
-GET /articles?filter=(status = "PUBLISHED" OR status = "DRAFT") AND createdAt > "2024-01-01T00:00:00Z"
-
-# Negation
-GET /articles?filter=NOT status = "DELETED"
-
-# Date range
-GET /articles?filter=createdAt >= "2024-01-01T00:00:00Z" AND createdAt < "2024-02-01T00:00:00Z"
-
-# Numeric range
-GET /products?filter=price >= 100 AND price <= 500
-
-# Nested field
-GET /articles?filter=author.name = "Kim"
-
-# Repeated field membership
-GET /articles?filter=has(tags, "golang")
-```
-
-❌ **Prohibited**: Do not use individual query parameters for filtering (e.g., `?status=PUBLISHED`, `?createdAfter=...`).
-
-✅ **Required**: Invalid filter expression → 400 Bad Request with RFC 9457 error body.
-
-#### Sorting
-
-⚠️ **Recommended**: Use the `orderBy` parameter for sorting, combining field name and direction.
-
-```
-GET /articles?orderBy=createdAt:desc
-GET /articles?orderBy=title:asc
-GET /articles?orderBy=createdAt:desc,title:asc
-```
-
-⚠️ **Recommended**: Document the default sort order in the API documentation.
-
----
-
-### 3.6 Partial Response
-
-✅ **Required**: Support the `fields` query parameter for clients to request specific response fields (AIP-157).
-
-```
-GET /articles/123?fields=id,title,author.name
-```
-
-✅ **Required**: `id` is always included in the response regardless of the `fields` value.
-
-⚠️ **Recommended**: Use dot notation to select nested fields.
-
-```
-GET /articles/123?fields=id,author.name,author.email
-```
-
-✅ **Required**: Apply `fields` filtering to each item in List responses.
-
-✅ **Required**: `INPUT_ONLY` fields are always excluded from responses regardless of `fields`.
-
-⚠️ **Recommended**: ETag reflects the full resource, not the partial view.
-
-✅ **Required**: Unknown field name in `fields` → 400 Bad Request.
-
-**Example:**
-
-```
-GET /articles?fields=id,title,author.name
-
----
-
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-[
-  {
-    "id": "123",
-    "title": "REST API Design",
-    "author": {
-      "name": "Kim"
+  "code": "VALIDATION_ERROR",
+  "detail": "The request contains invalid fields.",
+  "instance": "/users",
+  "traceId": "abc-123-xyz",
+  "details": [
+    {
+      "@type": "type.googleapis.com/google.rpc.BadRequest",
+      "fieldViolations": [
+        {
+          "field": "user.email",
+          "description": "Must be a valid email address."
+        }
+      ]
     }
-  }
-]
+  ]
+}
+```
+
+- **Machine-readable code:** Include a `code` string field (UPPER_SNAKE_CASE). `[T1]`
+- **Field-level errors (AIP-193 style):** Include a `details` array with polymorphic objects. `[T1]`
+- Include **all** validation failures at once. `[T1]`
+- `traceId` MUST match the `Request-Id` response header. `[T1]`
+- Never expose internal implementation details. `[T1]`
+
+---
+
+## 7. Resource Schema & Field Rules
+
+**Field Behavior Annotations (AIP-203):** `[T1]`
+Declare behavior in OpenAPI schema using `x-field-behavior`.
+
+| Annotation | Meaning |
+|-----------|---------|
+| `REQUIRED` | Client must provide |
+| `OUTPUT_ONLY` | Set by server; client must not provide |
+| `INPUT_ONLY` | Client-provided; excluded from response |
+| `IMMUTABLE` | Cannot change after creation |
+| `OPTIONAL` | Optionally provided |
+| `IDENTIFIER` | Resource identifier; cannot change |
+
+---
+
+## 8. CRUD Behavior
+
+**Standard method response rules:**
+- POST (Create): return `201` with full resource + `Location` header. `[T1]`
+- PATCH (Update): return the updated full resource. `[T1]`
+- DELETE: return `204` with no body. `[T1]`
+
+**PATCH (Update — default):** `[T1]`
+- `updateMask` query parameter is REQUIRED: comma-separated field paths — `?updateMask=title,content`.
+- Only modify fields specified by `updateMask`.
+- Empty mask or unknown field path → `400 Bad Request`.
+
+**Optimistic Concurrency Control (AIP-154):** `[T1]`
+- Include an `etag` field in the resource (OUTPUT_ONLY).
+- Pass etag via `If-Match: {etag}` header on Update/Delete requests.
+- Etag mismatch → return `412 Precondition Failed`.
+
+---
+
+## 9. Actions
+
+**Non-CRUD actions (AIP-136):** `[T1]`
+Use `POST` with colon syntax for operations that carry side-effects.
+
+```
+POST /orders/{id}:cancel
+POST /reports:generate
 ```
 
 ---
 
-### 3.7 Expand/Embed
+## 10. Collections & Pagination
 
-✅ **Required**: Support the `expand` query parameter to include related resources in the response.
+- Collections return **top-level JSON array** `[]`. `[T1]`
+- **Empty collections**: return `200 OK` + `[]` — never `404`. `[T1]`
 
-```
-GET /articles/123?expand=author,comments.author
-```
-
-✅ **Required**: To prevent N+1 query explosions and DoS attacks (Unrestricted Resource Consumption), the server MUST enforce a strict upper limit on the **total number of expanded entities** returned in a single response (e.g., maximum 100 entities).
-
-✅ **Required**: If an expansion request would exceed the maximum entity limit, return `400 Bad Request`.
-
-⚠️ **Recommended**: Limit the maximum expansion depth to 3 levels.
+**Token-based Pagination (AIP-158, Recommended):** `[T2]`
+- Use `pageSize` and `pageToken` (opaque token).
+- Link header with `rel="next"`, `prev`, `first`.
 
 ---
 
-### 3.8 Bulk Operations
+## 11. Filtering & Sorting
 
-Bulk operations allow processing multiple resources in a single request to reduce network overhead.
+❌ Do not use individual query parameters for filtering.
 
-✅ **Required**: Express bulk operations as custom methods on the collection URL using colon syntax.
+**Filter expression (AIP-160):** `[T1]`
+- Syntax: `?filter=status = "ACTIVE" AND price >= 1000`.
+- Operators: `=`, `!=`, `<`, `>`, `<=`, `>=`, `AND`, `OR`, `NOT`, `has()`.
+- Invalid filter expression → `400 Bad Request`.
 
-| Method | Goal | Endpoint |
-|--------|------|----------|
-| `batchCreate` | Create multiple resources | `POST /{resources}:batchCreate` |
-| `batchGet` | Retrieve multiple resources by ID | `POST /{resources}:batchGet` |
-| `batchUpdate` | Update multiple resources | `POST /{resources}:batchUpdate` |
-| `batchDelete` | Delete multiple resources | `POST /{resources}:batchDelete` |
-
-✅ **Required**: The request body MUST contain an array of items or IDs to process.
-
-✅ **Required**: Specify whether the bulk operation is atomic (all-or-nothing) or non-atomic (partial success allowed).
-
-✅ **Required**: For non-atomic operations, the response MUST use a structure that can express per-item success or failure (including RFC 9457 error objects for failed items).
+**Sorting:** `?orderBy=createdAt:desc,title:asc`. `[T2]`
 
 ---
 
-## 4. API Operations
+## 12. Partial Response & Resource Expansion
 
-### 4.1 API Versioning
+**Partial Response (AIP-157):** `[T2]`
+- Use `fields` query parameter: `?fields=id,title,author.name`.
+- `id` is always included.
 
-#### Version Notation
+**Resource Expansion (Expand/Embed):** `[T2]`
+- Use `expand` query parameter: `?expand=author`.
+- **Total Entity Limit REQUIRED:** MUST enforce a hard limit (e.g., max 100 entities). `[T1]`
+- Exceeding limit → `400 Bad Request`.
 
-❌ **Prohibited**: Do not include the API version in the URL path.
+---
 
-> **Reason**: A URL is a resource identifier. `/v1/articles` and `/v2/articles` represent the same resource but with different URLs, which violates REST principles. URL versioning also forces clients to rewrite their code entirely. Header versioning allows clients to migrate gradually and gives the server flexibility to apply a default version when no version header is specified.
+## 13. Bulk Operations
 
-✅ **Required**: Specify the version in the `Api-Version` header using ISO 8601 (`YYYY-MM-DD`) date format.
+✅ **Required**: Express bulk operations as custom methods on the collection URL using colon syntax. `[T3]`
+- `batchCreate`, `batchGet`, `batchUpdate`, `batchDelete`.
+- Specify whether atomic or non-atomic.
 
+---
+
+## 14. API Versioning
+
+❌ **URL path versioning is PROHIBITED.** `[T1]`
+
+✅ **Header versioning is REQUIRED:** `[T1]`
 ```
 Api-Version: 2024-01-20
 ```
 
-❌ **Prohibited**: Do not apply a default or latest version when the version header is missing.
-✅ **Required**: If the `Api-Version` header is missing, the server MUST return `400 Bad Request` to enforce explicit versioning and prevent accidental backward compatibility breaks.
-
-#### Backward Compatibility
-
-✅ **Required**: Maintain backward compatibility within the same version.
-
-**Breaking changes** (require new `Api-Version` date):
-
-| Category | Examples |
-|----------|----------|
-| Removal | Endpoint, field, or enum value removal |
-| Rename | Field or endpoint name change |
-| Type change | Field type or format change (e.g., `string` → `int`) |
-| Constraint tightening | `optional` → `required`, new required field, stricter validation rules |
-| Semantic change | Status code meaning change, default value change, sort order change |
-
-**Compatible changes** (no version bump required):
-
-| Category | Examples |
-|----------|----------|
-| Addition | New endpoint, new optional field, new enum value, new query parameter |
-| Relaxation | `required` → `optional`, loosened validation rules |
-| Metadata | Response property order change, description update |
-
-#### Compatibility Principles
-
-✅ **Required**: Clients MUST ignore unknown fields in responses (tolerant reader pattern).
-
-✅ **Required**: Servers MUST ignore unknown fields in requests.
-
-✅ **Required**: Treat enums as open-ended — clients MUST handle unknown enum values gracefully rather than failing.
-
-⚠️ **Recommended**: Maintain the previous version for at least 6 months before a version bump.
+- Requests without version header MUST receive **`400 Bad Request`**. `[T1]`
+- Responses always include the applied version. `[T1]`
+- Maintain previous versions for minimum 6 months. `[T2]`
 
 ---
 
-### 4.2 Deprecation
+## 15. Deprecation
 
-✅ **Required**: Notify clients of deprecated APIs via response headers.
-
-```
-Deprecation: true
-Sunset: Sat, 01 Jan 2025 00:00:00 GMT
-Link: <https://api.example.com/users/articles>; rel="successor-version"
-```
-
-⚠️ **Recommended**: Announce deprecation at least 6 months before the end-of-life date.
-
-⚠️ **Recommended**: Notify clients with `Deprecation`, `Sunset`, and `Link` headers on deprecated API calls.
-
-```
-HTTP/1.1 200 OK
-Deprecation: true
-Sunset: Sat, 01 Jan 2025 00:00:00 GMT
-Link: <https://api.example.com/users/articles>; rel="successor-version"
-
-[
-  { "id": "1", "title": "Item 1" },
-  ...
-]
-```
+- Include headers: `Deprecation: true`, `Sunset`, `Link`. `[T1]`
+- Notice must be given at least 6 months before sunset. `[T1]`
 
 ---
 
-### 4.3 Rate Limiting
+## 16. Rate Limiting & Retries
 
-API servers limit request frequency per client to ensure service stability.
-
-#### Response Headers
-
-✅ **Required**: Include the following headers in all responses where rate limiting applies.
-
-**Legacy headers (X-RateLimit-\*)**
-
-| Header | Description | Example |
-|--------|-------------|---------|
-| `X-RateLimit-Limit` | Maximum requests allowed within the time window | `100` |
-| `X-RateLimit-Remaining` | Remaining requests in the current time window | `99` |
-| `X-RateLimit-Reset` | Time when the window resets (Unix timestamp, seconds) | `1742342450` |
-
-**IETF standard headers ([draft-ietf-httpapi-ratelimit-headers-10](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/), Internet-Draft, Standards Track)**
-
-| Header | Description | Example |
-|--------|-------------|---------|
-| `RateLimit` | Current rate limit state (Structured Field) | `limit=100, remaining=99, reset=50` |
-| `RateLimit-Policy` | Active rate limit policy | `100;w=3600` |
-
-> **Note**: The `reset` value in the `RateLimit` header is **delta-seconds** (seconds until window reset), while `X-RateLimit-Reset` is a **Unix timestamp**. Be careful not to confuse them.
->
-> **`RateLimit-Policy` structure**: `100;w=3600` — `100` is the maximum allowed requests, `w=3600` is the window size in seconds. Include in all responses.
-
-**Normal response example:**
-
-```
-HTTP/1.1 200 OK
-Content-Type: application/json
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 99
-X-RateLimit-Reset: 1742342450
-RateLimit: limit=100, remaining=99, reset=50
-RateLimit-Policy: 100;w=3600
-
-[
-  { "id": "1", "title": "Item 1" }
-]
-```
-
-#### 429 Too Many Requests Response
-
-✅ **Required**: Return `429 Too Many Requests` when rate limit is exceeded.
-
-✅ **Required**: Include the `Retry-After` header in 429 responses. Use delta-seconds (seconds to wait before retrying).
-
-✅ **Required**: Use RFC 7807/9457 Problem Details structure for 429 response bodies.
-
-**429 response example:**
-
-```
-HTTP/1.1 429 Too Many Requests
-Content-Type: application/problem+json
-Retry-After: 50
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 0
-X-RateLimit-Reset: 1742342450
-RateLimit: limit=100, remaining=0, reset=50
-RateLimit-Policy: 100;w=3600
-```
-
-```json
-{
-  "type": "https://api.example.com/errors/too-many-requests",
-  "title": "Rate Limit Exceeded",
-  "status": 429,
-  "detail": "You have exceeded the allowed request limit. Please try again in 50 seconds."
-}
-```
-
-#### Client Retry Strategy
-
-✅ **Required**: Clients must wait for the duration specified in the `Retry-After` header before retrying after a 429 response.
-
-⚠️ **Recommended**: When the `Retry-After` header is absent or other transient errors occur (503, etc.), use an exponential backoff + jitter strategy. `attempt` starts at 1 (1 = first retry).
-
-```
-wait_time = min(maxDelay, baseDelay × 2^(attempt - 1)) + random(0, jitterRange)
-```
-
-Example: attempt=1 → `min(60, 1 × 2^0) + random(0,1)` = 1~2 seconds
-
-| Parameter | Recommended Value | Description |
-|-----------|-------------------|-------------|
-| `baseDelay` | 1 second | Wait time for the first retry |
-| `maxDelay` | 60 seconds | Maximum wait time cap |
-| `jitterRange` | 0 ~ 1 second | Random delay (to prevent thundering herd) |
-| Max retry count | 3 ~ 5 times | Prevent infinite retries |
-
-❌ **Prohibited**: Do not retry immediately or at fixed intervals after receiving a 429 response.
-
-❌ **Prohibited**: Do not ignore the `Retry-After` header and use your own wait time when it is present.
+- **Response headers:** `RateLimit: limit=N, remaining=N, reset=N`. `[T2]`
+- **429 Too Many Requests:** Include `Retry-After` + RFC 9457 body. `[T2]`
+- **Client retry strategy:** Exponential Backoff with Jitter. `[T2]`
 
 ---
 
-### 4.4 Long-Running Operations
+## 17. Caching
 
-For operations that do not complete immediately (report generation, data import, etc.), create a domain resource immediately and track processing progress via the resource's status field.
-
-✅ **Required**: Upon receiving a long-running operation request, create the domain resource immediately and return `201 Created` + `Location` header.
-
-✅ **Required**: Include a `status` field in the domain resource to represent processing state.
-
-⚠️ **Recommended**: Use the following status values:
-
-| Status | Description |
-|--------|-------------|
-| `PENDING` | Operation is waiting to start |
-| `IN_PROGRESS` | Operation is being processed |
-| `COMPLETED` | Operation has completed |
-| `FAILED` | Operation has failed |
-
-⚠️ **Recommended**: When status is `FAILED`, include an RFC 7807/9457 error structure in the resource.
-
-**Example:**
-
-```
-# Start operation — immediately create domain resource
-POST /reports  →  201 Created
-                  Location: /reports/123
-                  { "id": "123", "status": "PENDING" }
-
-# Poll status
-GET /reports/123  →  { "id": "123", "status": "IN_PROGRESS" }
-GET /reports/123  →  { "id": "123", "status": "COMPLETED", ... }
-GET /reports/123  →  { "id": "123", "status": "FAILED", "error": { ... } }
-```
-
-❌ **Prohibited**: Do not use a separate generic `/operations` resource. Track status within the domain resource itself.
+- `Cache-Control` header. `[T2]`
+- `ETag` usage for all mutable resources. `[T2]`
 
 ---
 
-### 4.5 Idempotency-Key
+## 18. Long-Running Operations
 
-POST is not idempotent, so retrying after a network error can result in duplicate resource creation. Use the `Idempotency-Key` header for APIs where duplicate execution is dangerous, such as payments, orders, and email sending.
-
-✅ **Required**: Support the `Idempotency-Key` header for POST endpoints where duplicate execution is risky.
-
-```
-POST /orders
-Content-Type: application/json
-Idempotency-Key: a8098c1a-f86e-11da-bd1a-00112444be1e
-
-{
-  "productId": "123",
-  "quantity": 2
-}
-```
-
-**Server Behavior:**
-- First request: Process normally and store the result
-- Re-request with same key: Return the stored result without reprocessing
-- Same request with different key: Treat as a separate request
-
-✅ **Required**: Use client-generated UUID v4 for `Idempotency-Key` values.
-
-⚠️ **Recommended**: Return the same status code and body as the original response for re-requests with the same key.
-
-⚠️ **Recommended**: Set the validity period of `Idempotency-Key` to at least 24 hours.
-
-❌ **Prohibited**: Do not design POST endpoints with financial impact (payments, orders, etc.) without `Idempotency-Key` support.
+- Return `201 Created` + `Location` header immediately. `[T3]`
+- Include `status` field: `PENDING`, `IN_PROGRESS`, `COMPLETED`, `FAILED`. `[T3]`
 
 ---
 
-## 5. Authentication & Security
+## 19. Idempotency-Key
 
-### 5.1 Authentication Methods
-
-#### Bearer Token (JWT)
-
-✅ **Required**: Use the `Authorization` header for authentication tokens. Do not include in query parameters or request body.
-
-```
-Authorization: Bearer eyJhbGciOiJSUzI1NiJ9...
-```
-
-#### API Key
-
-⚠️ **Recommended**: Use the `Authorization` header for API Key authentication.
-
-```
-Authorization: ApiKey your-api-key-here
-```
-
-❌ **Prohibited**: Do not pass API Keys as query parameters. URLs may be recorded in server logs.
-
-```
-# Bad
-GET /articles?apiKey=secret-key
-```
+- Support `Idempotency-Key` header for risky POST endpoints. `[T3]`
+- Use UUID v4. Key validity: minimum 24 hours. `[T3]`
 
 ---
 
-### 5.2 Authorization & Access Control
+## 20. OpenAPI Specification
 
-✅ **Required**: **Prevent BOLA (Broken Object Level Authorization):** Every endpoint accessing a specific resource (`/{resource}/{id}`) MUST verify that the authenticated user (or tenant) is the owner of the resource or holds explicit permission to access it. Never rely solely on the unpredictability of the ID.
-
----
-
-### 5.3 Input Validation & Mass Assignment
-
-✅ **Required**: **Prevent Mass Assignment (BOPA):** When processing `PATCH` or `POST` requests, the server MUST implement a strict **Allowlist** in the DTO (Data Transfer Object) layer. Clients MUST NOT be able to arbitrarily update protected fields (e.g., `role`, `isVerified`, `balance`) by including them in the request body or `updateMask`.
+- All APIs MUST maintain an OpenAPI 3.0+ spec (API First). `[T2]`
+- `description` and `operationId` required. `[T2]`
+- MUST validate spec compliance in CI using linters. `[T1]`
 
 ---
 
-### 5.4 Security Headers
+## 21. Authentication & Security
 
-✅ **Required**: All API responses MUST include the following security headers:
-- `X-Content-Type-Options: nosniff` (Prevents MIME-sniffing attacks)
-- `Strict-Transport-Security: max-age=31536000; includeSubDomains` (Enforces HTTPS)
+- **HTTPS Required.** `[T1]`
+- **Security Headers REQUIRED:** `X-Content-Type-Options: nosniff`, `Strict-Transport-Security`. `[T1]`
+- `Authorization` header for Bearer tokens or API Keys. `[T1]`
 
----
+**Authorization (BOLA Prevention):** `[T1]`
+- Servers MUST verify ownership/permissions for *every* specific resource access.
 
-### 5.5 401 vs 403 Distinction
-
-| Status Code | Meaning | When to Use |
-|-------------|---------|-------------|
-| `401 Unauthorized` | Authentication failure | Missing token, expired token, malformed token |
-| `403 Forbidden` | Authorization failure | Authenticated but lacks permission for the resource/action |
-
-✅ **Required**: Include the `WWW-Authenticate` header in 401 responses.
-
-```
-HTTP/1.1 401 Unauthorized
-WWW-Authenticate: Bearer realm="api", error="token_expired"
-Content-Type: application/problem+json
-
-{
-  "type": "https://api.example.com/errors/unauthorized",
-  "title": "Authentication Required",
-  "status": 401,
-  "detail": "The access token has expired."
-}
-```
-
-⚠️ **Recommended**: Do not reveal resource existence in 403 responses. For security-sensitive resources, you may respond with 404 as if the resource does not exist.
-
-```
-HTTP/1.1 403 Forbidden
-Content-Type: application/problem+json
-
-{
-  "type": "https://api.example.com/errors/forbidden",
-  "title": "Access Denied",
-  "status": 403,
-  "detail": "You do not have permission to access this resource."
-}
-```
+**Mass Assignment Prevention (BOPA):** `[T1]`
+- Servers MUST use an Allowlist in DTOs. `PATCH` body/`updateMask` must not modify protected fields.
 
 ---
 
-### 5.6 Webhooks
+## 22. References
 
-✅ **Required**: Use a consistent payload wrapper for webhook events.
-
-```json
-{
-  "id": "evt_123",
-  "type": "article.published",
-  "created": "2024-01-20T10:00:00Z",
-  "data": { ... }
-}
-```
-
-✅ **Required**: Sign payloads using HMAC-SHA256 with a shared secret. Include the signature in the `X-Hub-Signature-256` header.
-
-⚠️ **Recommended**: Webhook handlers should be idempotent to handle duplicate events safely.
-
----
-
-## 6. Health Check
-
-✅ **Required**: Provide a `GET /health` endpoint to monitor service availability.
-
-✅ **Required**: Return `200 OK` with `{"status": "UP"}` if the service is healthy.
-
-⚠️ **Recommended**: Distinguish between shallow (liveness) and deep (readiness) checks. Deep checks should verify dependencies like databases and caches.
-
----
-
-## 7. OpenAPI Specification
-
-### 7.1 API First
-
-✅ **Required**: All APIs MUST maintain an OpenAPI 3.0+ specification as the single source of truth.
-
-⚠️ **Recommended**: Define the OpenAPI spec before implementation (API First approach).
-
-### 7.2 Spec Quality
-
-✅ **Required**: Every endpoint, parameter, and schema property MUST include a `description` field.
-
-✅ **Required**: Every operation MUST have a unique `operationId` — this enables code generation and documentation automation.
-
-⚠️ **Recommended**: Key schemas and parameters SHOULD include `example` or `examples` for documentation clarity.
-
-```yaml
-# Good
-paths:
-  /articles:
-    get:
-      operationId: listArticles
-      description: Retrieve a paginated list of articles.
-      parameters:
-        - name: pageSize
-          in: query
-          description: Number of items per page.
-          schema:
-            type: integer
-            example: 20
-```
-
-### 7.3 Schema Mapping
-
-✅ **Required**: Map field behaviors to OpenAPI properties:
-
-| Field Behavior | OpenAPI Property |
-|----------------|------------------|
-| Read-only (e.g., `id`, `createdAt`) | `readOnly: true` |
-| Create-only (e.g., write-once fields) | `writeOnly: true` |
-| Nullable (explicit need only) | `nullable: true` (OpenAPI 3.0); `type: ["string", "null"]` (OpenAPI 3.1) |
-
-⚠️ **Recommended**: Follow the field-omission principle — minimize use of `nullable`. Omit fields rather than sending `null`.
-
-✅ **Required**: Define RFC 9457 Problem Details as a shared `$ref` component for error responses.
-
-```yaml
-components:
-  schemas:
-    ProblemDetail:
-      type: object
-      required: [type, title, status, detail]
-      properties:
-        type:
-          type: string
-          format: uri
-          description: URI identifying the error type.
-          example: "https://api.example.com/errors/validation-failed"
-        title:
-          type: string
-          description: Short summary of the error type.
-        status:
-          type: integer
-          description: HTTP status code.
-        detail:
-          type: string
-          description: Specific error description.
-        instance:
-          type: string
-          description: Request path where the problem occurred.
-        traceId:
-          type: string
-          description: Matches Request-Id response header.
-```
-
-### 7.4 Extensions & Validation
-
-⚠️ **Recommended**: Mark non-public endpoints with the `x-internal: true` extension.
-
-⚠️ **Recommended**: Validate spec compliance in CI using linters such as Spectral or Zally.
-
----
-
-## 8. References
-
-**Google API Improvement Proposals (AIP):**
-
-- [AIP-121: Resource-oriented design](https://google.aip.dev/121)
-- [AIP-136: Custom methods](https://google.aip.dev/136)
-- [AIP-154: Resource freshness validation (ETags)](https://google.aip.dev/154)
-- [AIP-157: Partial responses](https://google.aip.dev/157)
-- [AIP-160: Filtering](https://google.aip.dev/160)
-- [AIP-161: Field masks](https://google.aip.dev/161)
-- [AIP-163: Change validation](https://google.aip.dev/163)
-- [AIP-164: Soft delete](https://google.aip.dev/164)
-- [AIP-203: Field behavior documentation](https://google.aip.dev/203)
-- [AIP-216: States](https://google.aip.dev/216)
-
-**RFCs & Standards:**
-
-- [RFC 2119 - Key words for use in RFCs to Indicate Requirement Levels](https://datatracker.ietf.org/doc/html/rfc2119)
-- [RFC 8174 - Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words](https://datatracker.ietf.org/doc/html/rfc8174)
-- [RFC 3339 - Date and Time on the Internet](https://datatracker.ietf.org/doc/html/rfc3339)
-- [RFC 9110: HTTP Semantics](https://datatracker.ietf.org/doc/html/rfc9110)
-- [RFC 8288 - Web Linking](https://datatracker.ietf.org/doc/html/rfc8288)
-- [RFC 6585 - Additional HTTP Status Codes (429)](https://datatracker.ietf.org/doc/html/rfc6585#section-4)
-- [RFC 8594: The Sunset HTTP Header Field](https://datatracker.ietf.org/doc/html/rfc8594)
-- [RFC 9745: The Deprecation HTTP Response Header Field](https://datatracker.ietf.org/doc/html/rfc9745)
-- [draft-ietf-httpapi-ratelimit-headers-10: RateLimit Header Fields for HTTP](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/)
-
-**Industry Guidelines & Other:**
-
-- [Microsoft Azure REST API Guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md)
-- [JSON:API Specification](https://jsonapi.org/)
-- [Architectural Styles and the Design of Network-based Software Architectures - Roy Fielding](https://roy.gbiv.com/pubs/dissertation/fielding_dissertation.pdf)
-- [Day1, 2-2. 그런 REST API로 괜찮은가](https://www.youtube.com/watch?v=RP_f5dMoHFc)
+- [Google API Improvement Proposals (AIP)](https://google.aip.dev)
+- [RFC 9457: Problem Details for HTTP APIs](https://datatracker.ietf.org/doc/html/rfc9457)
+- [OWASP API Security Top 10](https://owasp.org/www-project-api-security/)


### PR DESCRIPTION
## Summary
- api 플러그인 버전 업데이트 (0.2.0 -> 0.2.1)
- api 가이드라인 문서 구조 개선 및 티어(Tier) 시스템 도입

## Motivation
- ADR-0010에 따른 티어 기반 API 가이드라인 적용 및 문서 가독성 향상

## Changes
- `.claude-plugin/marketplace.json`, `plugins/api/.claude-plugin/plugin.json`: 버전 0.2.1로 업데이트
- `README.md`, `README.ko.md`: api 플러그인 버전 표기 업데이트
- `plugins/api/README.md`, `plugins/api/README.ko.md`: 티어 시스템(`[T1]`, `[T2]`, `[T3]`) 가이드 추가 및 섹션 재구성

## Test plan
- [x] 버전 표기 정합성 확인
- [x] 문서 링크 및 마크다운 렌더링 확인