### PR TITLE
chore(git,workflow): bump versions to 0.0.10 and 0.1.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,13 +27,13 @@
       "name": "git",
       "source": "./plugins/git",
       "description": "Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
-      "version": "0.0.9"
+      "version": "0.0.10"
     },
     {
       "name": "workflow",
       "source": "./plugins/workflow",
       "description": "Workflow skills — multi-LLM cross-check with Gemini; feature-pipeline applies workflow:karpathy-original (11 principles, verbatim) at S1.5 and S6.",
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "name": "dev",

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,8 +10,8 @@
 |--------|------|------|
 | [api](./plugins/api) | v0.2.1 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
 | [docs](./plugins/docs) | v0.0.4 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
-| [git](./plugins/git) | v0.0.9 | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
-| [workflow](./plugins/workflow) | v0.1.3 | 워크플로우 스킬 — Gemini 멀티 LLM 크로스체크 + 아이디어에서 커밋까지 전체 파이프라인 오케스트레이션 |
+| [git](./plugins/git) | v0.0.10 | Git 워크플로우 스킬 — 안전한 커밋, PR 생성, PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
+| [workflow](./plugins/workflow) | v0.1.4 | 워크플로우 스킬 — Gemini 멀티 LLM 크로스체크 + 아이디어에서 커밋까지 전체 파이프라인 오케스트레이션 |
 | [dev](./plugins/dev) | v0.0.1 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 
 ## 마켓플레이스 등록

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A collection of engineering guidelines for software development, as a Claude Cod
 |--------|---------|-------------|
 | [api](./plugins/api) | v0.2.1 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
 | [docs](./plugins/docs) | v0.0.4 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
-| [git](./plugins/git) | v0.0.9 | Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
-| [workflow](./plugins/workflow) | v0.1.3 | Workflow skills — Gemini multi-LLM cross-check + full feature pipeline orchestration (grill → plan → verify → execute) |
+| [git](./plugins/git) | v0.0.10 | Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
+| [workflow](./plugins/workflow) | v0.1.4 | Workflow skills — Gemini multi-LLM cross-check + full feature pipeline orchestration (grill → plan → verify → execute) |
 | [dev](./plugins/dev) | v0.0.1 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 
 ## Marketplace Registration

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Git workflow skills — safe commit, PR creation, PR review, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Workflow skills — multi-LLM cross-check with Gemini; feature-pipeline applies workflow:karpathy-original (11 principles, verbatim) at S1.5 and S6.",
   "author": {
     "name": "ppzxc",


### PR DESCRIPTION
## Summary
- git 플러그인 버전 0.0.9 → 0.0.10
- workflow 플러그인 버전 0.1.3 → 0.1.4

## Motivation
PR #83에서 workflow/git 스킬 버그 수정 후 버전 범프가 누락됨.

## Changes
- `.claude-plugin/marketplace.json` 버전 업데이트
- `plugins/git/.claude-plugin/plugin.json` 버전 업데이트
- `plugins/workflow/.claude-plugin/plugin.json` 버전 업데이트
- `README.md` / `README.ko.md` 버전 테이블 업데이트

## Test plan
- [ ] 버전 3곳 동기화 확인 (marketplace.json, plugin.json, README)