### PR TITLE
feat(git): Self-Review를 pr-review-toolkit:code-reviewer로 교체 (v0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,7 +33,7 @@
       "name": "git",
       "source": "./plugins/git",
       "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     {
       "name": "llm",

--- a/.claude/rules/git-rules.md
+++ b/.claude/rules/git-rules.md
@@ -11,5 +11,6 @@ git 플러그인 스킬을 사용하거나 수정할 때 반드시 다음 제약
 ✓ git:clean entry에서 별도 peer crosscheck를 추가하지 말 것 (post-work pipeline이므로 plan 검토 대상 없음) [ADR-0035]
 ✓ git:review의 cross-review는 Self/Peer 두 SUBAGENT 병렬 dispatch로 수행할 것 (Claude Code host) [ADR-0033]
 ✓ peer 폴백 체인은 자기 호스트를 제외한 풀에서 우선순위대로 시도하고 모든 sentinel(NOT_FOUND/TIMEOUT/ERROR)에서 다음 peer로 이동할 것 [ADR-0033]
-✓ Self SUBAGENT 선택은 실행 시 AskUserQuestion으로 동적 노출하고 review-capable agent(description에 review/code/audit 키워드)를 필터링할 것 [ADR-0033]
 ✓ Auto-fix는 severity-gated hybrid(high/critical=union, medium/low=intersection)로 적용할 것 [ADR-0033]
+✓ Self-Review SUBAGENT는 언어별 스킬 대신 pr-review-toolkit:code-reviewer (opus)를 단독 사용할 것 [ADR-0036]
+✓ Self-Review SUBAGENT prompt에 gh pr diff 결과를 직접 주입할 것 (checkout 불필요) [ADR-0036]

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
 | [guideline](./plugins/guideline) | v0.2.1 | 소프트웨어 엔지니어링 가이드라인 및 코딩 원칙 — RESTful API 가이드라인, Andrej Karpathy의 11가지 코딩 행동 지침, Honest Judgment 안티-sycophancy 리뷰 규칙 포함 |
 | [workflow](./plugins/workflow) | v0.1.1 | 오케스트레이션된 개발 프로세스 워크플로우 스킬 — 고강도 개발 기율 강제를 위한 init, idea, feature, develop, planning 스킬 포함 |
 | [docs](./plugins/docs) | v0.0.7 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
-| [git](./plugins/git) | v0.1.0 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
+| [git](./plugins/git) | v0.2.0 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰, squash merge, 이슈 생성, PR 전체 흐름, worktree 정리 |
 | [llm](./plugins/llm) | v0.3.0 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |
 | [dev](./plugins/dev) | v0.0.4 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 | [context](./plugins/context) | v0.5.0 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [guideline](./plugins/guideline) | v0.2.1 | Software engineering guidelines and coding principles — including RESTful API guidelines, Andrej Karpathy's 11 coding principles, and the Honest Judgment anti-sycophancy review rule |
 | [workflow](./plugins/workflow) | v0.1.1 | Orchestrated developer workflow skills — including init, idea, feature, develop, and planning for rigorous software engineering |
 | [docs](./plugins/docs) | v0.0.7 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
-| [git](./plugins/git) | v0.1.0 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
+| [git](./plugins/git) | v0.2.0 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup |
 | [llm](./plugins/llm) | v0.3.0 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |
 | [dev](./plugins/dev) | v0.0.4 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 | [context](./plugins/context) | v0.5.0 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |

--- a/docs/decisions/0036-git-review-self-reviewer-migration.md
+++ b/docs/decisions/0036-git-review-self-reviewer-migration.md
@@ -1,0 +1,68 @@
+# git:review Self-Review agent를 pr-review-toolkit:code-reviewer로 교체
+
+* Status: accepted
+* Date: 2026-05-28
+* Decision Makers: ppzxc
+* Consulted: —
+* Informed: —
+
+## Context and Problem Statement
+
+`git:review` Self-Review SUBAGENT(ADR-0033)는 언어별 스킬(java:reviewer/golang:reviewer/java:spring)을 Skill 툴로 호출하여 리뷰를 수행했다. 이 구조는 언어 매핑 유지 비용이 높고, 미매핑 언어는 general criteria로 silently 강등된다. 또한 Step 4a의 동적 agent 선택(AskUserQuestion)이 UX 단계를 추가했다. `pr-review-toolkit:code-reviewer`(opus)는 CLAUDE.md 컴플라이언스 + 버그 감지를 단일 agent로 처리하며, confidence 스코어링(≥80만 리포트)으로 노이즈를 자체 필터링한다.
+
+## Decision Drivers
+
+* 언어별 스킬 유지 비용 제거
+* Step 4a 동적 선택 제거 → UX 단순화
+* opus model 고정으로 Self-Review 품질 유지
+* CLAUDE.md 컴플라이언스 자동 포함
+* git:clean / git:review standalone 두 컨텍스트 모두 동작
+
+## Considered Options
+
+* (i) 언어별 스킬 유지 + 추가 언어 매핑 확장
+* **(ii) pr-review-toolkit:code-reviewer 단독 사용** ← 선택
+
+## Decision Outcome
+
+Chosen option: "(ii) pr-review-toolkit:code-reviewer 단독 사용", because 언어별 스킬 유지 비용을 제거하고, opus model + confidence 필터(≥80)로 Self-Review 품질을 유지할 수 있으며, SUBAGENT prompt에 `gh pr diff <PR_NUMBER>` 결과를 직접 주입하여 diff 소스 문제를 해결한다.
+
+### Consequences
+
+* Good, because 언어별 스킬(java:reviewer/golang:reviewer/java:spring) 제거 → maintenance 포인트 감소
+* Good, because Step 4a(동적 agent 선택 AskUserQuestion) 제거 → UX 단순화
+* Good, because code-reviewer가 CLAUDE.md 컴플라이언스를 자동 포함
+* Good, because confidence ≥80 자체 필터로 노이즈 감소
+* Good, because `gh pr diff <PR_NUMBER>` 주입으로 git:clean / standalone 모두 동작
+* Bad, because 언어별 specialized ruleset(Java/Go peer ruleset) 수준의 도메인 특화 리뷰는 Self에서 불가 (Peer에서 계속 적용)
+
+### Confirmation
+
+- `plugins/git/skills/review/SKILL.md` Step 4a 제거, Step 5a에 code-reviewer dispatch 포함
+- `.claude/rules/git-rules.md`에 [ADR-0036] 태그 규칙 2개 추가
+- 버전 v0.1.0 → v0.2.0 범프 3곳 동기화
+
+## Pros and Cons of the Options
+
+### (i) 언어별 스킬 유지 + 언어 매핑 확장
+
+* Good, because 언어별 specialized 리뷰 유지
+* Bad, because 언어 매핑 테이블 지속 관리 필요
+* Bad, because 미매핑 언어 silently 강등
+* Bad, because Step 4a UX 단계 유지
+
+### (ii) pr-review-toolkit:code-reviewer 단독 사용 (선택)
+
+* Good, because 단일 agent로 언어 무관 리뷰
+* Good, because opus model + confidence 필터
+* Good, because 유지 비용 없음
+* Bad, because Java/Go 언어별 critical 룰셋은 Peer에서만 적용
+
+## More Information
+
+- ADR-0033: `0033-git-review-parallel-subagent-cross-review.md` (보강, supersede 아님)
+- `pr-review-toolkit:code-reviewer` agent: `model: opus`, confidence 0-100 스코어링, ≥80만 리포트
+- confidence → severity 매핑: 90-100 → critical, 80-89 → high (모두 union merge)
+- diff 소스: `gh pr diff <PR_NUMBER>` → SUBAGENT prompt 직접 주입
+- `plugins/git/skills/review/SKILL.md` — 강제 구현
+- `.claude/rules/git-rules.md` — 강제 규칙

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -38,6 +38,7 @@
 | [ADR-0033](0033-git-review-parallel-subagent-cross-review.md) | accepted | `git:review` 병렬 SUBAGENT 크로스 리뷰 — Self/Peer SUBAGENT 병렬 dispatch, 호스트별 폴백 체인, severity-gated 머지 |
 | [ADR-0034](0034-llm-plugin-4way-and-context-map-deprecation.md) | accepted | llm 플러그인 4-way 폴백 체인 확장 + context-map 전면 폐기 (ADR-0021/0022/0023 부분 supersede) |
 | [ADR-0035](0035-deprecate-git-clean-peer-crosscheck.md) | accepted | `git:clean` entry peer crosscheck 폐지 — post-work pipeline 본질 재확인, ADR-0023 full supersede |
+| [ADR-0036](0036-git-review-self-reviewer-migration.md) | accepted | `git:review` Self-Review agent를 pr-review-toolkit:code-reviewer로 교체 (언어별 스킬 제거, Step 4a 제거) |
 
 ## 새 ADR 추가
 

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/skills/review/SKILL.md
+++ b/plugins/git/skills/review/SKILL.md
@@ -46,19 +46,7 @@ Step 2에서 가져온 `files` 필드 사용 (추가 API 호출 불필요).
 
 고유 언어 집합 수집. Spring 감지 여부 확인: diff에 `@RestController`, `@Service`, `@Component`, `@Repository`, `@Controller`, `@Configuration`, 또는 `import org.springframework.` 포함 여부.
 
-### 4. Prepare Review Context
-
-#### 4a. Select Self-Review Agent (Claude Code host only)
-
-시스템 agent 목록에서 review-capable agent 필터링:
-- description에 "review", "code", "audit" 키워드 포함 agent
-- 최대 4개 후보 AskUserQuestion으로 노출
-
-후보 0개면 `general-purpose` + `model=opus` 강제.
-
-Gemini/agy/Codex host: 이 단계 skip.
-
-#### 4b. Build Peer Ruleset
+### 4. Build Peer Ruleset
 
 감지된 언어에 따라 peer prompt에 임베드할 ruleset 결정 (`peer-review-cli.md` Language Rulesets 섹션 참조):
 
@@ -82,25 +70,18 @@ gh pr diff <PR_NUMBER>
 
 **5a. Self-Review SUBAGENT**
 
-Agent 툴로 Step 4a에서 선택한 agent 타입 dispatch (model=opus).
+Agent 툴로 `pr-review-toolkit:code-reviewer` dispatch.
 
 Prompt:
 
 ```
-You are reviewing a GitHub PR. Analyze the diff and return all findings.
+You are reviewing a GitHub PR as a self-reviewer.
 
-Detected languages: {LANGUAGES}
-Spring detected: {yes|no}
+Review the following diff thoroughly for bugs, security issues, and CLAUDE.md compliance.
 
-Instructions for language-specific review:
-- .java files: invoke `java:reviewer` skill via Skill tool.
-  If Spring detected: also invoke `java:spring` skill via Skill tool.
-- .go files: invoke `golang:reviewer` skill via Skill tool.
-- Other languages: apply general review criteria.
+Output MUST follow subagent-output-schema exactly:
 
-Output schema — MUST follow exactly (see subagent-output-schema.md):
-
-reviewer: claude-opus
+reviewer: pr-review-toolkit:code-reviewer
 
 | severity | file:line | category | issue |
 | --- | --- | --- | --- |
@@ -111,8 +92,13 @@ Immediately after each row, add:
 + fixed line
 ```
 
+Confidence → severity mapping:
+- confidence 90-100 → severity: critical
+- confidence 80-89 → severity: high
+- below 80: do not report
+
 severity: critical=security/data-loss, high=bug/runtime-error, medium=logic-issue, low=style/naming
-If no issues: write "reviewer: claude-opus\n\nNo issues found."
+If no issues: write "reviewer: pr-review-toolkit:code-reviewer\n\nNo issues found."
 
 --- DIFF START ---
 {PR_DIFF}
@@ -140,7 +126,7 @@ Follow peer-review-cli.md exactly:
 Ruleset and diff for embedding in CLI prompt:
 
 <RULESET>
-{RULESET from Step 4b}
+{RULESET from Step 4}
 </RULESET>
 
 <DIFF>
@@ -205,10 +191,10 @@ finding 없으면 skip.
 
 ```bash
 # fix 적용 + peer available:
-gh pr review <PR_NUMBER> --comment --body "Cross-reviewed (<self-agent> + <peer: agy|gemini|codex>). <N> issue(s) found and fixed. (critical:<c> high:<h> medium:<m> low:<l>)"
+gh pr review <PR_NUMBER> --comment --body "Cross-reviewed (code-reviewer + <peer: agy|gemini|codex>). <N> issue(s) found and fixed. (critical:<c> high:<h> medium:<m> low:<l>)"
 
 # fix 적용 + peer unavailable:
-gh pr review <PR_NUMBER> --comment --body "Auto-reviewed (self-only: <self-agent>). <N> issue(s) found and fixed."
+gh pr review <PR_NUMBER> --comment --body "Auto-reviewed (self-only: code-reviewer). <N> issue(s) found and fixed."
 
 # fix 없음:
 gh pr review <PR_NUMBER> --comment --body "Auto-reviewed. No issues found."
@@ -224,7 +210,6 @@ gh pr review <PR_NUMBER> --comment --body "Auto-reviewed. No issues found."
 | PR already merged/closed | Abort, display current state |
 | CI failing | Include CI failure details in review |
 | Empty diff | Display "No changes found" and abort |
-| No reviewer skill found | Use general review criteria |
 | Peer reviewer unavailable | Proceed with self-only, notify user |
 | Self SUBAGENT failed | Proceed with peer findings only, notify user |
 | Both failed | Abort, display error |


### PR DESCRIPTION
## Summary
- `git:review` Self-Review SUBAGENT를 언어별 스킬에서 `pr-review-toolkit:code-reviewer` (opus)로 교체
- Step 4a (동적 agent 선택 AskUserQuestion) 제거
- ADR-0036 추가, git-rules.md 동기화, 버전 v0.2.0 범프

## Motivation
언어별 스킬(java:reviewer/golang:reviewer/java:spring) 유지 비용 제거. code-reviewer는 confidence ≥80 자체 필터로 노이즈를 줄이고, CLAUDE.md 컴플라이언스를 자동 포함한다. `gh pr diff` 직접 주입으로 git:clean/standalone 두 컨텍스트 모두 정상 동작.

## Changes
- `SKILL.md`: Step 4a 제거, Step 5a → code-reviewer dispatch (confidence→severity 매핑 포함)
- `git-rules.md`: ADR-0036 규칙 2개 추가, 구 AskUserQuestion 규칙 제거
- `docs/decisions/0036-*.md`: ADR 신규 생성
- 버전 4곳 v0.1.0 → v0.2.0

## Test plan
- [ ] SKILL.md Step 4a 제거 확인
- [ ] Step 5a code-reviewer dispatch 확인
- [ ] git-rules.md ADR-0036 규칙 확인
- [ ] 버전 v0.2.0 4곳 동기화 확인

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.