### PR TITLE
feat(workflow): karpathy phase markers in feature-pipeline (v0.1.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,7 +33,7 @@
       "name": "workflow",
       "source": "./plugins/workflow",
       "description": "Workflow skills — multi-LLM cross-check with Gemini; feature-pipeline applies workflow:karpathy-original (11 principles, verbatim) at S1.5 and S6.",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "name": "dev",

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
 | [api](./plugins/api) | v0.2.1 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
 | [docs](./plugins/docs) | v0.0.4 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
 | [git](./plugins/git) | v0.0.9 | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
-| [workflow](./plugins/workflow) | v0.0.13 | 워크플로우 스킬 — Gemini 멀티 LLM 크로스체크 + 아이디어에서 커밋까지 전체 파이프라인 오케스트레이션 |
+| [workflow](./plugins/workflow) | v0.1.1 | 워크플로우 스킬 — Gemini 멀티 LLM 크로스체크 + 아이디어에서 커밋까지 전체 파이프라인 오케스트레이션 |
 | [dev](./plugins/dev) | v0.0.1 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 
 ## 마켓플레이스 등록

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [api](./plugins/api) | v0.2.1 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
 | [docs](./plugins/docs) | v0.0.4 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
 | [git](./plugins/git) | v0.0.9 | Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
-| [workflow](./plugins/workflow) | v0.0.13 | Workflow skills — Gemini multi-LLM cross-check + full feature pipeline orchestration (grill → plan → verify → execute) |
+| [workflow](./plugins/workflow) | v0.1.1 | Workflow skills — Gemini multi-LLM cross-check + full feature pipeline orchestration (grill → plan → verify → execute) |
 | [dev](./plugins/dev) | v0.0.1 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 
 ## Marketplace Registration

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Workflow skills — multi-LLM cross-check with Gemini; feature-pipeline applies workflow:karpathy-original (11 principles, verbatim) at S1.5 and S6.",
   "author": {
     "name": "ppzxc",

--- a/plugins/workflow/skills/feature-pipeline/SKILL.md
+++ b/plugins/workflow/skills/feature-pipeline/SKILL.md
@@ -1,5 +1,4 @@
 ---
-name: feature-pipeline
 description: Use when a user wants to develop a feature end-to-end in one session — from idea or rough draft through a cross-checked TDD plan to committed code. Triggered by /workflow:feature-pipeline or "build X with full workflow".
 user-invocable: true
 ---
@@ -76,6 +75,10 @@ digraph pipeline {
 
 ## S1.5: workflow:karpathy-original 로드 [ADR-0018]
 
+Skill tool 호출 **직전** 사용자에게 다음 안내문을 출력한다:
+
+> **S1 (의도 추출) 완료 → S1.5 진입.** 지금 `workflow:karpathy-original` 11원칙을 컨텍스트에 로드합니다. 이후 S3(plan)·S5(TDD 게이트)·S6(subagent)에서 동일 원문이 강제됩니다.
+
 grill-me 완료 직후, Gate 1 이전에 반드시 실행:
 
 ```
@@ -99,6 +102,8 @@ git rev-parse --git-dir && git rev-parse --git-common-dir
 두 경로가 **같으면**(= main repo) STOP — EnterWorktree 진입 후 재시작. 다르면 worktree 안에 있음.
 
 ## S3: Plan 파일 직접 작성 [ADR-0015]
+
+> _카파시 적용: §2 Simplicity First (plan 작성 가드레일)_
 
 `superpowers:writing-plans` 호출 없이 grill-me 결과를 plan 파일로 직접 작성한다.
 
@@ -125,6 +130,7 @@ plan 파일 최상단에 다음 헤더를 포함한다:
 **Goal:** <한 문장 — 이 플랜이 무엇을 구현하는가>
 **Architecture:** <2-3 문장 — 접근 방식>
 **Tech Stack:** <핵심 기술/라이브러리>
+**Karpathy applied:** S1.5 invoke; §2 in S3 plan, §4 in S5 gate, §1~§11 verbatim in S6 subagent
 ```
 
 ### Task 구조
@@ -212,6 +218,8 @@ grep '## Cross-check Feedback' "$(pwd)/docs/plans/<slug>.md"
 
 ## S5: TDD 검증 게이트
 
+> _카파시 적용: §4 Goal-Driven Execution (구조 검사만; 엄격한 §4 검사는 S6)_
+
 plan 파일 경로를 확인하고 아래 명령을 실행한 뒤 결과를 응답에 인용한다:
 
 ```bash
@@ -230,6 +238,8 @@ grep -E '^### Task .+\[(TDD-EXEMPT[^]]*|TDD|TIDY)\]' "$(pwd)/docs/plans/<slug>.m
 
 
 ## S6: Subagent 실행 지시
+
+> _카파시 적용: §1~§11 원문 verbatim paste (강제력 100%)_
 
 `superpowers:subagent-driven-development` 호출 시 implementer 프롬프트에 명시:
 - `[TIDY]` task → `dev:tidy` 스킬 활성화, `[PHASE: STRUCTURAL]` 엄수


### PR DESCRIPTION
## Summary
- S1.5 진입 시 사용자에게 karpathy 로드 안내문 출력
- S3/S5/S6 섹션 헤더에 해당 카파시 원칙(§2/§4/§1~§11) 적용 지점 표시
- plan 파일 헤더 템플릿에 `Karpathy applied:` 메타 라인 추가
- workflow 버전 v0.1.1 bump 및 README 동기화

## Motivation
karpathy 11원칙이 feature-pipeline의 어느 phase에서 어떻게 적용되는지 가시화되지 않아 흐름이 묵시적이었다. S1.5 invoke 순서(ADR-0018)는 유지하되, phase 경계에서 명시적 안내를 제공한다.

## Changes
- `SKILL.md:S1.5` — Skill 호출 직전 출력할 안내문 템플릿 추가
- `SKILL.md:S3` — `§2 Simplicity First` 적용 표시
- `SKILL.md:S5` — `§4 Goal-Driven Execution` 적용 표시 (구조 검사만)
- `SKILL.md:S6` — `§1~§11 verbatim paste` 적용 표시
- `SKILL.md:plan 헤더` — `**Karpathy applied:**` 1줄 고정 메타 라인

## Test plan
- [ ] SKILL.md grep: "S1 (의도 추출) 완료 → S1.5" 1건
- [ ] SKILL.md grep: "카파시 적용:" 3건 (S3/S5/S6)
- [ ] SKILL.md grep: "Karpathy applied:" 1건 (plan 헤더 템플릿)
- [ ] 버전 일치: marketplace.json / plugin.json / README.md / README.ko.md 모두 v0.1.1

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.