### PR TITLE
fix(context): Stop hook 잘못된 decision 필드 제거 및 .claude/ 필터 추가 (v0.3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -51,7 +51,7 @@
       "name": "context",
       "source": "./plugins/context",
       "description": "Dev Docs System skills — self-contained 4-file task folders (spec/plan/tasks/context) for resumable development",
-      "version": "0.2.0"
+      "version": "0.3.1"
     }
   ]
 }

--- a/README.ko.md
+++ b/README.ko.md
@@ -14,7 +14,7 @@
 | [git](./plugins/git) | v0.0.16 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
 | [llm](./plugins/llm) | v0.2.0 | LLM 위임 스킬 — agy (Antigravity CLI) 컨텍스트 맵 생성, claude 정밀 분석 및 auto 양방향 교차검증 |
 | [dev](./plugins/dev) | v0.0.4 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
-| [context](./plugins/context) | v0.3.0 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |
+| [context](./plugins/context) | v0.3.1 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |
 
 ## 마켓플레이스 등록
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [git](./plugins/git) | v0.0.16 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
 | [llm](./plugins/llm) | v0.2.0 | LLM delegation skills — agy (Antigravity CLI) context map, claude advanced reasoning, and auto bidirectional crosscheck |
 | [dev](./plugins/dev) | v0.0.4 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
-| [context](./plugins/context) | v0.3.0 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |
+| [context](./plugins/context) | v0.3.1 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |
 
 ## Marketplace Registration
 

--- a/docs/decisions/0028-context-guard-opt-in-stop-hook.md
+++ b/docs/decisions/0028-context-guard-opt-in-stop-hook.md
@@ -70,4 +70,4 @@ Chosen option: "옵션 2: 전용 설치 스킬로 호스트 옵트인 Stop hook 
 * [ADR-0014](0014-strengthen-feature-pipeline-evidence-based-gates.md) — hook 기반 강제를 검토했으나 플랫폼 의존성 이유로 거부한 결정. 본 ADR이 그 원칙을 유지하면서 옵트인 경로를 열어 refine.
 * [ADR-0027](0027-add-context-devdocs-plugin.md) — context 플러그인 도입 결정
 * `.claude/rules/context-rules.md` — context:guard 관련 규칙 (`[ADR-0028]` 태그)
-* Stop hook JSON 스키마: `{"decision":"allow","systemMessage":"..."}` — Claude Code 버전별 지원 여부 확인 필요
+* Stop hook JSON 스키마: `{"systemMessage":"..."}` — `decision` 필드는 Stop hook에서 `block`/생략만 유효하므로 비차단 reminder는 systemMessage 단독으로 emit한다.

--- a/plugins/context/.claude-plugin/plugin.json
+++ b/plugins/context/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Dev Docs System skills — self-contained 4-file task folders (spec/plan/tasks/context) for resumable, context-preserving development across sessions",
   "author": {
     "name": "ppzxc",

--- a/plugins/context/hooks/context-staleness-check.sh
+++ b/plugins/context/hooks/context-staleness-check.sh
@@ -27,7 +27,7 @@ done
 
 # Check for code changes outside docs/
 CHANGED=$(git -C "$GIT_ROOT" status --porcelain 2>/dev/null \
-          | awk '{print $NF}' | grep -v '^docs/' | head -1)
+          | awk '{print $NF}' | grep -vE '^(docs|\.claude)/' | head -1)
 [ -n "$CHANGED" ] || exit 0
 
 # Convert last_updated ISO-8601 to epoch (GNU date; BSD/macOS fallback)
@@ -40,7 +40,7 @@ fi
 # Find newest mtime among changed code files
 NEWEST=0
 for f in $(git -C "$GIT_ROOT" status --porcelain 2>/dev/null \
-           | awk '{print $NF}' | grep -v '^docs/'); do
+           | awk '{print $NF}' | grep -vE '^(docs|\.claude)/'); do
   fp="$GIT_ROOT/$f"
   [ -f "$fp" ] || continue
   MT=$(stat -c %Y "$fp" 2>/dev/null)
@@ -56,5 +56,5 @@ done
 
 # Stale: emit non-blocking reminder
 TASK=$(dirname "$BEST_FILE" | sed "s|$GIT_ROOT/||")
-printf '{"decision":"allow","systemMessage":"⚠️  %s/context.md 가 stale입니다. /context:update 로 진행상황을 기록하세요."}\n' "$TASK"
+printf '{"systemMessage":"⚠️  %s/context.md 가 stale입니다. /context:update 로 진행상황을 기록하세요."}\n' "$TASK"
 exit 0

--- a/plugins/context/skills/guard/SKILL.md
+++ b/plugins/context/skills/guard/SKILL.md
@@ -63,7 +63,7 @@ done
 
 # Check for code changes outside docs/
 CHANGED=$(git -C "$GIT_ROOT" status --porcelain 2>/dev/null \
-          | awk '{print $NF}' | grep -v '^docs/' | head -1)
+          | awk '{print $NF}' | grep -vE '^(docs|\.claude)/' | head -1)
 [ -n "$CHANGED" ] || exit 0
 
 # Convert last_updated ISO-8601 to epoch (GNU date; BSD/macOS fallback)
@@ -76,7 +76,7 @@ fi
 # Find newest mtime among changed code files
 NEWEST=0
 for f in $(git -C "$GIT_ROOT" status --porcelain 2>/dev/null \
-           | awk '{print $NF}' | grep -v '^docs/'); do
+           | awk '{print $NF}' | grep -vE '^(docs|\.claude)/'); do
   fp="$GIT_ROOT/$f"
   [ -f "$fp" ] || continue
   MT=$(stat -c %Y "$fp" 2>/dev/null)
@@ -92,12 +92,12 @@ done
 
 # Stale: emit non-blocking reminder
 TASK=$(dirname "$BEST_FILE" | sed "s|$GIT_ROOT/||")
-printf '{"decision":"allow","systemMessage":"⚠️  %s/context.md 가 stale입니다. /context:update 로 진행상황을 기록하세요."}\n' "$TASK"
+printf '{"systemMessage":"⚠️  %s/context.md 가 stale입니다. /context:update 로 진행상황을 기록하세요."}\n' "$TASK"
 exit 0
 ```
 
-> **스키마 참고**: Stop hook 비차단 출력에 `{"decision":"allow","systemMessage":"..."}` 형식을 사용한다.
-> Claude Code 버전별로 `systemMessage` 지원 여부가 다를 수 있으므로 설치 후 동작을 반드시 검증한다.
+> **스키마 참고**: Stop hook 비차단 출력에 `{"systemMessage":"..."}` 형식을 사용한다.
+> `decision` 필드는 Stop hook에서 `block` 또는 생략만 유효하며, 비차단 reminder는 decision 없이 systemMessage 단독으로 emit한다.
 
 ### 4. 사용자 확인
 


### PR DESCRIPTION
## Summary
- `context:guard`가 설치한 Stop hook 스크립트에서 `"decision":"allow"` 필드 제거
- staleness 트리거 필터에 `.claude/` 경로 추가 (worktrees dirty 노이즈 제거)
- ADR-0028 More Information JSON 스키마 라인 정정
- context 플러그인 버전 0.3.1 bumping (marketplace drift 0.2.0 → 0.3.1 복구 포함)

## Motivation
Stop hook에서 `"decision":"allow"`는 invalid value (`allow`는 PreToolUse 전용).
일부 Claude Code 버전이 이를 에러로 출력 → gatekeeper 세션에서 매 Stop마다 에러 메시지 반복.

## Changes
- `plugins/context/hooks/context-staleness-check.sh`: printf JSON에서 decision 필드 제거, grep 필터 확장
- `plugins/context/skills/guard/SKILL.md`: 임베디드 템플릿 동기화, 스키마 참고 주석 정정
- `docs/decisions/0028-context-guard-opt-in-stop-hook.md`: More Information JSON 스키마 라인 정정
- 버전 4개 위치 0.3.1로 동기화

## Test plan
- [ ] hook 스크립트 직접 실행: `{"systemMessage":"..."}` 출력 (decision 키 없음)
- [ ] `.claude/`만 dirty 상태에서 스크립트 침묵 확인 (exit 0, 출력 없음)
- [ ] jq 파싱 통과 확인

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.