### PR TITLE
fix(git:review): fix hallucinated reviewer skill name and add deterministic dispatch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "git",
       "source": "./plugins/git",
       "description": "Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
-      "version": "0.0.8"
+      "version": "0.0.9"
     },
     {
       "name": "workflow",

--- a/.claude/rules/git-rules.md
+++ b/.claude/rules/git-rules.md
@@ -1,0 +1,8 @@
+# Git 플러그인 규칙
+
+git 플러그인 스킬을 사용하거나 수정할 때 반드시 다음 제약을 따른다.
+
+✓ 다른 스킬을 디스패치할 때 스킬명을 추론으로 구성하지 말고 마켓플레이스에 실제 등록된 정확한 이름(`<plugin>:<skill>`)을 SKILL.md에 명시할 것
+✓ 언어별 reviewer 매핑은 결정적 테이블로 관리하고, 등재되지 않은 언어는 general review criteria로 fallback할 것
+✓ `.java` 파일 변경 시 항상 `java:reviewer`를 로드하고, PR diff에 Spring 어노테이션(@RestController/@Service/@Component/@Repository/@Controller/@Configuration) 또는 `import org.springframework.`가 보이면 `java:spring`을 추가 로드할 것
+✓ `.go` 파일 변경 시 `golang:reviewer`를 로드할 것

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@
 |------|------|
 | ADR 작성 / 규칙 수정 | `.claude/rules/rules-maintenance.md` |
 | workflow 스킬 사용 / 수정 | `.claude/rules/workflow-rules.md` |
+| git 스킬 사용 / 수정 | `.claude/rules/git-rules.md` |
 
 ### 참조
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 |--------|------|------|
 | [api](./plugins/api) | v0.2.1 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
 | [docs](./plugins/docs) | v0.0.4 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
-| [git](./plugins/git) | v0.0.8 | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
+| [git](./plugins/git) | v0.0.9 | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
 | [workflow](./plugins/workflow) | v0.0.13 | 워크플로우 스킬 — Gemini 멀티 LLM 크로스체크 + 아이디어에서 커밋까지 전체 파이프라인 오케스트레이션 |
 | [dev](./plugins/dev) | v0.0.1 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 |--------|---------|-------------|
 | [api](./plugins/api) | v0.2.1 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
 | [docs](./plugins/docs) | v0.0.4 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
-| [git](./plugins/git) | v0.0.8 | Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
+| [git](./plugins/git) | v0.0.9 | Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
 | [workflow](./plugins/workflow) | v0.0.13 | Workflow skills — Gemini multi-LLM cross-check + full feature pipeline orchestration (grill → plan → verify → execute) |
 | [dev](./plugins/dev) | v0.0.1 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/skills/review/SKILL.md
+++ b/plugins/git/skills/review/SKILL.md
@@ -54,9 +54,11 @@ Map detected languages to reviewer skills using the table below. **Do not infer 
 | `go` | `golang:reviewer` | — |
 | `java` | `java:reviewer` | `java:spring` if PR diff contains any of `@RestController`, `@Service`, `@Component`, `@Repository`, `@Controller`, `@Configuration`, or `import org.springframework.` |
 
+Process **all** rows whose language was detected — do not stop after the first match.
+
 For each row that matches the detected languages:
 1. Invoke the required skill via the `Skill` tool.
-2. If the conditional skill's trigger is present in the PR diff (already retrieved in Step 2 / Step 5), also invoke it.
+2. If the conditional skill's trigger is present in the diff: if you have not yet fetched the full diff, run `gh pr diff <PR_NUMBER>` now, then check for the trigger strings before invoking the conditional skill.
 
 Languages not listed in the table → skip skill loading and fall back to the general review criteria for that language's files. **Do not guess a skill name** (e.g., `<lang>:reviewer`) for unlisted languages — only invoke skills that appear in the table.
 

--- a/plugins/git/skills/review/SKILL.md
+++ b/plugins/git/skills/review/SKILL.md
@@ -47,16 +47,18 @@ Collect the unique set of detected languages.
 
 ### 4. Load Reviewer Skills
 
-From the list of skills available in the system (shown in session context), find skills whose name contains `reviewer`.
+Map detected languages to reviewer skills using the table below. **Do not infer skill names from descriptions or partial matches** — use the exact names listed.
 
-For each detected language, attempt to match a reviewer skill:
-- `go` → look for a skill containing `golang` or `go` and `reviewer` (e.g., `golang:reviewer`)
-- `java` → look for a skill containing `java` and `reviewer` (e.g., `java-reviewer:java-reviewer`)
-- Other languages → look for skill containing the language name and `reviewer`
+| Detected language | Required skill | Conditional skill |
+|-------------------|----------------|-------------------|
+| `go` | `golang:reviewer` | — |
+| `java` | `java:reviewer` | `java:spring` if PR diff contains any of `@RestController`, `@Service`, `@Component`, `@Repository`, `@Controller`, `@Configuration`, or `import org.springframework.` |
 
-For each matched reviewer skill, invoke it using the `Skill` tool to load its review criteria into context.
+For each row that matches the detected languages:
+1. Invoke the required skill via the `Skill` tool.
+2. If the conditional skill's trigger is present in the PR diff (already retrieved in Step 2 / Step 5), also invoke it.
 
-If no reviewer skill matches a detected language, fall back to the general review criteria for that language's files.
+Languages not listed in the table → skip skill loading and fall back to the general review criteria for that language's files. **Do not guess a skill name** (e.g., `<lang>:reviewer`) for unlisted languages — only invoke skills that appear in the table.
 
 ### 5. Code Review & Generate Fixes
 


### PR DESCRIPTION
## Summary
- `git:review` Step 4의 `java-reviewer:java-reviewer` 환각 스킬 호출 버그 수정
- 추론 기반 매칭을 결정적 매핑 테이블(go→golang:reviewer, java→java:reviewer)로 교체
- Spring 시그니처 감지 시 `java:spring` 조건부 로드 추가
- diff fetch 타이밍 명시 + 멀티 언어 동시 처리 보장

## Motivation
`/git:clean` 실행 중 `.java` 파일 변경 PR 리뷰 단계에서 `Skill(java-reviewer:java-reviewer)` — 존재하지 않는 이름 — 호출로 `Unknown skill` 에러가 발생해 워크플로우가 중단됨. 근본 원인은 Step 4의 모호한 추론 지시 + 잘못된 예시 이름. 단순 오타 수정이 아닌 결정적 테이블로 재설계해 동일 버그의 다른 언어 재발을 차단함.

## Changes
- `plugins/git/skills/review/SKILL.md`: Step 4 전체 교체 (결정적 매핑 테이블, Spring 조건부 로드, diff fetch 타이밍, 멀티 언어 처리)
- `.claude/rules/git-rules.md`: 신규 — git 스킬 디스패치 결정적 명시 규칙 4개
- `CLAUDE.md`: 규칙 파일 목록에 git-rules.md 추가
- `.claude-plugin/marketplace.json`, `plugins/git/.claude-plugin/plugin.json`, `README.md`, `README.ko.md`: git 플러그인 v0.0.8 → v0.0.9

## Test plan
- [ ] `.java` 변경이 있는 PR에서 `/git:review` 실행 시 `java:reviewer`가 호출되는지 확인 (`java-reviewer:java-reviewer` 호출 없음)
- [ ] Spring 어노테이션 포함 PR에서 `java:spring`도 추가 로드되는지 확인
- [ ] `.go` 변경 PR에서 `golang:reviewer` 정상 호출 확인
- [ ] `grep -c "java-reviewer:java-reviewer" plugins/git/skills/review/SKILL.md` → 0

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.