### PR TITLE
chore(skill): 전체 플러그인 SKILL.md에 agy용 name 필드 추가 및 버전 범프

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,37 +15,37 @@
       "name": "api",
       "source": "./plugins/api",
       "description": "RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, and non-CRUD action endpoints",
-      "version": "0.2.1"
+      "version": "0.2.2"
     },
     {
       "name": "docs",
       "source": "./plugins/docs",
       "description": "Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions",
-      "version": "0.0.4"
+      "version": "0.0.5"
     },
     {
       "name": "git",
       "source": "./plugins/git",
       "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
-      "version": "0.0.13"
+      "version": "0.0.14"
     },
     {
       "name": "llm",
       "source": "./plugins/llm",
       "description": "LLM delegation skills — agy(Antigravity CLI) context map generation and execution plan cross-check",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "name": "workflow",
       "source": "./plugins/workflow",
       "description": "Workflow skills — karpathy-guideline (11 Karpathy coding principles, verbatim)",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "name": "dev",
       "source": "./plugins/dev",
       "description": "Development methodology skills — Tidy First, TDD, and language-agnostic development practices",
-      "version": "0.0.1"
+      "version": "0.0.2"
     }
   ]
 }

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,12 +8,12 @@
 
 | 플러그인 | 버전 | 설명 |
 |--------|------|------|
-| [api](./plugins/api) | v0.2.1 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
-| [docs](./plugins/docs) | v0.0.4 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
-| [git](./plugins/git) | v0.0.13 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
-| [llm](./plugins/llm) | v0.1.0 | LLM 위임 스킬 — agy(Antigravity CLI) 컨텍스트 맵 생성 및 실행 계획 교차검증 |
-| [workflow](./plugins/workflow) | v0.2.0 | 워크플로우 스킬 — karpathy-guideline (Karpathy 11원칙 verbatim) |
-| [dev](./plugins/dev) | v0.0.1 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
+| [api](./plugins/api) | v0.2.2 | RESTful API 설계 가이드라인 — URL 구조, HTTP 메서드, 상태 코드, JSON 형식, 에러 응답, 버전 관리, 헤더, 비-CRUD action endpoint |
+| [docs](./plugins/docs) | v0.0.5 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
+| [git](./plugins/git) | v0.0.14 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
+| [llm](./plugins/llm) | v0.1.1 | LLM 위임 스킬 — agy(Antigravity CLI) 컨텍스트 맵 생성 및 실행 계획 교차검증 |
+| [workflow](./plugins/workflow) | v0.2.1 | 워크플로우 스킬 — karpathy-guideline (Karpathy 11원칙 verbatim) |
+| [dev](./plugins/dev) | v0.0.2 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 
 ## 마켓플레이스 등록
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ A collection of engineering guidelines for software development, as a Claude Cod
 
 | Plugin | Version | Description |
 |--------|---------|-------------|
-| [api](./plugins/api) | v0.2.1 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
-| [docs](./plugins/docs) | v0.0.4 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
-| [git](./plugins/git) | v0.0.13 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
-| [llm](./plugins/llm) | v0.1.0 | LLM delegation skills — agy(Antigravity CLI) context map generation and execution plan cross-check |
-| [workflow](./plugins/workflow) | v0.2.0 | Workflow skills — karpathy-guideline (11 Karpathy coding principles, verbatim) |
-| [dev](./plugins/dev) | v0.0.1 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
+| [api](./plugins/api) | v0.2.2 | RESTful API design guidelines — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, non-CRUD action endpoints |
+| [docs](./plugins/docs) | v0.0.5 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
+| [git](./plugins/git) | v0.0.14 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
+| [llm](./plugins/llm) | v0.1.1 | LLM delegation skills — agy(Antigravity CLI) context map generation and execution plan cross-check |
+| [workflow](./plugins/workflow) | v0.2.1 | Workflow skills — karpathy-guideline (11 Karpathy coding principles, verbatim) |
+| [dev](./plugins/dev) | v0.0.2 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 
 ## Marketplace Registration
 

--- a/plugins/api/.claude-plugin/plugin.json
+++ b/plugins/api/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "RESTful API design guidelines skill — URL structure, HTTP methods, status codes, JSON format, error responses, versioning, headers, and non-CRUD action endpoints",
   "author": {
     "name": "ppzxc",

--- a/plugins/api/skills/restful-guidelines/SKILL.md
+++ b/plugins/api/skills/restful-guidelines/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: api:restful-guidelines
 description: "Use when designing, implementing, or reviewing REST APIs — URL structure, HTTP methods, status codes, JSON format, error responses, and headers. Source: github.com/ppzxc/restful-api-guidelines"
 user-invocable: true
 ---

--- a/plugins/dev/.claude-plugin/plugin.json
+++ b/plugins/dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Development methodology skills — Tidy First, TDD, and language-agnostic development practices",
   "author": {
     "name": "ppzxc",

--- a/plugins/dev/skills/tidy/SKILL.md
+++ b/plugins/dev/skills/tidy/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: dev:tidy
 description: Use when refactoring code or preparing structural changes — /dev:tidy, "tidy first", "구조 정리", "리팩토링", or any request to separate structural changes from behavioral changes following Kent Beck's Tidy First principles.
 user-invocable: true
 ---

--- a/plugins/docs/.claude-plugin/plugin.json
+++ b/plugins/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Documentation decision records skills — ADR (Nygard format) and MADR (Markdown Architectural Decision Records 4.0) for capturing and tracking architecture decisions",
   "author": {
     "name": "ppzxc",

--- a/plugins/docs/skills/adr/SKILL.md
+++ b/plugins/docs/skills/adr/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: docs:adr
 description: "Use when creating an Architecture Decision Record — /docs:adr, \"ADR 작성\", \"결정 사항 기록\", or any request to document an architecture decision in Nygard format"
 user-invocable: true
 ---

--- a/plugins/docs/skills/madr/SKILL.md
+++ b/plugins/docs/skills/madr/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: docs:madr
 description: "Use when creating a Markdown Architectural Decision Record — /docs:madr, \"MADR 작성\", \"결정 사항 기록\", or any request to document an architecture decision in MADR 4.0 format"
 user-invocable: true
 ---

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/skills/clean/SKILL.md
+++ b/plugins/git/skills/clean/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: git:clean
 description: Use when the user wants to complete the full PR workflow — /git:clean, "PR 완료", "PR 전체 흐름", "worktree 정리", or any request to commit, push, review, merge, and cleanup in sequence
 user-invocable: true
 ---

--- a/plugins/git/skills/commit/SKILL.md
+++ b/plugins/git/skills/commit/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: git:commit
 description: Use when the user wants to commit changes — /git:commit, "커밋", "변경사항 커밋", or any request to stage and commit local changes
 user-invocable: true
 ---

--- a/plugins/git/skills/issue/SKILL.md
+++ b/plugins/git/skills/issue/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: git:issue
 description: Use when the user wants to create a GitHub issue — /git:issue, "이슈 만들어", "이슈 생성", "버그 리포트", or any request to create a GitHub issue
 user-invocable: true
 ---

--- a/plugins/git/skills/merge/SKILL.md
+++ b/plugins/git/skills/merge/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: git:merge
 description: Use when the user wants to squash-merge a GitHub PR — /git:merge, "PR 머지", "squash merge", or any request to merge a pull request into main
 user-invocable: true
 ---

--- a/plugins/git/skills/pull-request/SKILL.md
+++ b/plugins/git/skills/pull-request/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: git:pull-request
 description: Use when the user wants to push changes and create a GitHub PR — /git:pull-request, "PR 만들어", "PR 생성", "push하고 PR", or any request to open a pull request
 user-invocable: true
 ---

--- a/plugins/git/skills/review/SKILL.md
+++ b/plugins/git/skills/review/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: git:review
 description: Use when the user wants to review and automatically fix a GitHub PR — /git:review, "PR 리뷰", "코드 리뷰", or any request to review, fix, and comment on a pull request
 user-invocable: true
 ---

--- a/plugins/llm/.claude-plugin/plugin.json
+++ b/plugins/llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "LLM delegation skills — agy(Antigravity CLI) context map generation and execution plan cross-check",
   "author": {
     "name": "ppzxc",

--- a/plugins/llm/skills/agy/SKILL.md
+++ b/plugins/llm/skills/agy/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: llm:agy
 description: Generate context map and cross-check execution plans using Antigravity (agy). Analysis output only — no code execution. — /llm:agy, "agy crosscheck", "교차검증", "context map"
 user-invocable: true
 ---

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Workflow skills — karpathy-guideline (11 Karpathy coding principles, verbatim)",
   "author": {
     "name": "ppzxc",

--- a/plugins/workflow/skills/karpathy-guideline/SKILL.md
+++ b/plugins/workflow/skills/karpathy-guideline/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: workflow:karpathy-guideline
 description: Load the original 11 Karpathy coding guidelines verbatim — do not paraphrase or summarize. User-invocable via /workflow:karpathy-guideline to load guidelines into context before any coding session.
 user-invocable: true
 ---


### PR DESCRIPTION
## Summary
- 모든 플러그인(git, api, llm, dev, docs, workflow) SKILL.md frontmatter에 `name:` 필드 추가
- 6개 플러그인 버전 범프 (marketplace.json, README 동기 포함)

## Motivation
agy(Antigravity CLI)가 심볼릭 링크로 스킬을 로드할 때 SKILL.md의 `name:` 필드가
없으면 모든 스킬이 기본값 `"SKILL"`로 충돌하여 감지 실패.
Claude Code 컨벤션(`<plugin>:<skill>`) 형식으로 12개 SKILL.md에 name 필드 추가.

## Changes
- `git:clean`, `git:commit`, `git:issue`, `git:merge`, `git:pull-request`, `git:review` — name 필드 추가
- `api:restful-guidelines`, `llm:agy`, `dev:tidy`, `docs:adr`, `docs:madr`, `workflow:karpathy-guideline` — name 필드 추가
- 버전 범프: api 0.2.1→0.2.2, docs 0.0.4→0.0.5, git 0.0.13→0.0.14, llm 0.1.0→0.1.1, workflow 0.2.0→0.2.1, dev 0.0.1→0.0.2
- marketplace.json, README.md, README.ko.md 동기 업데이트

## Test plan
- [ ] agy 스킬 목록에서 12개 스킬 모두 정상 감지 확인
- [ ] Claude Code에서 기존 스킬 동작 이상 없음 확인

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.