### PR TITLE
refactor(git): git:clean Step 0a peer crosscheck 제거 (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,7 +33,7 @@
       "name": "git",
       "source": "./plugins/git",
       "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
-      "version": "0.0.17"
+      "version": "0.1.0"
     },
     {
       "name": "llm",

--- a/.claude/rules/git-rules.md
+++ b/.claude/rules/git-rules.md
@@ -7,7 +7,8 @@ git 플러그인 스킬을 사용하거나 수정할 때 반드시 다음 제약
 ✓ `.java` 파일 변경 시 항상 `java:reviewer`를 로드하고, PR diff에 Spring 어노테이션(@RestController/@Service/@Component/@Repository/@Controller/@Configuration) 또는 `import org.springframework.`가 보이면 `java:spring`을 추가 로드할 것
 ✓ `.go` 파일 변경 시 `golang:reviewer`를 로드할 것
 ✓ PR 제목과 본문은 한글로 작성할 것 (기술 용어·코드·커맨드 제외)
-✓ git:review와 git:clean의 peer crosscheck는 자기 호스트와 다른 LLM에게 위임할 것. 자기 자신에게 cross-check를 보내는 호출 금지 [ADR-0022][ADR-0023]
+✓ git:review의 peer crosscheck는 자기 호스트와 다른 LLM에게 위임할 것. 자기 자신에게 cross-check를 보내는 호출 금지 [ADR-0022][ADR-0033]
+✓ git:clean entry에서 별도 peer crosscheck를 추가하지 말 것 (post-work pipeline이므로 plan 검토 대상 없음) [ADR-0035]
 ✓ git:review의 cross-review는 Self/Peer 두 SUBAGENT 병렬 dispatch로 수행할 것 (Claude Code host) [ADR-0033]
 ✓ peer 폴백 체인은 자기 호스트를 제외한 풀에서 우선순위대로 시도하고 모든 sentinel(NOT_FOUND/TIMEOUT/ERROR)에서 다음 peer로 이동할 것 [ADR-0033]
 ✓ Self SUBAGENT 선택은 실행 시 AskUserQuestion으로 동적 노출하고 review-capable agent(description에 review/code/audit 키워드)를 필터링할 것 [ADR-0033]

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
 | [guideline](./plugins/guideline) | v0.2.1 | 소프트웨어 엔지니어링 가이드라인 및 코딩 원칙 — RESTful API 가이드라인, Andrej Karpathy의 11가지 코딩 행동 지침, Honest Judgment 안티-sycophancy 리뷰 규칙 포함 |
 | [workflow](./plugins/workflow) | v0.1.1 | 오케스트레이션된 개발 프로세스 워크플로우 스킬 — 고강도 개발 기율 강제를 위한 init, idea, feature, develop, planning 스킬 포함 |
 | [docs](./plugins/docs) | v0.0.7 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
-| [git](./plugins/git) | v0.0.17 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
+| [git](./plugins/git) | v0.1.0 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
 | [llm](./plugins/llm) | v0.3.0 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |
 | [dev](./plugins/dev) | v0.0.4 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 | [context](./plugins/context) | v0.5.0 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [guideline](./plugins/guideline) | v0.2.1 | Software engineering guidelines and coding principles — including RESTful API guidelines, Andrej Karpathy's 11 coding principles, and the Honest Judgment anti-sycophancy review rule |
 | [workflow](./plugins/workflow) | v0.1.1 | Orchestrated developer workflow skills — including init, idea, feature, develop, and planning for rigorous software engineering |
 | [docs](./plugins/docs) | v0.0.7 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
-| [git](./plugins/git) | v0.0.17 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
+| [git](./plugins/git) | v0.1.0 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
 | [llm](./plugins/llm) | v0.3.0 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |
 | [dev](./plugins/dev) | v0.0.4 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 | [context](./plugins/context) | v0.5.0 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |

--- a/docs/decisions/0023-git-clean-bidirectional-peer-cross-check.md
+++ b/docs/decisions/0023-git-clean-bidirectional-peer-cross-check.md
@@ -1,6 +1,6 @@
 # `git:clean` 양방향 peer cross-check 도입 (호스트별 라우팅)
 
-* Status: accepted
+* Status: superseded by ADR-0035
 * Date: 2026-05-22
 * Decision Makers: ppzxc
 

--- a/docs/decisions/0035-deprecate-git-clean-peer-crosscheck.md
+++ b/docs/decisions/0035-deprecate-git-clean-peer-crosscheck.md
@@ -1,0 +1,58 @@
+# `git:clean` entry peer crosscheck 폐지
+
+* Status: accepted
+* Date: 2026-05-28
+* Decision Makers: ppzxc
+
+## Context and Problem Statement
+
+`git:clean`은 코드 작업이 끝난 뒤 commit → PR → review → merge → cleanup을 실행하는 post-work pipeline orchestrator이다. ADR-0023에서 ADR-0022(git:review)의 양방향 peer cross-check 패턴을 차용하여 Step 0a를 추가했다. 그러나 `/git:*` entrypoint는 사전 plan/spec이 종결된 뒤 호출되므로 "계획 검토"의 대상이 없고, 0a가 검토하는 내용(현재 git 상태 + deterministic step 표)은 두 LLM이 동일한 추론을 반복하는 행위에 그친다. ADR-0023은 git:review 패턴의 mechanical 차용이었음을 인정하고 폐기한다.
+
+## Decision Drivers
+
+* `/git:*`는 post-work pipeline이다 — entry 시점에 검토할 "plan"이 없다.
+* 진짜 정보 비대칭(코드 내용 vs 의도 차이)은 Step 3 `git:review` 내 양방향 SUBAGENT cross-review(ADR-0033)가 담당한다.
+* Plan-level 위험(dirty tree, unmerged branch, duplicate PR)은 git native guard(`git branch -d`, `git checkout`, `gh pr create`)가 이미 차단한다.
+* ADR-0023 도입 당시 primary driver가 "ADR-0022와의 일관성 유지"였음 — fit 검증 없는 패턴 복제를 수정한다.
+* ADR-0034가 이미 ADR-0023 일부를 supersede했으므로 본 ADR에서 전체 폐기를 완결한다.
+
+## Considered Options
+
+* Step 0a 전체 제거
+* Step 0a를 self-check(peer 없이)로 축소
+
+## Decision Outcome
+
+Chosen option: "Step 0a 전체 제거", because post-work pipeline에서 LLM plan 검토 레이어는 ROI가 없으며 sub-skill guard와 git:review cross-check가 실질 안전망을 충분히 제공한다.
+
+### Consequences
+
+* Good, because git:clean 진입 시 불필요한 peer LLM 호출(최대 300s) 제거 → latency 단축.
+* Good, because agy MCP / claude CLI 의존성 제거 → 환경에 무관하게 안정 동작.
+* Good, because Step 3 git:review가 코드 cross-check 단일 책임을 명확히 보유한다.
+* Bad, because plan-level peer review layer가 없어지지만, 이 layer가 실질 버그를 탐지한 사례가 없었으므로 손실 무시 가능.
+
+### Confirmation
+
+* `plugins/git/skills/clean/SKILL.md`에 `Step 0a`, `agy_cross_check`, `CLAUDE_CLI_` 문자열이 없음을 `grep`으로 확인.
+* `/git:clean` 호출 시 Step 0 → Step 1이 peer 호출 없이 즉시 진행됨을 확인.
+
+## Pros and Cons of the Options
+
+### Step 0a 전체 제거
+
+* Good, because 불필요한 LLM 왕복 제거, 실행 속도 향상.
+* Good, because 환경 의존성 제거 (agy/claude CLI 부재 시에도 동작).
+* Bad, because git:clean 자체에 외부 검증 layer가 없어짐 (git native guard + git:review로 보완).
+
+### Step 0a를 self-check로 축소
+
+* Good, because CLI 의존성 제거.
+* Bad, because self-check = 동일 LLM이 자기 계획 재확인 → 정보 이득 없음. 코드만 남고 가치는 없다.
+
+## More Information
+
+* Supersedes ADR-0023 (`git:clean` 양방향 peer cross-check 도입)
+* Related rules: `.claude/rules/git-rules.md`
+* Code cross-check 책임: ADR-0033 (`git:review` 병렬 SUBAGENT 크로스 리뷰)
+* Pre-flight / stdin pipe / sentinel 패턴 보존: ADR-0033, ADR-0034

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -28,7 +28,7 @@
 | [ADR-0020](0020-raise-feature-pipeline-plan-size-cap-to-16kb.md) | accepted | feature-pipeline plan 파일 사이즈 캡 16KB 상향 + plan-skip HIGH 위험 차단 (supersedes ADR-0016 8KB 수치 부분) |
 | [ADR-0021](0021-migrate-llm-backend-from-gemini-cli-to-agy.md) | accepted | gemini-cli MCP 제거 및 agy 백엔드 교체 (feature-pipeline 제거, llm 플러그인 신설) |
 | [ADR-0022](0022-bidirectional-peer-cross-review.md) | accepted | `git:review` 양방향 peer cross-review (호스트별 라우팅, Claude↔agy↔Gemini) |
-| [ADR-0023](0023-git-clean-bidirectional-peer-cross-check.md) | accepted | `git:clean` 양방향 peer cross-check 도입 (호스트별 라우팅, Claude↔agy↔Gemini) |
+| [ADR-0023](0023-git-clean-bidirectional-peer-cross-check.md) | superseded by ADR-0035 | `git:clean` 양방향 peer cross-check 도입 (호스트별 라우팅, Claude↔agy↔Gemini) |
 | [ADR-0027](0027-add-context-devdocs-plugin.md) | superseded by ADR-0030 (HARD-GATE 부분) | context Dev Docs 플러그인 추가 (4파일 자기완결 폴더, workflow와 공존) |
 | [ADR-0028](0028-context-guard-opt-in-stop-hook.md) | superseded by ADR-0031 | context 플러그인 옵트인 Stop hook 도입 — context:guard 설치 스킬로 호스트 프로젝트에 staleness reminder 제공 |
 | [ADR-0029](0029-context-plan-tiered-verification.md) | superseded by ADR-0030 | context:plan 계층형 자가검증·리뷰 게이트 도입 (Tier 1 self-review + Tier 2 비-Claude CLI cross-check) |
@@ -37,6 +37,7 @@
 | [ADR-0032](0032-context-plan-discipline-injection.md) | accepted | context:plan 디시플린 주입 — karpathy/tdd/tidy 원칙 디폴트 ON (설계 lens + [S]/[B] 검증 + GAN prompt 확장) |
 | [ADR-0033](0033-git-review-parallel-subagent-cross-review.md) | accepted | `git:review` 병렬 SUBAGENT 크로스 리뷰 — Self/Peer SUBAGENT 병렬 dispatch, 호스트별 폴백 체인, severity-gated 머지 |
 | [ADR-0034](0034-llm-plugin-4way-and-context-map-deprecation.md) | accepted | llm 플러그인 4-way 폴백 체인 확장 + context-map 전면 폐기 (ADR-0021/0022/0023 부분 supersede) |
+| [ADR-0035](0035-deprecate-git-clean-peer-crosscheck.md) | accepted | `git:clean` entry peer crosscheck 폐지 — post-work pipeline 본질 재확인, ADR-0023 full supersede |
 
 ## 새 ADR 추가
 

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.0.17",
+  "version": "0.1.0",
   "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/skills/clean/SKILL.md
+++ b/plugins/git/skills/clean/SKILL.md
@@ -43,46 +43,6 @@ Assess current state.
 
 Assess current state and determine which steps are needed.
 
-### Step 0a. Peer Crosscheck (host-aware)
-
-자기 호스트를 식별하고 peer reviewer에게 현재 Git 상태와 `/git:clean` 실행 계획에 대한 크로스체크를 위임한다. 자기 자신에게 cross-check를 보내는 호출은 금지 [ADR-0023].
-
-현재 Git 상태 및 계획 정보 획득:
-- 브랜치명, 미커밋 파일 목록, 기존 PR 번호(있다면), 원격/로컬 브랜치 커밋 차이.
-- 계획 정보: 수행 예정인 단계 (예: Step 1 Commit 여부, Step 2 PR 여부, Step 3 Review 여부, Step 4 Merge 여부, Step 5 Cleanup 여부).
-
-| 자기가 누구인가 | peer reviewer 호출 |
-|----------------|-------------------|
-| Claude Code | `mcp__agy__agy_cross_check(plan=<Git 상태 및 clean 실행 계획>)` |
-| Gemini CLI | Bash (300s timeout): `printf '%s' "$CLEAN_PLAN" \| claude -p "<peer crosscheck 지시>"` — 계획 정보는 stdin pipe로 전달 |
-| Antigravity (agy host) | (Gemini CLI와 동일) |
-
-**Pre-flight** — `claude -p` 분기 진입 전 `timeout 3 claude --version` 실행. exit ≠ 0이면 즉시 `CLAUDE_CLI_NOT_FOUND:` sentinel 발동 (미인증/오프라인 상태로 300s hang 방지).
-
-**Safety** — 계획 정보는 반드시 stdin pipe 또는 임시 파일로 전달한다. CLI 인자에 직접 보간하지 않는다 — shell metacharacter (백틱·`$()`) injection 및 `ARG_MAX` 초과 위험을 차단한다.
-
-자기 호스트 식별: LLM 자기 인지(Claude는 자기가 Claude임을 안다). 보조 시그널 (강한 시그널 우선 적용):
-- `mcp__agy__agy_cross_check` 도구가 호출 가능 → Claude Code
-- `mcp__agy__` 도구가 보이지 않으나 `claude` CLI는 PATH에 있음 → Gemini CLI 또는 Antigravity
-- 두 시그널 모두 없으면 self-only check로 fallback
-
-**동기 실행** — 결과를 받기 전 Step 1로 넘어가지 않는다.
-
-**Peer 검토 관점:** consistency·omissions·ordering·risk·feasibility·version-compat (아키텍처 관점). 정리 대상 브랜치/작업공간이 안전하고 유실될 변경사항이 없는지 검토.
-
-**Sentinel 처리** — 다음 prefix로 시작하면 즉시 Step 1로 진행. 동일 인자 재호출 금지:
-
-| Sentinel | 트리거 호스트 | 의미 |
-|----------|-------------|------|
-| `AGY_TIMEOUT:` | Claude Code | agy 300s 초과 |
-| `AGY_ERROR(exit=...)` | Claude Code | agy 비정상 종료 |
-| `AGY_NOT_FOUND:` | Claude Code | agy 바이너리 부재 |
-| `CLAUDE_CLI_NOT_FOUND:` | Gemini / agy host | `claude` 바이너리 부재 |
-| `CLAUDE_CLI_TIMEOUT:` | Gemini / agy host | `claude -p` 300s 초과 |
-| `CLAUDE_CLI_ERROR(exit=N):` | Gemini / agy host | `claude -p` 비정상 종료 |
-
-Sentinel 발생 시: notify user "⚠️ peer reviewer unavailable, self-only check".
-
 ### Step 1. Commit (if uncommitted changes exist)
 
 If uncommitted changes exist, execute the **git:commit** skill.

--- a/plugins/git/skills/clean/SKILL.md
+++ b/plugins/git/skills/clean/SKILL.md
@@ -36,7 +36,6 @@ git branch --show-current
 gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo "main"
 ```
 
-Assess current state.
 **CRITICAL:** If `git branch --show-current` equals the default branch:
 1. Generate a new feature branch name (e.g., `feat/clean-$(date +%Y%m%d-%H%M)`).
 2. Create and checkout the new branch: `git checkout -b <NEW_BRANCH>`


### PR DESCRIPTION
## Summary
- `git:clean` Step 0a(Peer Crosscheck) 섹션 제거
- ADR-0035 신규 작성 (ADR-0023 full supersede)
- git-rules.md 규칙 분리 업데이트
- git 플러그인 v0.0.17 → v0.1.0 버전 범프

## Motivation
`/git:*`는 post-work pipeline으로 entry 시점에 검토할 "plan"이 없다.
Step 0a가 검토하던 내용(git 상태 + deterministic step 표)은 두 LLM이 동일 추론을 반복하는 행위에 그쳤다.
코드 cross-check는 Step 3 `git:review`(ADR-0033)가 단일 책임으로 담당한다.

## Changes
- `plugins/git/skills/clean/SKILL.md`: Step 0a 섹션 40줄 삭제
- `docs/decisions/0035-deprecate-git-clean-peer-crosscheck.md`: ADR-0023 full supersede ADR 신규
- `.claude/rules/git-rules.md`: git:review peer crosscheck 규칙 분리, ADR-0035 태그 추가
- 버전 3곳 동기화 (marketplace.json / plugin.json / README 2개)

## Test plan
- [ ] `grep -n "Step 0a\|agy_cross_check\|CLAUDE_CLI_" plugins/git/skills/clean/SKILL.md` → 0 matches
- [ ] ADR-0023 status `superseded by ADR-0035` 확인
- [ ] 버전 4곳 `0.1.0` 일치 확인