### PR TITLE
refactor(git): 공통 에러 테이블 git/references/error-common.md 추출 DRY (git v0.7.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,7 +33,7 @@
       "name": "git",
       "source": "./plugins/git",
       "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
-      "version": "0.6.0"
+      "version": "0.7.0"
     },
     {
       "name": "llm",

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
 | [guideline](./plugins/guideline) | v0.3.0 | 소프트웨어 엔지니어링 가이드라인 및 코딩 원칙 — RESTful API 가이드라인, Andrej Karpathy의 11가지 코딩 행동 지침, Honest Judgment 안티-sycophancy 리뷰 규칙 포함 |
 | [workflow](./plugins/workflow) | v0.1.1 | 오케스트레이션된 개발 프로세스 워크플로우 스킬 — 고강도 개발 기율 강제를 위한 init, idea, feature, develop, planning 스킬 포함 |
 | [docs](./plugins/docs) | v0.0.8 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
-| [git](./plugins/git) | v0.6.0 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰(fast/balanced/deep tier 선택), union 머지+agreement 태그 자동수정, squash merge, 이슈 생성, Closes #N 이슈 연결, PR 전체 흐름, worktree 정리 |
+| [git](./plugins/git) | v0.7.0 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰(fast/balanced/deep tier 선택), union 머지+agreement 태그 자동수정, squash merge, 이슈 생성, Closes #N 이슈 연결, PR 전체 흐름, worktree 정리 |
 | [llm](./plugins/llm) | v0.5.0 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |
 | [dev](./plugins/dev) | v0.1.0 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 | [context](./plugins/context) | v0.9.0 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [guideline](./plugins/guideline) | v0.3.0 | Software engineering guidelines and coding principles — including RESTful API guidelines, Andrej Karpathy's 11 coding principles, and the Honest Judgment anti-sycophancy review rule |
 | [workflow](./plugins/workflow) | v0.1.1 | Orchestrated developer workflow skills — including init, idea, feature, develop, and planning for rigorous software engineering |
 | [docs](./plugins/docs) | v0.0.8 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
-| [git](./plugins/git) | v0.6.0 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
+| [git](./plugins/git) | v0.7.0 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
 | [llm](./plugins/llm) | v0.5.0 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |
 | [dev](./plugins/dev) | v0.1.0 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 | [context](./plugins/context) | v0.9.0 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/plugin.json
+++ b/plugins/git/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/references/error-common.md
+++ b/plugins/git/references/error-common.md
@@ -1,0 +1,13 @@
+# Git 공통 에러 처리
+
+commit / merge / pull-request 스킬의 공통 에러 SOT.
+
+---
+
+## 공통 에러 카탈로그
+
+| Situation | Action |
+|-----------|--------|
+| gh authentication error | `gh auth status` 실행 안내. 미인증 시 `gh auth login` 안내 후 중단. |
+| Network / connectivity error | 네트워크 상태 확인 안내. `git remote -v` 로 remote URL 검증 후 재시도. |
+| Hook failure (pre-commit / pre-push) | hook 에러 출력 표시. 원인 수정 후 재시도 안내. `--no-verify` 우회 절대 금지. |

--- a/plugins/git/references/error-common.md
+++ b/plugins/git/references/error-common.md
@@ -10,4 +10,4 @@ commit / merge / pull-request 스킬의 공통 에러 SOT.
 |-----------|--------|
 | gh authentication error | `gh auth status` 실행 안내. 미인증 시 `gh auth login` 안내 후 중단. |
 | Network / connectivity error | 네트워크 상태 확인 안내. `git remote -v` 로 remote URL 검증 후 재시도. |
-| Hook failure (pre-commit / pre-push) | hook 에러 출력 표시. 원인 수정 후 재시도 안내. `--no-verify` 우회 절대 금지. |
+| Hook failure (pre-push) | hook 에러 출력 표시. 원인 수정 후 재시도 안내. `--no-verify` 우회 절대 금지. |

--- a/plugins/git/skills/commit/SKILL.md
+++ b/plugins/git/skills/commit/SKILL.md
@@ -78,10 +78,11 @@ EOF
 
 ## Error Handling
 
+공통 에러(gh auth / network / hook failure): → [`references/error-common.md`](../../references/error-common.md)
+
 | Situation | Action |
 |-----------|--------|
 | No changes to commit | Abort with "No changes found" message |
-| pre-commit hook fails | Show error output, guide user to fix and retry |
 | Only sensitive files changed | Guide user to handle them manually |
 
 ## Usage

--- a/plugins/git/skills/commit/SKILL.md
+++ b/plugins/git/skills/commit/SKILL.md
@@ -78,11 +78,12 @@ EOF
 
 ## Error Handling
 
-공통 에러(gh auth / network / hook failure): → [`references/error-common.md`](../../references/error-common.md)
+공통 에러(gh auth / network): → [`references/error-common.md`](../../references/error-common.md)
 
 | Situation | Action |
 |-----------|--------|
 | No changes to commit | Abort with "No changes found" message |
+| pre-commit hook fails | Show error output, guide user to fix and retry |
 | Only sensitive files changed | Guide user to handle them manually |
 
 ## Usage

--- a/plugins/git/skills/merge/SKILL.md
+++ b/plugins/git/skills/merge/SKILL.md
@@ -96,7 +96,7 @@ git branch -d <FEATURE_BRANCH> 2>/dev/null || true
 
 ## Error Handling
 
-공통 에러(gh auth / network / hook failure): → [`references/error-common.md`](../../references/error-common.md)
+공통 에러(gh auth / network / hook pre-push): → [`references/error-common.md`](../../references/error-common.md)
 
 | Situation | Action |
 |-----------|--------|

--- a/plugins/git/skills/merge/SKILL.md
+++ b/plugins/git/skills/merge/SKILL.md
@@ -96,6 +96,8 @@ git branch -d <FEATURE_BRANCH> 2>/dev/null || true
 
 ## Error Handling
 
+공통 에러(gh auth / network / hook failure): → [`references/error-common.md`](../../references/error-common.md)
+
 | Situation | Action |
 |-----------|--------|
 | PR not found | Abort, ask user for PR number |

--- a/plugins/git/skills/pull-request/SKILL.md
+++ b/plugins/git/skills/pull-request/SKILL.md
@@ -143,11 +143,12 @@ Output the PR URL.
 
 ## Error Handling
 
+공통 에러(gh auth / network / hook failure): → [`references/error-common.md`](../../references/error-common.md)
+
 | Situation | Action |
 |-----------|--------|
 | Push conflict | Abort, suggest `git pull --rebase` |
 | PR already exists | Display PR URL and abort |
-| gh authentication error | Guide user to run `gh auth status` |
 | Unclear branch name pattern | Ask user for the feature branch name |
 
 ## Usage

--- a/plugins/git/skills/pull-request/SKILL.md
+++ b/plugins/git/skills/pull-request/SKILL.md
@@ -143,7 +143,7 @@ Output the PR URL.
 
 ## Error Handling
 
-공통 에러(gh auth / network / hook failure): → [`references/error-common.md`](../../references/error-common.md)
+공통 에러(gh auth / network / hook pre-push): → [`references/error-common.md`](../../references/error-common.md)
 
 | Situation | Action |
 |-----------|--------|


### PR DESCRIPTION
## 요약

- `plugins/git/references/error-common.md` 신규 (플러그인 루트 references/ 최초) — 공통 에러 3개 (gh auth / network / hook failure) 표현 통일
- commit/SKILL.md, merge/SKILL.md, pull-request/SKILL.md 에러 섹션에서 공통 에러 → 참조 링크
- 스킬별 고유 에러 항목 보존: commit(no-changes/sensitive-files), merge(PR not found~local branch delete), pull-request(push conflict/PR exists/unclear branch)
- git v0.6.0→v0.7.0 (4곳 동기화)

## 검증

```bash
ls plugins/git/references/error-common.md
grep -c 'gh authentication error' plugins/git/skills/pull-request/SKILL.md  # 0 (공통으로 이동)
grep -c 'error-common.md' plugins/git/skills/commit/SKILL.md                # 1 ✓
grep -c 'error-common.md' plugins/git/skills/merge/SKILL.md                 # 1 ✓
grep -c 'error-common.md' plugins/git/skills/pull-request/SKILL.md          # 1 ✓
```

Closes #108

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.