### PR TITLE
refactor(git,llm): peer-cli 공통 인프라 _shared/peer-fallback-core 추출 (ADR-0046)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,13 +33,13 @@
       "name": "git",
       "source": "./plugins/git",
       "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
-      "version": "0.4.1"
+      "version": "0.5.0"
     },
     {
       "name": "llm",
       "source": "./plugins/llm",
       "description": "LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain",
-      "version": "0.3.0"
+      "version": "0.4.0"
     },
     {
       "name": "dev",

--- a/.claude/rules/git-rules.md
+++ b/.claude/rules/git-rules.md
@@ -17,3 +17,4 @@ git 플러그인 스킬을 사용하거나 수정할 때 반드시 다음 제약
 ✓ tier 플래그는 `--fast` / `--balanced` / `--deep` 세 값만 허용, 기본값 deep. 그 외 입력 시 에러 후 중단. git:clean에서 tier는 Step 3 review에만 forward [ADR-0039]
 ✓ 5b Peer CLI 모델 매핑은 `peer-review-cli.md` "Tier × CLI 모델 매핑" 표에 중앙집중 관리. 모델명 변경 시 표 1곳만 수정 [ADR-0039]
 ✓ PR 본문에 세션이 처리한 이슈를 `Closes #N`으로 연결하되, 탐지 결과는 PR confirm 게이트에서 사용자 승인 후에만 삽입할 것 [ADR-0038]
+✓ peer-cli 공통 인프라(pre-flight/host-matrix/호출골격/sentinel)는 `plugins/_shared/references/peer-fallback-core.md`를 SOT로 사용할 것 [ADR-0046]

--- a/.claude/rules/llm-rules.md
+++ b/.claude/rules/llm-rules.md
@@ -8,3 +8,4 @@
 ✓ wrapper 우선순위는 MCP/스킬/SubAgent 1순위 → stdin CLI fallback 2순위 [ADR-0034]
 ✓ self+peer 병렬 SUBAGENT dispatch 수행 (ADR-0033 패턴 차용) [ADR-0034]
 ✓ 입력 분류 4종(plan/spec/idea/diff). diff 입력은 git:review로 redirect [ADR-0034]
+✓ peer-cli 공통 인프라(pre-flight/host-matrix/호출골격/sentinel)는 `plugins/_shared/references/peer-fallback-core.md`를 SOT로 사용할 것 [ADR-0046]

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,8 +11,8 @@
 | [guideline](./plugins/guideline) | v0.3.0 | 소프트웨어 엔지니어링 가이드라인 및 코딩 원칙 — RESTful API 가이드라인, Andrej Karpathy의 11가지 코딩 행동 지침, Honest Judgment 안티-sycophancy 리뷰 규칙 포함 |
 | [workflow](./plugins/workflow) | v0.1.1 | 오케스트레이션된 개발 프로세스 워크플로우 스킬 — 고강도 개발 기율 강제를 위한 init, idea, feature, develop, planning 스킬 포함 |
 | [docs](./plugins/docs) | v0.0.8 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
-| [git](./plugins/git) | v0.4.1 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰(fast/balanced/deep tier 선택), union 머지+agreement 태그 자동수정, squash merge, 이슈 생성, Closes #N 이슈 연결, PR 전체 흐름, worktree 정리 |
-| [llm](./plugins/llm) | v0.3.0 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |
+| [git](./plugins/git) | v0.5.0 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰(fast/balanced/deep tier 선택), union 머지+agreement 태그 자동수정, squash merge, 이슈 생성, Closes #N 이슈 연결, PR 전체 흐름, worktree 정리 |
+| [llm](./plugins/llm) | v0.4.0 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |
 | [dev](./plugins/dev) | v0.1.0 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 | [context](./plugins/context) | v0.9.0 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [guideline](./plugins/guideline) | v0.3.0 | Software engineering guidelines and coding principles — including RESTful API guidelines, Andrej Karpathy's 11 coding principles, and the Honest Judgment anti-sycophancy review rule |
 | [workflow](./plugins/workflow) | v0.1.1 | Orchestrated developer workflow skills — including init, idea, feature, develop, and planning for rigorous software engineering |
 | [docs](./plugins/docs) | v0.0.8 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
-| [git](./plugins/git) | v0.4.1 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
-| [llm](./plugins/llm) | v0.3.0 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |
+| [git](./plugins/git) | v0.5.0 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
+| [llm](./plugins/llm) | v0.4.0 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |
 | [dev](./plugins/dev) | v0.1.0 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 | [context](./plugins/context) | v0.9.0 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |
 

--- a/docs/adr/0046-shared-peer-fallback-core.md
+++ b/docs/adr/0046-shared-peer-fallback-core.md
@@ -1,0 +1,66 @@
+# Peer-CLI 공통 인프라를 _shared/references/peer-fallback-core.md로 추출
+
+* Status: accepted
+* Date: 2026-06-02
+* Decision Makers: ppzxc
+
+## Context and Problem Statement
+
+`plugins/git/skills/review/references/peer-review-cli.md`(311줄)와 `plugins/llm/skills/auto/references/peer-cli.md`(191줄)에 동일한 인프라 블록이 중복된다: pre-flight `timeout 3 <cli> --version`, host fallback matrix 패턴, CLI 호출 헤더(stdin pipe/injection 방지), mktemp+trap+timeout 호출 골격, sentinel 처리 표. 두 파일을 독립적으로 수정하면 불일치(sentinel 문법 차이 등)가 발생한다.
+
+## Decision Drivers
+
+* DRY — 공통 인프라 변경 시 1곳만 수정
+* sentinel 문법 불일치 해소 (AGY_NOT_FOUND: vs CLI_NOT_FOUND: 혼용)
+* 신규 CLI 추가 시 단일 파일만 갱신
+
+## Considered Options
+
+* **추출**: `plugins/_shared/references/peer-fallback-core.md` 신규, 두 peer-cli 파일에서 공통 블록 제거 후 참조
+* **인라인 유지**: 두 파일에 중복 그대로 유지
+* **단순 주석**: 참조 주석만 추가, 실제 블록은 그대로 유지
+
+## Decision Outcome
+
+Chosen option: "추출", because 공통 블록을 1곳으로 통합하면 sentinel 문법 표준화와 향후 CLI 추가/변경이 단일 파일 수정으로 완결된다.
+
+### Consequences
+
+* Good, because pre-flight / sentinel 카탈로그를 1곳에서 관리
+* Good, because sentinel 통합 prefix `CLI_NOT_FOUND:<cli>` 표준화로 파일 간 불일치 제거
+* Bad, because peer-cli 파일을 읽을 때 peer-fallback-core.md도 함께 참조해야 함
+
+### Confirmation
+
+```bash
+ls plugins/_shared/references/peer-fallback-core.md
+grep -c 'CLI_NOT_FOUND:agy' plugins/git/skills/review/references/peer-review-cli.md   # ≥0 (old AGY_NOT_FOUND 미존재)
+grep -c 'AGY_NOT_FOUND'     plugins/git/skills/review/references/peer-review-cli.md   # 0
+grep -c 'AGY_NOT_FOUND'     plugins/llm/skills/auto/references/peer-cli.md            # 0
+```
+
+## Pros and Cons of the Options
+
+### 추출
+
+* Good, because 단일 SOT — 변경 파급 최소화
+* Good, because sentinel 문법 표준화 강제 가능
+* Bad, because 파일 참조 깊이 1단계 증가
+
+### 인라인 유지
+
+* Good, because 각 파일 자체 완결
+* Bad, because 불일치 재발 방지 불가 (sentinel 문법 등)
+* Bad, because CLI 추가 시 N개 파일 동시 수정 필요
+
+### 단순 주석
+
+* Neutral, because 읽기 편의 개선
+* Bad, because 실제 중복 제거 안 됨, 불일치 재발 위험 동일
+
+## More Information
+
+* [ADR-0022](0022-bidirectional-peer-cross-review.md) — 자기 호스트 제외 규칙
+* [ADR-0034](0034-llm-plugin-4way-and-context-map-deprecation.md) — llm 4-way 폴백 체인
+* `.claude/rules/git-rules.md` — `[ADR-0046]` 태그
+* `.claude/rules/llm-rules.md` — `[ADR-0046]` 태그

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,6 +48,7 @@
 | [ADR-0043](0043-context-plan-input-maturity-routing.md) | accepted | context:plan 입력 성숙도 분류 — 4-way 분류(idea/spec/plan/diff) + idea 브랜치 brainstorm→grill 정순 복원, ADR-0030 부분 supersede |
 | [ADR-0044](0044-context-recall-rename.md) | accepted | context:resume → context:recall 리네임 — 토큰 레벨 /resume suffix-match 제거, ADR-0042 supersede |
 | [ADR-0045](0045-skill-no-arg-inference-confirm-gate.md) | accepted | 스킬 no-arg 유추 시 실행 전 확인 게이트 도입 — interactive 세션에서 유추 결과 제시 후 AskUserQuestion 확인 (context:recall/update, dev:tidy, guideline:restful-api 적용) |
+| [ADR-0046](0046-shared-peer-fallback-core.md) | accepted | Peer-CLI 공통 인프라를 `_shared/references/peer-fallback-core.md`로 추출 — pre-flight/host-matrix/호출골격/sentinel 단일 SOT, CLI_NOT_FOUND:<cli> 통합 prefix |
 
 ## 새 ADR 추가
 

--- a/plugins/_shared/references/peer-fallback-core.md
+++ b/plugins/_shared/references/peer-fallback-core.md
@@ -1,0 +1,127 @@
+# Peer Fallback Core — 공유 인프라
+
+`peer-review-cli.md`와 `peer-cli.md`의 공통 CLI 인프라 SOT. [ADR-0046](../../../docs/adr/0046-shared-peer-fallback-core.md)
+
+---
+
+## Host Fallback Matrix
+
+| Self host | Peer 우선순위 |
+|-----------|---------------|
+| Claude Code | agy → gemini → codex |
+| Gemini CLI | claude → agy → codex |
+| Antigravity (agy) | claude → gemini → codex |
+| Codex | claude → agy → gemini |
+
+자기 자신은 풀에서 제외 (ADR-0022/0023). 전부 실패 시 self-only fallback, 사용자에게 알림.
+
+---
+
+## Pre-flight 확인
+
+CLI 시도 전 반드시 version 확인:
+
+```bash
+timeout 3 agy --version    2>/dev/null || echo "CLI_NOT_FOUND:agy"
+timeout 3 gemini --version 2>/dev/null || echo "CLI_NOT_FOUND:gemini"
+timeout 3 codex --version  2>/dev/null || echo "CLI_NOT_FOUND:codex"
+timeout 3 claude --version 2>/dev/null || echo "CLI_NOT_FOUND:claude"
+```
+
+exit ≠ 0이면 해당 sentinel 발동 → 다음 CLI로 skip. 확인된 CLI만 시도.
+
+---
+
+## CLI 호출 헤더
+
+입력은 반드시 stdin pipe 또는 임시파일로 전달. CLI 인자 직접 보간 금지 (shell injection / ARG_MAX 초과 방지).
+
+---
+
+## CLI 호출 골격
+
+각 CLI 공통 패턴. `<PROMPT_CONTENT>`는 호출처 파일의 domain-specific 프롬프트로 대체.
+
+### AGY
+
+```bash
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+cat > "$TMPFILE" << 'EOF'
+<PROMPT_CONTENT>
+EOF
+
+printf '\n<CONTENT_DELIMITER_START>\n%s\n<CONTENT_DELIMITER_END>\n' "$CONTENT" >> "$TMPFILE"
+
+timeout 330 agy -p "$(cat "$TMPFILE")" --print-timeout 300s
+```
+
+### Gemini
+
+```bash
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+cat > "$TMPFILE" << 'EOF'
+<PROMPT_CONTENT>
+EOF
+
+printf '\n<CONTENT_DELIMITER_START>\n%s\n<CONTENT_DELIMITER_END>\n' "$CONTENT" >> "$TMPFILE"
+
+printf '%s' "$(cat "$TMPFILE")" | timeout 300 gemini -p "MODE — see stdin"
+```
+
+### Codex
+
+```bash
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+cat > "$TMPFILE" << 'EOF'
+<PROMPT_CONTENT>
+EOF
+
+printf '\n<CONTENT_DELIMITER_START>\n%s\n<CONTENT_DELIMITER_END>\n' "$CONTENT" >> "$TMPFILE"
+
+cat "$TMPFILE" | timeout 300 codex exec -
+```
+
+### Claude CLI (비-Claude 호스트용)
+
+```bash
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+cat > "$TMPFILE" << 'EOF'
+<PROMPT_CONTENT>
+EOF
+
+printf '\n<CONTENT_DELIMITER_START>\n%s\n<CONTENT_DELIMITER_END>\n' "$CONTENT" >> "$TMPFILE"
+
+printf '%s' "$(cat "$TMPFILE")" | timeout 300 claude -p "MODE — see stdin"
+```
+
+---
+
+## Sentinel 카탈로그
+
+모든 sentinel → 다음 peer로 시도. 동일 인자 재호출 금지.
+
+통합 prefix 형식: `CLI_NOT_FOUND:<cli>` / `CLI_TIMEOUT:<cli>` / `CLI_ERROR:<cli>(exit=N)`
+
+| Sentinel | 의미 | 처리 |
+|----------|------|------|
+| `CLI_NOT_FOUND:agy` | agy 부재 | 다음 peer |
+| `CLI_TIMEOUT:agy` | 300s 초과 | 다음 peer |
+| `CLI_ERROR:agy(exit=N)` | 비정상 종료 | 다음 peer |
+| `CLI_NOT_FOUND:gemini` | gemini 부재 | 다음 peer |
+| `CLI_TIMEOUT:gemini` | 300s 초과 | 다음 peer |
+| `CLI_ERROR:gemini(exit=N)` | 비정상 종료 | 다음 peer |
+| `CLI_NOT_FOUND:codex` | codex 부재 | 다음 peer |
+| `CLI_TIMEOUT:codex` | 300s 초과 | 다음 peer |
+| `CLI_ERROR:codex(exit=N)` | 비정상 종료 | 다음 peer |
+| `CLI_NOT_FOUND:claude` | claude CLI 부재 | 다음 peer |
+| `CLI_TIMEOUT:claude` | 300s 초과 | 다음 peer |
+| `CLI_ERROR:claude(exit=N)` | 비정상 종료 | 다음 peer |
+| (모두 실패) | — | self-only fallback, user notify |

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/plugin.json
+++ b/plugins/git/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git",
-  "version": "0.0.16",
-  "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check, squash merge, issue creation, full PR lifecycle orchestration, and worktree cleanup",
+  "version": "0.5.0",
+  "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",
     "email": "cjh8487@naver.com",

--- a/plugins/git/skills/review/references/peer-review-cli.md
+++ b/plugins/git/skills/review/references/peer-review-cli.md
@@ -3,7 +3,7 @@
 git:review Step 5b (Peer-Review Coordinator SUBAGENT)에서 참조한다.
 `context:plan/references/verification.md`의 CLI 패턴을 코드 리뷰용으로 fork.
 
-공통 인프라(host matrix, pre-flight, 호출 골격, sentinel): → [`peer-fallback-core.md`](../../../../../_shared/references/peer-fallback-core.md)
+공통 인프라(host matrix, pre-flight, 호출 골격, sentinel): → [`peer-fallback-core.md`](../../../../_shared/references/peer-fallback-core.md)
 
 ---
 
@@ -161,7 +161,7 @@ Low:
 
 ## CLI 호출 패턴
 
-→ 호출 골격(mktemp+trap+timeout, sentinel 처리): [`peer-fallback-core.md`](../../../../../_shared/references/peer-fallback-core.md#cli-호출-골격)
+→ 호출 골격(mktemp+trap+timeout, sentinel 처리): [`peer-fallback-core.md`](../../../../_shared/references/peer-fallback-core.md#cli-호출-골격)
 
 각 CLI 호출 시 Review Prompt를 tmpfile에 작성 후 `{RULESET_BLOCK}`과 `{DIFF_CONTENT}`를 주입하여 실행.
 tier별 모델 플래그는 위 Tier × CLI 모델 매핑 표에서 선택.

--- a/plugins/git/skills/review/references/peer-review-cli.md
+++ b/plugins/git/skills/review/references/peer-review-cli.md
@@ -3,6 +3,8 @@
 git:review Step 5b (Peer-Review Coordinator SUBAGENT)에서 참조한다.
 `context:plan/references/verification.md`의 CLI 패턴을 코드 리뷰용으로 fork.
 
+공통 인프라(host matrix, pre-flight, 호출 골격, sentinel): → [`peer-fallback-core.md`](../../../../../_shared/references/peer-fallback-core.md)
+
 ---
 
 ## Tier × CLI 모델 매핑
@@ -30,34 +32,6 @@ git:review Step 5b (Peer-Review Coordinator SUBAGENT)에서 참조한다.
 **매핑 미확인 CLI**: 기본값 사용 + provenance에 `<cli>-default` 기록.
 
 CLI 호출 시 위 플래그를 해당 CLI 호출 패턴에 삽입한다.
-
----
-
-## Host Fallback Matrix
-
-| Self host | Peer 우선순위 |
-|-----------|---------------|
-| Claude Code | agy → gemini → codex |
-| Gemini CLI | claude → agy → codex |
-| Antigravity (agy) | claude → gemini → codex |
-| Codex | claude → agy → gemini |
-
-자기 자신은 풀에서 제외 (ADR-0022/0023). 전부 실패 시 `reviewer: claude-self-generate\n\nNo issues found.` 반환 후 notify user.
-
----
-
-## Pre-flight 순서
-
-CLI 시도 전 반드시 version 확인:
-
-```bash
-timeout 3 agy --version    2>/dev/null || echo "AGY_NOT_FOUND:"
-timeout 3 gemini --version 2>/dev/null || echo "CLI_NOT_FOUND:gemini"
-timeout 3 codex --version  2>/dev/null || echo "CLI_NOT_FOUND:codex"
-timeout 3 claude --version 2>/dev/null || echo "CLAUDE_CLI_NOT_FOUND:"
-```
-
-exit ≠ 0이면 해당 sentinel 발동 → 다음 CLI로 skip. 확인된 CLI만 시도.
 
 ---
 
@@ -187,117 +161,10 @@ Low:
 
 ## CLI 호출 패턴
 
-입력은 반드시 stdin pipe 또는 임시파일로 전달. CLI 인자 직접 보간 금지 (shell injection / ARG_MAX 초과 방지).
+→ 호출 골격(mktemp+trap+timeout, sentinel 처리): [`peer-fallback-core.md`](../../../../../_shared/references/peer-fallback-core.md#cli-호출-골격)
 
-### AGY
-
-```bash
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
-# Write prompt to tmpfile (heredoc + diff append)
-cat > "$TMPFILE" << 'REVIEWEOF'
-You are an adversarial code reviewer. The diff below was written by a different model.
-Your mission: identify ALL defects — bugs, security issues, logic errors, style violations.
-
-Output format (STRICT):
-
-reviewer: agy
-
-| severity | file:line | category | issue |
-| --- | --- | --- | --- |
-
-Immediately after each row, add a fix block:
-```diff
-- old line
-+ fixed line
-```
-
-severity: critical=security/data-loss, high=bug/runtime-error, medium=logic-issue, low=style/naming
-
-If no issues found: output exactly:
-reviewer: agy
-
-No issues found.
-
-REVIEWEOF
-
-# Append ruleset + diff
-printf '<RULESET>\n%s\n</RULESET>\n\n--- DIFF START ---\n%s\n--- DIFF END ---\n' \
-  "$RULESET_CONTENT" "$DIFF_CONTENT" >> "$TMPFILE"
-
-timeout 330 agy -p "$(cat "$TMPFILE")" --print-timeout 300s
-```
-
-### Gemini
-
-```bash
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
-cat > "$TMPFILE" << 'REVIEWEOF'
-[동일 프롬프트, reviewer: gemini]
-REVIEWEOF
-
-printf '<RULESET>\n%s\n</RULESET>\n\n--- DIFF START ---\n%s\n--- DIFF END ---\n' \
-  "$RULESET_CONTENT" "$DIFF_CONTENT" >> "$TMPFILE"
-
-printf '%s' "$(cat "$TMPFILE")" | timeout 300 gemini -p "CODE REVIEW MODE — see stdin"
-```
-
-### Codex
-
-```bash
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
-cat > "$TMPFILE" << 'REVIEWEOF'
-[동일 프롬프트, reviewer: codex]
-REVIEWEOF
-
-printf '<RULESET>\n%s\n</RULESET>\n\n--- DIFF START ---\n%s\n--- DIFF END ---\n' \
-  "$RULESET_CONTENT" "$DIFF_CONTENT" >> "$TMPFILE"
-
-cat "$TMPFILE" | timeout 300 codex exec -
-```
-
-### Claude CLI (비-Claude 호스트용)
-
-```bash
-# Pre-flight
-timeout 3 claude --version || { echo "CLAUDE_CLI_NOT_FOUND:"; exit 1; }
-
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
-cat > "$TMPFILE" << 'REVIEWEOF'
-[동일 프롬프트, reviewer: claude]
-REVIEWEOF
-
-printf '<RULESET>\n%s\n</RULESET>\n\n--- DIFF START ---\n%s\n--- DIFF END ---\n' \
-  "$RULESET_CONTENT" "$DIFF_CONTENT" >> "$TMPFILE"
-
-printf '%s' "$(cat "$TMPFILE")" | timeout 300 claude -p "CODE REVIEW MODE — see stdin"
-```
-
----
-
-## Sentinel 처리
-
-모든 sentinel → 다음 peer로 시도. 동일 인자 재호출 금지.
-
-| Sentinel prefix | 의미 | 처리 |
-|----------------|------|------|
-| `AGY_NOT_FOUND:` | agy 부재 | 다음 peer |
-| `AGY_TIMEOUT:` | 300s 초과 | 다음 peer |
-| `AGY_ERROR(exit=N):` | 비정상 종료 | 다음 peer |
-| `CLI_NOT_FOUND:` | gemini/codex 부재 | 다음 peer |
-| `CLI_TIMEOUT:` | 300s 초과 | 다음 peer |
-| `CLI_ERROR(exit=N):` | 비정상 종료 | 다음 peer |
-| `CLAUDE_CLI_NOT_FOUND:` | claude CLI 부재 | 다음 peer |
-| `CLAUDE_CLI_TIMEOUT:` | claude CLI 300s 초과 | 다음 peer |
-| `CLAUDE_CLI_ERROR(exit=N):` | claude CLI 비정상 종료 | 다음 peer |
-| (모두 실패) | — | self-only로 fallback, user notify |
+각 CLI 호출 시 Review Prompt를 tmpfile에 작성 후 `{RULESET_BLOCK}`과 `{DIFF_CONTENT}`를 주입하여 실행.
+tier별 모델 플래그는 위 Tier × CLI 모델 매핑 표에서 선택.
 
 ---
 

--- a/plugins/llm/.claude-plugin/plugin.json
+++ b/plugins/llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain",
   "author": {
     "name": "ppzxc",

--- a/plugins/llm/plugin.json
+++ b/plugins/llm/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain",
   "author": {
     "name": "ppzxc",

--- a/plugins/llm/skills/auto/references/peer-cli.md
+++ b/plugins/llm/skills/auto/references/peer-cli.md
@@ -3,33 +3,9 @@
 `llm:auto` Step 2 (Peer-review Coordinator)에서 참조한다.  
 `plugins/git/skills/review/references/peer-review-cli.md`의 인프라 패턴을 cross-check(plan/spec/idea) 용도로 fork.
 
----
+공통 인프라(host matrix, pre-flight, 호출 골격, sentinel): → [`peer-fallback-core.md`](../../../../_shared/references/peer-fallback-core.md)
 
-## Host Fallback Matrix
-
-| Self host | Peer 우선순위 |
-|-----------|---------------|
-| Claude Code | agy → gemini → codex |
-| Antigravity (agy) | claude → gemini → codex |
-
-자기 자신은 풀에서 제외 (ADR-0022/0023/0034). 전부 실패 시 self-only fallback, 사용자에게 알림.
-
-Self-host = {Claude Code, agy} 2종. Gemini CLI / Codex는 SKILL 실행 환경 미검증 → self-host 행 없음.
-
----
-
-## Pre-flight 순서
-
-CLI 시도 전 반드시 version 확인:
-
-```bash
-timeout 3 agy --version    2>/dev/null || echo "AGY_NOT_FOUND:"
-timeout 3 gemini --version 2>/dev/null || echo "CLI_NOT_FOUND:gemini"
-timeout 3 codex --version  2>/dev/null || echo "CLI_NOT_FOUND:codex"
-timeout 3 claude --version 2>/dev/null || echo "CLAUDE_CLI_NOT_FOUND:"
-```
-
-exit ≠ 0이면 해당 sentinel 발동 → 다음 CLI로 skip. 확인된 CLI만 시도.
+Self-host = {Claude Code, agy} 2종. Gemini CLI / Codex는 SKILL 실행 환경 미검증 → host matrix에서 자기 호스트 행 없음.
 
 ---
 
@@ -77,6 +53,8 @@ No issues found.
 
 ## CLI 호출 패턴
 
+→ 호출 골격(mktemp+trap+timeout, sentinel 처리): [`peer-fallback-core.md`](../../../../_shared/references/peer-fallback-core.md#cli-호출-골격)
+
 입력은 반드시 stdin pipe 또는 임시파일로 전달. CLI 인자 직접 보간 금지 (shell injection / ARG_MAX 초과 방지).
 
 ### AGY (MCP 우선, CLI fallback)
@@ -86,19 +64,7 @@ MCP 가용 시:
 mcp__agy__agy_cross_check(plan=<cross-check 프롬프트 + 입력 전문>)
 ```
 
-CLI fallback:
-```bash
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
-cat > "$TMPFILE" << 'CROSSEOF'
-[cross-check 프롬프트, reviewer: agy]
-CROSSEOF
-
-printf '\n--- CONTENT START ---\n%s\n--- CONTENT END ---\n' "$CONTENT" >> "$TMPFILE"
-
-timeout 330 agy -p "$(cat "$TMPFILE")" --print-timeout 300s
-```
+CLI fallback: peer-fallback-core.md AGY 골격에 Cross-check Prompt + `$CONTENT` 주입.
 
 ### Gemini (SubAgent 우선, CLI fallback)
 
@@ -107,19 +73,7 @@ SubAgent (Claude Code 호스트에서만):
 Agent(subagent_type: "gemini:gemini-rescue", prompt: <프롬프트 전문>)
 ```
 
-CLI fallback:
-```bash
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
-cat > "$TMPFILE" << 'CROSSEOF'
-[cross-check 프롬프트, reviewer: gemini]
-CROSSEOF
-
-printf '\n--- CONTENT START ---\n%s\n--- CONTENT END ---\n' "$CONTENT" >> "$TMPFILE"
-
-printf '%s' "$(cat "$TMPFILE")" | timeout 300 gemini -p "CROSS-CHECK MODE — see stdin"
-```
+CLI fallback: peer-fallback-core.md Gemini 골격에 Cross-check Prompt + `$CONTENT` 주입.
 
 ### Codex (SubAgent 우선, CLI fallback)
 
@@ -128,59 +82,11 @@ SubAgent (Claude Code 호스트에서만):
 Agent(subagent_type: "codex:codex-rescue", prompt: <프롬프트 전문>)
 ```
 
-CLI fallback:
-```bash
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
-cat > "$TMPFILE" << 'CROSSEOF'
-[cross-check 프롬프트, reviewer: codex]
-CROSSEOF
-
-printf '\n--- CONTENT START ---\n%s\n--- CONTENT END ---\n' "$CONTENT" >> "$TMPFILE"
-
-cat "$TMPFILE" | timeout 300 codex exec -
-```
+CLI fallback: peer-fallback-core.md Codex 골격에 Cross-check Prompt + `$CONTENT` 주입.
 
 ### Claude CLI (비-Claude 호스트용)
 
-```bash
-# Pre-flight
-timeout 3 claude --version 2>/dev/null || { echo "CLAUDE_CLI_NOT_FOUND:"; exit 1; }
-
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
-cat > "$TMPFILE" << 'CROSSEOF'
-[cross-check 프롬프트, reviewer: claude]
-CROSSEOF
-
-printf '\n--- CONTENT START ---\n%s\n--- CONTENT END ---\n' "$CONTENT" >> "$TMPFILE"
-
-printf '%s' "$(cat "$TMPFILE")" | timeout 300 claude -p "CROSS-CHECK MODE — see stdin"
-```
-
----
-
-## Sentinel 처리
-
-모든 sentinel → 다음 peer로 시도. 동일 인자 재호출 금지.
-
-| Sentinel prefix | 의미 | 처리 |
-|----------------|------|------|
-| `AGY_NOT_FOUND:` | agy 부재 | 다음 peer |
-| `AGY_TIMEOUT:` | 300s 초과 | 다음 peer |
-| `AGY_ERROR(exit=N):` | 비정상 종료 | 다음 peer |
-| `CLI_NOT_FOUND:gemini` | gemini 부재 | 다음 peer |
-| `CLI_TIMEOUT:gemini` | 300s 초과 | 다음 peer |
-| `CLI_ERROR:gemini(exit=N)` | 비정상 종료 | 다음 peer |
-| `CLI_NOT_FOUND:codex` | codex 부재 | 다음 peer |
-| `CLI_TIMEOUT:codex` | 300s 초과 | 다음 peer |
-| `CLI_ERROR:codex(exit=N)` | 비정상 종료 | 다음 peer |
-| `CLAUDE_CLI_NOT_FOUND:` | claude CLI 부재 | 다음 peer |
-| `CLAUDE_CLI_TIMEOUT:` | 300s 초과 | 다음 peer |
-| `CLAUDE_CLI_ERROR(exit=N):` | 비정상 종료 | 다음 peer |
-| (모두 실패) | — | self-only fallback, user notify |
+peer-fallback-core.md Claude CLI 골격에 Cross-check Prompt + `$CONTENT` 주입.
 
 ---
 


### PR DESCRIPTION
## 요약

- `plugins/_shared/references/peer-fallback-core.md` 신규 생성 — pre-flight, host matrix, CLI 호출 골격, sentinel 카탈로그 단일 SOT
- `peer-review-cli.md`(311→178줄), `peer-cli.md`(191→97줄) 공통 블록 제거 → 참조 링크
- sentinel 문법 통합: `AGY_NOT_FOUND:` / `CLAUDE_CLI_NOT_FOUND:` → `CLI_NOT_FOUND:<cli>` 표준화
- git v0.4.1→v0.5.0, llm v0.3.0→v0.4.0 minor bump

## 변경 파일

- `docs/adr/0046-shared-peer-fallback-core.md` (신규)
- `plugins/_shared/references/peer-fallback-core.md` (신규)
- `plugins/git/skills/review/references/peer-review-cli.md` (-133줄)
- `plugins/llm/skills/auto/references/peer-cli.md` (-94줄)
- `.claude/rules/git-rules.md`, `.claude/rules/llm-rules.md` — [ADR-0046] 태그 추가
- 버전 파일 8곳

## 검증

```bash
ls plugins/_shared/references/peer-fallback-core.md
grep -c 'AGY_NOT_FOUND' plugins/git/skills/review/references/peer-review-cli.md  # 0
grep -c 'AGY_NOT_FOUND' plugins/llm/skills/auto/references/peer-cli.md           # 0
```

Closes #106

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.