### PR TITLE
fix(context): /resume 라우팅 충돌 해소 — context:resume 활성화 가드 추가 (v0.5.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -51,7 +51,7 @@
       "name": "context",
       "source": "./plugins/context",
       "description": "Dev Docs System skills — self-contained 4-file task folders (spec/plan/tasks/context) for resumable development",
-      "version": "0.5.1"
+      "version": "0.5.2"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## 스킬 라우팅
 
 사용자가 `/context:plan`을 입력하면 다른 행동 이전에 `Skill` 도구로 `context:plan`을 호출할 것.
+사용자가 `/resume`을 정확히 입력하면 Claude Code 내장 명령으로 처리하고 `Skill` 도구를 호출하지 말 것.
 
 ## Claude Code 전용
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -14,7 +14,7 @@
 | [git](./plugins/git) | v0.4.1 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰(fast/balanced/deep tier 선택), union 머지+agreement 태그 자동수정, squash merge, 이슈 생성, Closes #N 이슈 연결, PR 전체 흐름, worktree 정리 |
 | [llm](./plugins/llm) | v0.3.0 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |
 | [dev](./plugins/dev) | v0.0.4 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
-| [context](./plugins/context) | v0.5.1 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |
+| [context](./plugins/context) | v0.5.2 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |
 
 ## 마켓플레이스 등록
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [git](./plugins/git) | v0.4.1 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
 | [llm](./plugins/llm) | v0.3.0 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |
 | [dev](./plugins/dev) | v0.0.4 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
-| [context](./plugins/context) | v0.5.1 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |
+| [context](./plugins/context) | v0.5.2 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |
 
 ## Marketplace Registration
 

--- a/plugins/context/.claude-plugin/plugin.json
+++ b/plugins/context/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Dev Docs System skills — self-contained 4-file task folders (spec/plan/tasks/context) for resumable, context-preserving development across sessions",
   "author": {
     "name": "ppzxc",

--- a/plugins/context/skills/resume/SKILL.md
+++ b/plugins/context/skills/resume/SKILL.md
@@ -6,6 +6,11 @@ user-invocable: true
 
 # Context Resume — 세션 재개
 
+<ACTIVATION>
+ONLY activate for: `/context:resume`, "컨텍스트 재개", "이어서", "어디까지 했지"
+Do NOT activate for: `/resume` — Claude Code built-in command, pass through
+</ACTIVATION>
+
 세션 단절 후 `docs/context/{TASK_NAME}/`의 4파일을 읽어 작업을 정확히 재개한다.
 
 ---


### PR DESCRIPTION
## Summary
- `/resume` (Claude Code 내장 명령)와 `context:resume` 스킬 간 라우팅 충돌 해소
- `context:resume` SKILL.md에 `<ACTIVATION>` 가드 추가
- CLAUDE.md 스킬 라우팅 섹션에 `/resume` 예외 규칙 추가

## Motivation
사용자가 `/resume`을 입력하면 `using-superpowers`의 "1% chance" 규칙으로 인해 모델이 `context:resume` 스킬을 호출하는 버그 수정. Claude Code 내장 `/resume`과 플러그인 스킬의 명확한 경계 설정 필요.

## Changes
- `plugins/context/skills/resume/SKILL.md`: `<ACTIVATION>` 블록 추가 — 정확한 트리거 명시 및 `/resume` 패스스루 명시
- `CLAUDE.md`: 스킬 라우팅 섹션에 `/resume` → Claude Code 내장 처리 규칙 1줄 추가
- `plugins/context/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `README.md`, `README.ko.md`: v0.5.1 → v0.5.2 버전 범프

## Test plan
- [ ] `/resume` 입력 시 Claude Code 내장 명령으로 처리됨 (Skill 도구 미호출)
- [ ] `/context:resume` 입력 시 정상적으로 context:resume 스킬 호출됨