### PR TITLE
chore(workflow): bump version to 0.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,7 +33,7 @@
       "name": "workflow",
       "source": "./plugins/workflow",
       "description": "Workflow skills — multi-LLM cross-check with Gemini; feature-pipeline applies workflow:karpathy-original (11 principles, verbatim) at S1.5 and S6.",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     {
       "name": "dev",

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
 | [api](./plugins/api) | v0.2.1 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
 | [docs](./plugins/docs) | v0.0.4 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
 | [git](./plugins/git) | v0.0.9 | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
-| [workflow](./plugins/workflow) | v0.1.1 | 워크플로우 스킬 — Gemini 멀티 LLM 크로스체크 + 아이디어에서 커밋까지 전체 파이프라인 오케스트레이션 |
+| [workflow](./plugins/workflow) | v0.1.2 | 워크플로우 스킬 — Gemini 멀티 LLM 크로스체크 + 아이디어에서 커밋까지 전체 파이프라인 오케스트레이션 |
 | [dev](./plugins/dev) | v0.0.1 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 
 ## 마켓플레이스 등록

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [api](./plugins/api) | v0.2.1 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
 | [docs](./plugins/docs) | v0.0.4 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
 | [git](./plugins/git) | v0.0.9 | Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
-| [workflow](./plugins/workflow) | v0.1.1 | Workflow skills — Gemini multi-LLM cross-check + full feature pipeline orchestration (grill → plan → verify → execute) |
+| [workflow](./plugins/workflow) | v0.1.2 | Workflow skills — Gemini multi-LLM cross-check + full feature pipeline orchestration (grill → plan → verify → execute) |
 | [dev](./plugins/dev) | v0.0.1 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 
 ## Marketplace Registration

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Workflow skills — multi-LLM cross-check with Gemini; feature-pipeline applies workflow:karpathy-original (11 principles, verbatim) at S1.5 and S6.",
   "author": {
     "name": "ppzxc",


### PR DESCRIPTION
## Summary
- workflow 플러그인 버전 `0.1.1` → `0.1.2` patch bump

## Motivation
v0.1.1 태깅(#78) 이후 머지된 feat 커밋 #80 (plan mode 호환성, 16KB plan 파일 상한, plan-skip 가드레일 강화)에 대한 버전 동기화 누락 수정.

## Changes
- `plugins/workflow/.claude-plugin/plugin.json` — version 0.1.2
- `.claude-plugin/marketplace.json` — version 0.1.2
- `README.md` — version badge 0.1.2
- `README.ko.md` — version badge 0.1.2

## Test plan
- [x] 4개 파일 모두 0.1.2로 일치 확인
- [x] JSON 문법 검증 통과
- [x] 0.1.1 잔재 없음 확인