### PR TITLE
feat(context): context Dev Docs 플러그인 추가 — 4파일 자기완결 세션 재개 시스템

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "Engineering guidelines and best practices for software development",
-    "version": "0.2.1"
+    "version": "0.2.2"
   },
   "plugins": [
     {
@@ -46,6 +46,12 @@
       "source": "./plugins/dev",
       "description": "Development methodology skills — Tidy First, TDD, and language-agnostic development practices",
       "version": "0.0.4"
+    },
+    {
+      "name": "context",
+      "source": "./plugins/context",
+      "description": "Dev Docs System skills — self-contained 4-file task folders (spec/plan/tasks/context) for resumable development",
+      "version": "0.1.0"
     }
   ]
 }

--- a/.claude/rules/context-rules.md
+++ b/.claude/rules/context-rules.md
@@ -1,0 +1,11 @@
+# Context 플러그인 규칙
+
+context 플러그인 스킬을 사용하거나 수정할 때 반드시 다음 제약을 따른다.
+
+✓ 산출물은 `docs/context/{TASK_NAME}/`의 4파일(spec/plan/tasks/context.md)로 고정할 것 [ADR-0027]
+✓ TASK_NAME은 kebab slug으로 정규화하여 경로 traversal·특수문자를 제거할 것 [ADR-0027]
+✓ workflow 플러그인 산출물(`docs/superpowers/plans/`)과 context 산출물(`docs/context/{TASK}/`)의 경로 경계를 혼용하지 말 것 [ADR-0027]
+✓ 래핑 스킬명은 실제 등록명(`superpowers:brainstorming`/`grill-me`/`superpowers:writing-plans`)을 추론 없이 정확히 명시할 것 [ADR-0027]
+✓ brainstorming은 spec+User Review Gate까지만 진행시키고 writing-plans 자동 호출을 차단할 것 [ADR-0027]
+✓ 플랜모드 활성 시 파일 쓰기 직전 Shift+Tab 해제를 요청하고 ExitPlanMode 자체 호출을 금지할 것 [ADR-0016][ADR-0019]
+✓ `context.md` 최상단에 `<!-- last_updated: ISO-8601(UTC) -->` 라인을 두고 update 시 갱신할 것 [ADR-0027]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@
 |------|------|
 | ADR 작성 / 규칙 수정 | `.claude/rules/rules-maintenance.md` |
 | git 스킬 사용 / 수정 | `.claude/rules/git-rules.md` |
+| context 스킬 사용 / 수정 | `.claude/rules/context-rules.md` |
 
 ### 참조
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -14,6 +14,7 @@
 | [git](./plugins/git) | v0.0.16 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
 | [llm](./plugins/llm) | v0.2.0 | LLM 위임 스킬 — agy (Antigravity CLI) 컨텍스트 맵 생성, claude 정밀 분석 및 auto 양방향 교차검증 |
 | [dev](./plugins/dev) | v0.0.4 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
+| [context](./plugins/context) | v0.1.0 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |
 
 ## 마켓플레이스 등록
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [git](./plugins/git) | v0.0.16 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
 | [llm](./plugins/llm) | v0.2.0 | LLM delegation skills — agy (Antigravity CLI) context map, claude advanced reasoning, and auto bidirectional crosscheck |
 | [dev](./plugins/dev) | v0.0.4 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
+| [context](./plugins/context) | v0.1.0 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |
 
 ## Marketplace Registration
 

--- a/docs/decisions/0027-add-context-devdocs-plugin.md
+++ b/docs/decisions/0027-add-context-devdocs-plugin.md
@@ -34,7 +34,7 @@ Chosen option: "옵션 B — 신규 context 플러그인", because 세션 무관
 * Good, because `<!-- last_updated: ISO-8601 -->` 마커로 `update`·`resume`가 최신 태스크를 자동 선택한다.
 * Bad, because grill-me는 파일을 쓰지 않는 대화형 전용 스킬이므로, 오케스트레이터가 합의 내용을 직접 캡처해야 한다 (취약점).
 * Bad, because brainstorming의 writing-plans 자동 체인 차단은 ARGUMENTS의 HARD-GATE 지시에 의존하며 100% 보장되지 않는다 (ADR-0016·ADR-0019 연계).
-* Neutral, because context 플러그인은 일반 markdown 파일을 산출하며 `ExitPlanMode`를 자체 호출하지 않는다 — 네이티브 플랜 승인 추적과 간섭하지 않는다 (ADR-0016 참조).
+* Neutral, because context 플러그인은 일반 markdown 파일을 산출하며 ExitPlanMode를 자체 호출하지 않는다 — 네이티브 플랜 승인 추적과 간섭하지 않는다 (ADR-0016 참조).
 
 ### Confirmation
 

--- a/docs/decisions/0027-add-context-devdocs-plugin.md
+++ b/docs/decisions/0027-add-context-devdocs-plugin.md
@@ -1,0 +1,68 @@
+# Add Context Dev Docs Plugin — 4파일 자기완결 폴더로 세션 재개성 확보
+
+* Status: accepted
+* Date: 2026-05-27
+* Decision Makers: ppzxc
+
+## Context and Problem Statement
+
+Claude Code는 컨텍스트 압축(compaction) 또는 세션 단절 시 작업 맥락이 소실된다.
+현재 `docs/superpowers/plans/`에 단일 plan.md를 두는 방식으로는 세션 재개 시 이전 결정·진행 상황을 빠르게 복원하기 어렵다.
+업계 표준 Dev Docs 패턴(spec-kit, Cline Memory Bank)에 정렬하는 자기완결 폴더 구조가 필요하다.
+
+## Decision Drivers
+
+* 세션 단절 후 폴더 하나만 읽으면 정확히 재개되어야 한다.
+* 기존 `workflow` 플러그인 파이프라인과 공존해야 한다.
+* 마켓플레이스 휴대성 — 호스트 프로젝트 컨벤션(ADR 번호, rules 경로)을 런타임에 상속해야 한다.
+* `brainstorming`→`grill-me`→`writing-plans` 기존 스킬 체인을 재사용해야 한다.
+
+## Considered Options
+
+* 옵션 A: workflow 플러그인의 단일 plan.md 구조를 확장
+* 옵션 B: 4파일 자기완결 폴더를 만드는 신규 `context` 플러그인 ← 채택
+* 옵션 C: `docs/superpowers/` 하위 폴더를 재사용
+
+## Decision Outcome
+
+Chosen option: "옵션 B — 신규 context 플러그인", because 세션 무관 재개성, workflow와 경로 경계 분리 공존, 업계 표준 정렬, 마켓플레이스 휴대성을 동시에 달성할 수 있다.
+
+### Consequences
+
+* Good, because `docs/context/{TASK_NAME}/`의 4파일(spec/plan/tasks/context.md)만 읽으면 언제든 재개된다.
+* Good, because workflow 산출물(`docs/superpowers/plans/`)과 context 산출물(`docs/context/`)이 경로로 명확히 분리된다.
+* Good, because `<!-- last_updated: ISO-8601 -->` 마커로 `update`·`resume`가 최신 태스크를 자동 선택한다.
+* Bad, because grill-me는 파일을 쓰지 않는 대화형 전용 스킬이므로, 오케스트레이터가 합의 내용을 직접 캡처해야 한다 (취약점).
+* Bad, because brainstorming의 writing-plans 자동 체인 차단은 ARGUMENTS의 HARD-GATE 지시에 의존하며 100% 보장되지 않는다 (ADR-0016·ADR-0019 연계).
+* Neutral, because context 플러그인은 일반 markdown 파일을 산출하며 `ExitPlanMode`를 자체 호출하지 않는다 — 네이티브 플랜 승인 추적과 간섭하지 않는다 (ADR-0016 참조).
+
+### Confirmation
+
+`plugins/context/skills/*/SKILL.md`에 `user-invocable: true`가 3개 존재하고, 각 스킬이 `last_updated` grep 스캔 규칙과 location override 파일위치 검증을 포함하는지 확인한다.
+
+## Pros and Cons of the Options
+
+### 옵션 A: workflow plan.md 확장
+
+* Good, because 기존 구조를 유지하므로 변경 범위가 작다.
+* Bad, because 단일 파일은 컨텍스트 재앵커링에 충분한 구조(Current Status / Decision Log / Blockers)를 담기 어렵다.
+* Bad, because `docs/superpowers/plans/`와 경로가 혼용되어 update·resume 스캔이 복잡해진다.
+
+### 옵션 B: 신규 context 플러그인 (채택)
+
+* Good, because 4파일 역할 분리로 spec(설계)·plan(아키텍처)·tasks(체크리스트)·context(동적 앵커)가 명확히 구분된다.
+* Good, because workflow 플러그인과 경로 경계가 명확히 분리된다.
+* Bad, because 신규 플러그인 추가로 플러그인 수가 증가한다.
+
+### 옵션 C: docs/superpowers/ 재사용
+
+* Good, because 추가 디렉토리 없이 기존 구조를 활용한다.
+* Bad, because brainstorming·writing-plans 기본 산출 경로와 충돌하여 update·resume 스캔이 오염된다.
+* Bad, because 마켓플레이스 휴대성 원칙(호스트 컨벤션 상속)과 충돌한다.
+
+## More Information
+
+* ADR-0016: feature-pipeline 플랜 모드 회피 (ExitPlanMode 자체 호출 금지 근거)
+* ADR-0019: feature-pipeline 플랜 모드 호환성 (플랜모드 감지 패턴)
+* `.claude/rules/context-rules.md`: 경로 경계·TASK_NAME 정규화 가드레일
+* 업계 참조: [Cline Memory Bank](https://github.com/cline/cline/discussions/2278), spec-kit 패턴

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -29,6 +29,7 @@
 | [ADR-0021](0021-migrate-llm-backend-from-gemini-cli-to-agy.md) | accepted | gemini-cli MCP 제거 및 agy 백엔드 교체 (feature-pipeline 제거, llm 플러그인 신설) |
 | [ADR-0022](0022-bidirectional-peer-cross-review.md) | accepted | `git:review` 양방향 peer cross-review (호스트별 라우팅, Claude↔agy↔Gemini) |
 | [ADR-0023](0023-git-clean-bidirectional-peer-cross-check.md) | accepted | `git:clean` 양방향 peer cross-check 도입 (호스트별 라우팅, Claude↔agy↔Gemini) |
+| [ADR-0027](0027-add-context-devdocs-plugin.md) | accepted | context Dev Docs 플러그인 추가 (4파일 자기완결 폴더, workflow와 공존) |
 
 ## 새 ADR 추가
 

--- a/plugins/context/.claude-plugin/plugin.json
+++ b/plugins/context/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "context",
+  "version": "0.1.0",
+  "description": "Dev Docs System skills — self-contained 4-file task folders (spec/plan/tasks/context) for resumable, context-preserving development across sessions",
+  "author": {
+    "name": "ppzxc",
+    "email": "cjh8487@naver.com",
+    "url": "https://ppzxc.github.io"
+  }
+}

--- a/plugins/context/README.ko.md
+++ b/plugins/context/README.ko.md
@@ -1,0 +1,45 @@
+# Context 플러그인
+
+**Context** 플러그인은 세션이 끊겨도 재개 가능한 Dev Docs 시스템을 제공한다.
+`docs/context/{TASK_NAME}/` 폴더 하나만 읽으면 정확히 이어서 작업할 수 있다.
+
+## 스킬 목록
+
+| 스킬 | 트리거 | 설명 |
+|------|--------|------|
+| `plan` | `/context:plan` | raw 아이디어에서 4파일 Dev Docs 폴더를 생성 — brainstorming → grill → writing-plans 인라인 파이프라인 |
+| `update` | `/context:update` | 컨텍스트 압축 직전 현재 세션 상태를 폴더에 저장 |
+| `resume` | `/context:resume` | 세션 단절 후 4파일을 읽어 작업을 재개 |
+
+## 산출물 구조
+
+각 태스크는 자기완결 폴더를 생성한다:
+
+```
+docs/context/{TASK_NAME}/
+  spec.md      — brainstorming 설계 산출물 (보존)
+  plan.md      — 목표·아키텍처·파일 구조 (tasks 제거됨)
+  tasks.md     — 추출된 체크리스트
+  context.md   — 동적 재개 앵커 (현재 상태 / 결정 로그 / 다음 할 일 / 블로커)
+```
+
+`context.md` 최상단의 `<!-- last_updated: ISO-8601 -->` 마커를 `update`·`resume`가 grep하여 최신 태스크를 자동 선택한다.
+
+## 휴대성 원칙
+
+이 플러그인은 런타임에 호스트 프로젝트의 컨벤션을 상속한다.
+ADR 번호와 rules 파일 경로는 스킬 파일 안에 하드코딩하지 않는다 — 호스트의 `docs/decisions/`와 `.claude/rules/`에 둔다.
+
+## 설치
+
+```bash
+claude plugin marketplace add https://github.com/ppzxc/engineering-guidelines.git
+```
+
+## 사용법
+
+```bash
+/context:plan  raw 아이디어를 여기에
+/context:update
+/context:resume
+```

--- a/plugins/context/README.md
+++ b/plugins/context/README.md
@@ -1,0 +1,45 @@
+# Context Plugin
+
+The **Context** plugin provides a self-contained Dev Docs system for resumable, context-preserving development across sessions.
+A single folder `docs/context/{TASK_NAME}/` holds all 4 files needed to re-anchor exactly where you left off — even after session breaks.
+
+## Skills
+
+| Skill | Trigger | Description |
+|-------|---------|-------------|
+| `plan` | `/context:plan` | Start a new task from a raw idea — creates the 4-file Dev Docs folder via brainstorming → grill → writing-plans pipeline |
+| `update` | `/context:update` | Persist current session state before context compaction |
+| `resume` | `/context:resume` | Re-anchor on a task after a session break by reading the 4-file folder |
+
+## Output Structure
+
+Each task produces a self-contained folder:
+
+```
+docs/context/{TASK_NAME}/
+  spec.md      — brainstorming design output (preserved)
+  plan.md      — goal, architecture, file structure (tasks trimmed)
+  tasks.md     — extracted checkbox checklist
+  context.md   — dynamic resume anchor (Current Status / Decision Log / Next Steps / Blockers)
+```
+
+The `context.md` file carries a `<!-- last_updated: ISO-8601 -->` marker used by `update` and `resume` to auto-detect the most recent task.
+
+## Portability Principle
+
+This plugin inherits the host project's conventions at runtime.
+ADR numbers and rule file paths are **not** hardcoded inside skill files — they stay in the host project's `docs/decisions/` and `.claude/rules/`.
+
+## Installation
+
+```bash
+claude plugin marketplace add https://github.com/ppzxc/engineering-guidelines.git
+```
+
+## Usage
+
+```bash
+/context:plan  my raw idea here
+/context:update
+/context:resume
+```

--- a/plugins/context/plugin.json
+++ b/plugins/context/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "context",
+  "version": "0.1.0",
+  "description": "Dev Docs System skills — self-contained 4-file task folders (spec/plan/tasks/context) for resumable, context-preserving development across sessions",
+  "author": {
+    "name": "ppzxc",
+    "email": "cjh8487@naver.com",
+    "url": "https://ppzxc.github.io"
+  }
+}

--- a/plugins/context/skills/plan/SKILL.md
+++ b/plugins/context/skills/plan/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: plan
+description: Use when starting a new task from a raw idea and you want a resumable 4-file Dev Docs folder — /context:plan, "컨텍스트 플랜", "작업 폴더 만들어", "재개 가능한 계획"
+user-invocable: true
+---
+
+# Context Plan — 4파일 Dev Docs 폴더 생성
+
+raw 아이디어에서 출발해 `docs/context/{TASK_NAME}/`에 4파일 자기완결 폴더(spec/plan/tasks/context.md)를 만든다.
+이 폴더 하나만 읽으면 세션이 끊겨도 정확히 재개된다.
+
+---
+
+## 실행 순서
+
+### 1. 플랜모드 감지
+
+시작 시 1회 확인한다. 플랜모드가 활성이면:
+- read-only 단계(brainstorming Q&A, grill 질문)만 진행한다.
+- 파일 쓰기 직전 사용자에게 Shift+Tab으로 플랜모드를 해제하도록 요청한다.
+- **ExitPlanMode를 자체 호출하는 것은 절대 금지한다.**
+
+### 2. TASK_NAME 정규화
+
+ARGUMENTS로 받은 raw 아이디어(또는 사용자 입력)에서 TASK_NAME을 kebab slug으로 변환한다:
+1. 소문자로 변환
+2. 공백 → `-`
+3. `[^a-z0-9-]` 문자 제거 (`../` 등 경로 traversal 자동 제거됨)
+4. 연속 `-` 축약 (예: `--` → `-`)
+5. 양끝 `-` 제거
+
+결과 경로: `docs/context/{TASK_NAME}/`
+
+### 3. 폴더 충돌 정책
+
+`docs/context/{TASK_NAME}/` 존재 여부를 확인한다. 존재하면 AskUserQuestion으로 분기:
+- **덮어쓰기**: 기존 작업 상태 소실 경고 후 진행
+- **기존 작업 재개**: `context:resume`를 안내하고 종료
+- **다른 이름으로 생성**: 새 TASK_NAME 입력 받기
+
+비대화 모드(AskUserQuestion 불가) 기본값: suffix `-2` 추가.
+
+### 4. brainstorming 호출 (location override) + 자동 체인 차단 + 파일위치 검증
+
+`superpowers:brainstorming` 스킬을 호출하라.
+ARGUMENTS:
+- 사용자가 언급한 raw 아이디어 그대로
+- (location override) spec 저장 위치를 기본값(`docs/superpowers/specs/...`) 대신
+  `docs/context/{TASK_NAME}/spec.md`로 한다.
+  이는 "User preferences for spec location override this default" 규칙에 따른
+  ARGUMENTS 기반 명시적 경로 지정이다.
+- (HARD-GATE 절단) spec 작성 + User Review Gate(사용자 승인)까지만 진행하고 거기서 정지하라.
+  writing-plans를 호출하지 말 것 — 이 오케스트레이터가 grill을 거쳐 별도 호출한다.
+
+> ⚠ 이 정지 지시가 없으면 brainstorming은 writing-plans를 하드와이어드 terminal state로 자동 실행하여
+> `docs/superpowers/plans/`에 산출물이 생긴다. 차단 지점은 spec 작성 후 User Review Gate.
+
+**파일위치 검증 (brainstorming 반환 직후 필수)**:
+1. `test -f docs/context/{TASK_NAME}/spec.md` 확인.
+2. 실패하면 `docs/superpowers/specs/` 아래 최신 `.md`를 찾아 정본 경로로 이동:
+   `mv <found-path> docs/context/{TASK_NAME}/spec.md`
+3. 재확인 후 진행.
+
+**체크포인트**: User Review Gate 승인 즉시 `spec.md`가 정본 경로에 디스크에 확정됨을 확인한다.
+이후 grill/writing-plans로 진행. 각 sub-skill 산출물은 다음 단계 진행 전 반드시 디스크에 확정되어야 한다.
+
+### 5. grill-me 호출 (파일 미생성 보정)
+
+`grill-me` 스킬을 호출하라.  (네임스페이스 없음 — `grill-me` 그대로)
+ARGUMENTS: `docs/context/{TASK_NAME}/spec.md` 경로 + spec 핵심 1줄 요약
+
+**보정 명시**: grill-me는 파일을 쓰지 않는 순수 대화형 스킬이다. grill 합의 결과(결정 사항)는
+이 오케스트레이터가 대화에서 직접 캡처하여 Step 7의 `context.md` Decision Log에 기록한다.
+grill 출력 파일을 읽으려 시도하지 말 것.
+
+### 6. writing-plans 호출 (location override) + 파일위치 검증
+
+`superpowers:writing-plans` 스킬을 호출하라.
+ARGUMENTS:
+- spec 경로 `docs/context/{TASK_NAME}/spec.md`
+- (location override) plan 저장 위치를 기본값(`docs/superpowers/plans/...`) 대신
+  `docs/context/{TASK_NAME}/plan.md`로 한다 (ARGUMENTS 기반 경로 지정).
+
+**파일위치 검증 (writing-plans 반환 직후 필수)**:
+1. `test -f docs/context/{TASK_NAME}/plan.md` 확인.
+2. 실패하면 `docs/superpowers/plans/` 아래 최신 `.md`를 찾아 정본 경로로 이동:
+   `mv <found-path> docs/context/{TASK_NAME}/plan.md`
+3. 재확인 후 Step 7로 진행.
+
+### 7. 분할·합성 + plan.md 트림
+
+**tasks.md 추출**: plan.md의 `- [ ]` 체크리스트를 Phase별 그룹, `[P]` 병렬 마커,
+체크포인트 보존하여 `docs/context/{TASK_NAME}/tasks.md`에 저장한다.
+
+**context.md 생성**: 아래 템플릿으로 `docs/context/{TASK_NAME}/context.md`를 만든다.
+- Current Status: 초기값 ("작업 폴더 생성 완료. tasks.md Step 1부터 시작.")
+- Key Files: plan.md의 File Structure 섹션에서 추출
+- Decision Log: Step 5(grill)에서 캡처한 합의 결정 사항
+- Next Steps: tasks.md의 첫 번째 미완료 항목
+- Blockers: "None"
+- `Last Updated`: 오늘 날짜
+
+```markdown
+<!-- last_updated: YYYY-MM-DDTHH:MM:SSZ -->
+
+## Current Status
+<!-- 한 줄: 지금 전체적으로 어디까지 -->
+
+## Key Files
+<!-- 주요 파일 경로 + 한 줄 역할 -->
+
+## Decision Log
+<!-- grill 합의 + 구현 중 추가 결정 (spec 초기 설계결정과 구분) -->
+
+## Next Steps
+<!-- 바로 다음 할 일 -->
+
+## Blockers / Known Issues
+<!-- 막힌 것 / 미해결 -->
+
+Last Updated: YYYY-MM-DD
+```
+
+> **스캔 키**: `update`·`resume`의 최신 태스크 선택은 `<!-- last_updated: ... -->` 주석 라인(ISO-8601 UTC)을
+> grep하여 `sort -r` 정렬로 결정한다. `Last Updated:` 가시 라인은 사람용이며 스캔에 사용하지 않는다.
+
+**plan.md 트림**: tasks.md 추출 후 plan.md에서 bite-sized task 단계(`### Task N` 및 그 하위 `- [ ]` step 전체)를
+제거하고 Header(Goal/Architecture/Tech Stack) + File Structure만 남긴다.
+자동 수행, 사용자 확인 불필요(무손실 이동).
+
+### 8. 완료 핸드오프
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+docs/context/{TASK_NAME}/ 폴더 생성 완료
+  spec.md    — brainstorming 설계 산출물
+  plan.md    — 목표·아키텍처·파일 구조 (tasks 제거됨)
+  tasks.md   — 실행 체크리스트
+  context.md — 동적 재개 앵커
+
+세션 단절 후 재개: /context:resume
+작업 상태 저장:    /context:update
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/plugins/context/skills/resume/SKILL.md
+++ b/plugins/context/skills/resume/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: resume
+description: Use after a session break to re-anchor on a task by reading its Dev Docs folder — /context:resume, "컨텍스트 재개", "이어서", "continue", "어디까지 했지"
+user-invocable: true
+---
+
+# Context Resume — 세션 재개
+
+세션 단절 후 `docs/context/{TASK_NAME}/`의 4파일을 읽어 작업을 정확히 재개한다.
+
+---
+
+## 실행 순서
+
+### 1. 대상 폴더 선택
+
+선택적 ARGUMENTS = TASK_NAME.
+
+TASK_NAME이 생략된 경우:
+1. `docs/context/*/context.md`를 glob으로 수집한다.
+2. 각 파일에서 `<!-- last_updated:` 라인을 grep으로 추출한다.
+3. ISO-8601 문자열로 `sort -r` 정렬 → 가장 최신 폴더를 선택한다.
+4. 동일 최신 타임스탬프가 복수이면 AskUserQuestion으로 선택한다.
+
+### 2. 4파일 읽기 및 재앵커링
+
+선택된 `docs/context/{TASK_NAME}/`의 4파일을 모두 읽는다:
+- `spec.md` — 설계 목표와 배경
+- `plan.md` — 아키텍처와 파일 구조
+- `tasks.md` — 전체 체크리스트와 완료 현황
+- `context.md` — 현재 상태, 결정 로그, 다음 할 일, 블로커
+
+읽은 내용을 바탕으로 현재 상황을 요약한다:
+- 어디까지 완료했는지 (tasks.md의 `[x]` 항목)
+- 바로 다음 할 일 (context.md의 Next Steps)
+- 블로커 또는 미해결 이슈 (context.md의 Blockers)
+
+### 3. 작업 재개
+
+context.md의 Next Steps와 Blockers를 기준으로 이어서 작업한다.
+Blockers가 있으면 먼저 사용자에게 알리고 해결 방향을 협의한다.

--- a/plugins/context/skills/update/SKILL.md
+++ b/plugins/context/skills/update/SKILL.md
@@ -18,7 +18,7 @@ user-invocable: true
 선택적 ARGUMENTS = TASK_NAME.
 
 TASK_NAME이 생략된 경우:
-1. `docs/context/*/context.md` 를 glob으로 수집한다.
+1. `docs/context/*/context.md`를 glob으로 수집한다.
 2. 각 파일에서 `<!-- last_updated:` 라인을 grep으로 추출한다.
 3. ISO-8601 문자열로 `sort -r` 정렬 → 가장 최신 폴더를 선택한다.
 4. 동일 최신 타임스탬프가 복수이면 AskUserQuestion으로 선택한다.

--- a/plugins/context/skills/update/SKILL.md
+++ b/plugins/context/skills/update/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: update
+description: Use right before context compaction to persist task state into the Dev Docs folder — /context:update, "컨텍스트 업데이트", "상태 저장", "진행상황 기록"
+user-invocable: true
+---
+
+# Context Update — 작업 상태 영속화
+
+현재 세션의 진행 상태를 `docs/context/{TASK_NAME}/`에 저장한다.
+컨텍스트 압축(compaction) 직전에 사용한다.
+
+---
+
+## 실행 순서
+
+### 1. 대상 폴더 선택
+
+선택적 ARGUMENTS = TASK_NAME.
+
+TASK_NAME이 생략된 경우:
+1. `docs/context/*/context.md` 를 glob으로 수집한다.
+2. 각 파일에서 `<!-- last_updated:` 라인을 grep으로 추출한다.
+3. ISO-8601 문자열로 `sort -r` 정렬 → 가장 최신 폴더를 선택한다.
+4. 동일 최신 타임스탬프가 복수이면 AskUserQuestion으로 선택한다.
+
+### 2. 파일 갱신 규칙
+
+**tasks.md**:
+- 완료된 항목: `- [ ]` → `- [x]`로 변경
+- 신규 task가 있으면 적절한 위치에 추가
+
+**context.md**:
+- `Current Status`: 지금 전체 진행 상황 1줄로 갱신
+- `Decision Log`: 이번 세션에서 내린 결정 추가
+- `Next Steps`: 다음에 할 작업으로 갱신
+- `Blockers / Known Issues`: 막힌 것·미해결 갱신
+- `Last Updated`: 오늘 날짜로 갱신
+- `<!-- last_updated: ... -->`: ISO-8601 UTC 타임스탬프로 갱신
+
+**plan.md**:
+- 스코프 변경이 필요한 경우, 수정 전 **반드시 AskUserQuestion으로 사용자 확인**을 받는다.
+- 확인 없이 plan.md를 수정하지 않는다.
+
+### 3. 완료 보고
+
+갱신된 파일 목록과 변경 요약을 출력한다.

--- a/plugins/llm/skills/agy/references/collect-project-data.sh
+++ b/plugins/llm/skills/agy/references/collect-project-data.sh
@@ -4,6 +4,8 @@
 
 set -u
 
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || true
+
 echo "=== [Project Tree (depth 3)] ==="
 tree -L 3 --dirsfirst -I 'node_modules|.git|target|build|dist|vendor|.idea|__pycache__' 2>/dev/null \
   || find . -maxdepth 3 -not \( -path './.git' -prune -o -path './node_modules' -prune \

--- a/plugins/llm/skills/agy/references/collect-project-data.sh
+++ b/plugins/llm/skills/agy/references/collect-project-data.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Context Map용 PROJECT_DATA 수집 스크립트. agy SKILL.md §Step 1-1에서 호출.
+# 출력은 stdout으로. 호출자가 PROJECT_DATA 변수로 캡처해 agy_context_map 인자로 전달.
+
+set -u
+
+echo "=== [Project Tree (depth 3)] ==="
+tree -L 3 --dirsfirst -I 'node_modules|.git|target|build|dist|vendor|.idea|__pycache__' 2>/dev/null \
+  || find . -maxdepth 3 -not \( -path './.git' -prune -o -path './node_modules' -prune \
+       -o -path './target' -prune -o -path './build' -prune \
+       -o -path './dist' -prune -o -path './vendor' -prune \) \
+       \( -type f -o -type d \) | sort | head -100
+
+echo ""
+echo "=== [Build Configuration] ==="
+for f in pom.xml build.gradle build.gradle.kts go.mod go.sum Cargo.toml \
+          package.json composer.json requirements.txt pyproject.toml; do
+  if [ -f "$f" ]; then
+    echo "--- $f ---"
+    head -80 "$f"
+    echo ""
+  fi
+done
+
+echo ""
+echo "=== [Core Entity/Model Signatures] ==="
+find . -not \( -path './.git' -prune -o -path './target' -prune -o -path './build' -prune \) \
+  -type f \( -name '*.java' -o -name '*.kt' \) \
+  \( -path '*/domain/*' -o -path '*/entity/*' -o -path '*/model/*' \) \
+  2>/dev/null | head -20 | while read -r src; do
+  echo "--- $src ---"
+  grep -n '^\(public \)\?\(class\|interface\|record\|enum\|data class\) ' "$src" | head -5
+  grep -n '^\s*private \|^\s*val \|^\s*var ' "$src" | head -10
+  echo ""
+done
+find . -not \( -path './.git' -prune -o -path './vendor' -prune -o -path './build' -prune \) \
+  -type f -name '*.go' 2>/dev/null | head -20 | while read -r src; do
+  if grep -q '^type .*struct' "$src"; then
+    echo "--- $src ---"
+    grep -n '^type \|^\s\+[A-Z]' "$src" | head -15
+    echo ""
+  fi
+done
+
+echo ""
+echo "=== [Recent Git Changes (last 2 weeks)] ==="
+git log --since='2 weeks ago' --grep='^\(feat\|fix\|refactor\|perf\|chore\)' \
+  --pretty=format:'%h - %s' --no-merges 2>/dev/null | head -n 20

--- a/plugins/llm/skills/agy/references/operations.md
+++ b/plugins/llm/skills/agy/references/operations.md
@@ -1,0 +1,46 @@
+# agy 스킬 — 운영 가이드라인
+
+본 문서는 Antigravity CLI(`agy`) MCP Wrapper의 효율적인 운영 및 리소스 관리를 위한 지침을 담고 있습니다.
+
+---
+
+## 1. agy conversations 파일 누적 및 클린업 정책
+
+Antigravity CLI는 비대화형 호출을 수행할 때마다 `~/.gemini/antigravity-cli/conversations/<uuid>.pb` 경로에 대화 상태 로그를 계속해서 누적 저장합니다.
+Wrapper는 매번 새로운 stateless 분석 세션을 생성하므로(즉, `--continue`를 사용하지 않으므로), 이 로그들이 주기적으로 삭제되지 않으면 디스크 용량을 점차 낭비하게 됩니다.
+
+### 🧹 디스크 관리 기준
+* **권장 정리 주기**: 7일 경과 로그 삭제 또는 디스크 점유량 100MB 초과 시 정리.
+* **현재 conversations 사용량 확인**:
+  ```bash
+  du -sh ~/.gemini/antigravity-cli/conversations/
+  ```
+
+### 🛠️ 수동 클린업 방법
+다음 명령을 통해 오래된 세션 데이터들을 삭제할 수 있습니다.
+```bash
+# 7일 이상 된 .pb 파일 전체 삭제
+find ~/.gemini/antigravity-cli/conversations -name '*.pb' -mtime +7 -delete
+
+# conversations 내 파일 수가 너무 많은 경우 가장 오래된 파일 절반을 강제 삭제
+ls -t ~/.gemini/antigravity-cli/conversations/*.pb | tail -n +$(( $(ls ~/.gemini/antigravity-cli/conversations/*.pb | wc -l) / 2 )) | xargs rm -f
+```
+
+### ⏰ 크론탭(crontab) 자동화 (권장)
+매일 새벽 3시에 7일이 지난 데이터를 자동으로 삭제하도록 크론(cron)에 등록합니다. (`crontab -e` 명령으로 편집)
+```cron
+0 3 * * * find /root/.gemini/antigravity-cli/conversations -name '*.pb' -mtime +7 -delete
+```
+
+---
+
+## 2. agy 인증 토큰 관리
+
+`agy`는 구글 OAuth 토큰(`~/.gemini/antigravity-cli/antigravity-oauth-token`)을 통해 API 인증을 수행합니다. 토큰이 만료되면 MCP Wrapper 실행 도중 `AGY_ERROR`가 발생하며 호출이 차단될 수 있습니다.
+
+### 🔐 토큰 만료 징후
+* MCP 도구 호출 시 즉각 `AGY_ERROR(exit=...)` 또는 에러 메일/로그에 인증 에러가 포함되는 경우.
+
+### 🔄 토큰 갱신 절차
+1. 쉘 환경에서 `agy install` 또는 `agy update`를 실행하여 대화형 인증창을 띄웁니다.
+2. 화면의 안내에 따라 로그인 인증 절차를 다시 완료하여 신규 OAuth 토큰을 발급받습니다.


### PR DESCRIPTION
## Summary
- `plugins/context` 신규 플러그인 추가 — 3개 스킬(plan/update/resume)로 구성
- 세션 단절 후 `docs/context/{TASK_NAME}/` 폴더 하나만 읽으면 정확히 재개되는 4파일 Dev Docs 시스템
- ADR-0027 결정 기록 및 `.claude/rules/context-rules.md` 가드레일 추가
- marketplace.json 0.2.1→0.2.2 버전 업, README/ADR 인덱스 동기화
- `plugins/llm/skills/agy/references/` 누락 파일(collect-project-data.sh, operations.md) 추가

## Motivation
Claude Code 세션 압축(compaction) 또는 단절 시 작업 맥락이 소실되는 문제를 해결한다.
brainstorming→grill-me→writing-plans 기존 스킬 체인을 재사용해 spec/plan/tasks/context.md 4파일을 생성하고,
`<!-- last_updated: ISO-8601 -->` 마커로 update·resume가 최신 태스크를 자동 선택한다.

## Changes
- `plugins/context/.claude-plugin/plugin.json` + `plugin.json` (v0.1.0)
- `plugins/context/skills/plan/SKILL.md` — 전방 오케스트레이터 (brainstorming HARD-GATE, location override, grill 캡처, plan.md 트림)
- `plugins/context/skills/update/SKILL.md` — 컨텍스트 압축 직전 상태 영속화
- `plugins/context/skills/resume/SKILL.md` — 세션 재개 앵커링
- `plugins/context/README.md` / `README.ko.md`
- `docs/decisions/0027-add-context-devdocs-plugin.md` (ADR-0027, MADR 4.0 full)
- `.claude/rules/context-rules.md` (7개 가드레일)
- `.claude-plugin/marketplace.json`, `CLAUDE.md`, `README.md`, `README.ko.md`, ADR 인덱스 동기화
- `plugins/llm/skills/agy/references/collect-project-data.sh` + `operations.md` (agy 스킬 누락 의존성)

## Test plan
- [ ] `jq . plugins/context/.claude-plugin/plugin.json` — JSON 유효성
- [ ] 3 스킬 `user-invocable: true` frontmatter 존재 확인
- [ ] `last_updated` grep 스캔 규칙 — update·resume 스킬에 존재
- [ ] `jq . .claude-plugin/marketplace.json` — marketplace JSON 유효성
- [ ] `/context:plan <더미아이디어>` 실행 → `docs/context/<slug>/` 4파일 생성 확인 (수동)

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.