### PR TITLE
chore(workflow): add ADR-0018 rules for karpathy phase markers

### DIFF
--- a/.claude/rules/workflow-rules.md
+++ b/.claude/rules/workflow-rules.md
@@ -20,3 +20,5 @@ feature-pipeline 스킬을 사용하거나 구현할 때 반드시 다음 제약
 ✓ feature-pipeline plan의 각 task는 Files: Create/Modify/Test 줄로 파일 매핑을 명시할 것 [ADR-0015]
 ✓ feature-pipeline은 ExitPlanMode 흐름에 진입하지 않을 것 (Gate 3 승인은 AskUserQuestion만으로 처리) [ADR-0016]
 ✓ feature-pipeline plan 파일에 grill-me 대화 본문을 누적하지 않을 것 (결정/태스크/cross-check 요약만, 8KB 이하 유지) [ADR-0016]
+✓ feature-pipeline은 S1.5 Skill 호출 직전에 사용자에게 "S1 완료 → S1.5 karpathy 로드 → S3/S5/S6 적용" 안내문을 출력할 것 [ADR-0018]
+✓ feature-pipeline plan 파일 헤더에 `**Karpathy applied:**` 라인을 포함할 것 (값은 SKILL.md S3 템플릿과 1자 일치) [ADR-0018]


### PR DESCRIPTION
## Summary
- feature-pipeline S1.5 karpathy 로드 안내문 출력 규칙 추가 [ADR-0018]
- feature-pipeline plan 파일 헤더에 `**Karpathy applied:**` 라인 포함 규칙 추가 [ADR-0018]

## Motivation
ADR-0018에서 결정된 karpathy phase marker 규칙을 workflow-rules.md에 반영하여
feature-pipeline 실행 시 S1.5 단계 안내와 plan 파일 헤더 동기화를 강제한다.

## Changes
- `.claude/rules/workflow-rules.md`: S1.5 안내문 출력 규칙, plan 헤더 Karpathy applied 라인 규칙 2개 추가

## Test plan
- [ ] workflow-rules.md 파일에 규칙 2개 정상 추가 확인
- [ ] ADR-0018 태그 정확히 부착 확인

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.