### PR TITLE
chore: 도구 아티팩트 디렉터리를 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 .claude/*
 !.claude/rules/
+.antigravitycli/
+.claude-octopus/
 .worktrees/
 docs/*
 !docs/decisions/
 !docs/agy-import-guidelines.md
 plugins/api/docs/superpowers/
 .context-map.md
-.antigravitycli/
-.claude-octopus/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/*
 !docs/agy-import-guidelines.md
 plugins/api/docs/superpowers/
 .context-map.md
+.antigravitycli/
+.claude-octopus/


### PR DESCRIPTION
## Summary
- `.antigravitycli/`, `.claude-octopus/` 두 디렉터리를 `.gitignore`에 추가

## Motivation
AGY CLI와 Claude Octopus의 런타임 상태 파일이 버전 관리에 포함될 위험 차단. `git add .` 등 실수로 커밋되거나 `git clean -fdx`로 삭제될 수 있는 리스크 제거.

## Changes
- `.gitignore`에 `.antigravitycli/`, `.claude-octopus/` 패턴 추가

## Test plan
- [ ] `git check-ignore -v .antigravitycli/` → 패턴 매칭 확인
- [ ] `git status`에서 해당 디렉터리가 더 이상 untracked로 표시되지 않음 확인