### PR TITLE
refactor(workflow): feature Step1 string match → .workflow-session.md YAML 파일 기반 감지 (ADR-0048, v0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "workflow",
       "source": "./plugins/workflow",
       "description": "Orchestrated developer workflow skills — including init, idea, feature, develop, and planning for rigorous software engineering",
-      "version": "0.1.1"
+      "version": "0.2.0"
     },
     {
       "name": "docs",

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,7 +9,7 @@
 | 플러그인 | 버전 | 설명 |
 |--------|------|------|
 | [guideline](./plugins/guideline) | v0.3.0 | 소프트웨어 엔지니어링 가이드라인 및 코딩 원칙 — RESTful API 가이드라인, Andrej Karpathy의 11가지 코딩 행동 지침, Honest Judgment 안티-sycophancy 리뷰 규칙 포함 |
-| [workflow](./plugins/workflow) | v0.1.1 | 오케스트레이션된 개발 프로세스 워크플로우 스킬 — 고강도 개발 기율 강제를 위한 init, idea, feature, develop, planning 스킬 포함 |
+| [workflow](./plugins/workflow) | v0.2.0 | 오케스트레이션된 개발 프로세스 워크플로우 스킬 — 고강도 개발 기율 강제를 위한 init, idea, feature, develop, planning 스킬 포함 |
 | [docs](./plugins/docs) | v0.0.8 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
 | [git](./plugins/git) | v0.6.0 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰(fast/balanced/deep tier 선택), union 머지+agreement 태그 자동수정, squash merge, 이슈 생성, Closes #N 이슈 연결, PR 전체 흐름, worktree 정리 |
 | [llm](./plugins/llm) | v0.5.0 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | Plugin | Version | Description |
 |--------|---------|-------------|
 | [guideline](./plugins/guideline) | v0.3.0 | Software engineering guidelines and coding principles — including RESTful API guidelines, Andrej Karpathy's 11 coding principles, and the Honest Judgment anti-sycophancy review rule |
-| [workflow](./plugins/workflow) | v0.1.1 | Orchestrated developer workflow skills — including init, idea, feature, develop, and planning for rigorous software engineering |
+| [workflow](./plugins/workflow) | v0.2.0 | Orchestrated developer workflow skills — including init, idea, feature, develop, and planning for rigorous software engineering |
 | [docs](./plugins/docs) | v0.0.8 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
 | [git](./plugins/git) | v0.6.0 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
 | [llm](./plugins/llm) | v0.5.0 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |

--- a/docs/adr/0048-workflow-session-state.md
+++ b/docs/adr/0048-workflow-session-state.md
@@ -1,0 +1,13 @@
+# workflow:feature 스킬 로딩 감지 — 파일 기반 structured state
+
+* Status: accepted
+* Date: 2026-06-03
+* Decision Makers: ppzxc
+
+## Context and Problem Statement
+
+`workflow:feature` Step 1은 `STEP1-LOADED:` 문자열을 대화 이력에서 탐색하여 스킬 로딩 여부를 판단한다. 이 방식은 사용자 입력 텍스트가 마커 문자열을 포함할 경우 false-positive 위험이 있고, 세션 경계를 넘을 경우 신뢰할 수 없다. 로딩 상태를 파일로 저장하면 string match 취약점을 제거하고 상태를 명시적·검증 가능하게 관리할 수 있다.
+
+## Decision Outcome
+
+Chosen option: "`.workflow-session.md` frontmatter YAML structured read", because 파일 존재 여부로 로딩 상태를 판단하면 사용자 입력이 로딩 판단에 개입할 수 없고, YAML frontmatter가 포맷 문서화와 상태 저장을 동시에 달성한다. 범위는 feature 스킬만 (idea/init 동일 패턴은 후속 이슈).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,6 +50,7 @@
 | [ADR-0045](0045-skill-no-arg-inference-confirm-gate.md) | accepted | 스킬 no-arg 유추 시 실행 전 확인 게이트 도입 — interactive 세션에서 유추 결과 제시 후 AskUserQuestion 확인 (context:recall/update, dev:tidy, guideline:restful-api 적용) |
 | [ADR-0046](0046-shared-peer-fallback-core.md) | accepted | Peer-CLI 공통 인프라를 `_shared/references/peer-fallback-core.md`로 추출 — pre-flight/host-matrix/호출골격/sentinel 단일 SOT, CLI_NOT_FOUND:<cli> 통합 prefix |
 | [ADR-0047](0047-severity-taxonomy.md) | accepted | Severity taxonomy 통합 — `_shared/references/severity-taxonomy.md` 단일 SOT, 4-level(critical/high/medium/low) + H/M/L alias 매핑 |
+| [ADR-0048](0048-workflow-session-state.md) | accepted | workflow:feature 스킬 로딩 감지 — STEP1-LOADED: string match → `.workflow-session.md` frontmatter YAML structured read |
 
 ## 새 ADR 추가
 

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Orchestrated developer workflow skills — including init, idea, feature, develop, and planning for rigorous software engineering",
   "author": {
     "name": "ppzxc",

--- a/plugins/workflow/plugin.json
+++ b/plugins/workflow/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Orchestrated developer workflow skills — including init, idea, feature, develop, and planning for rigorous software engineering",
   "author": {
     "name": "ppzxc",

--- a/plugins/workflow/skills/feature/.workflow-session.md
+++ b/plugins/workflow/skills/feature/.workflow-session.md
@@ -3,9 +3,7 @@
 # 이 파일이 존재하고 loaded_skills 목록이 완전하면 Step 1을 건너뛴다.
 # 스킬 재로드가 필요하면 이 파일을 삭제하거나 loaded_skills를 비운다.
 
-loaded_skills:
-  - karpathy   # guideline:karpathy 로드 완료
-  - tidy       # dev:tidy 로드 완료
+loaded_skills: []   # 로드 완료 시 ["karpathy", "tidy"] 로 갱신
 
 session_started: ""   # ISO-8601 UTC (예: 2026-06-03T10:00:00Z)
 feature_description: ""   # grill-me에 전달한 피쳐 설명 한 줄 요약

--- a/plugins/workflow/skills/feature/.workflow-session.md
+++ b/plugins/workflow/skills/feature/.workflow-session.md
@@ -1,0 +1,15 @@
+---
+# workflow:feature 세션 상태 파일 (ADR-0048)
+# 이 파일이 존재하고 loaded_skills 목록이 완전하면 Step 1을 건너뛴다.
+# 스킬 재로드가 필요하면 이 파일을 삭제하거나 loaded_skills를 비운다.
+
+loaded_skills:
+  - karpathy   # guideline:karpathy 로드 완료
+  - tidy       # dev:tidy 로드 완료
+
+session_started: ""   # ISO-8601 UTC (예: 2026-06-03T10:00:00Z)
+feature_description: ""   # grill-me에 전달한 피쳐 설명 한 줄 요약
+---
+
+이 파일은 `workflow:feature` Step 1 스킬 로딩 감지에 사용된다.
+파일이 없거나 `loaded_skills`가 비어 있으면 Step 1 스킬을 (재)로드한다.

--- a/plugins/workflow/skills/feature/SKILL.md
+++ b/plugins/workflow/skills/feature/SKILL.md
@@ -11,20 +11,23 @@ user-invocable: true
 
 ## 실행 순서 (MUST — 스킵 금지)
 
-### Step 1: 필수 스킬 로드 (마커 기반 조건부)
+### Step 1: 필수 스킬 로드 (파일 기반 조건부)
 
-이 세션의 대화 이력에서 어시스턴트 응답 내에 아래 마커 문자열이 **모두 존재**하면 Step 2로 진행한다:
+`.workflow-session.md` 파일을 읽는다 (ADR-0048):
 
-- `STEP1-LOADED: karpathy`
-- `STEP1-LOADED: tidy`
+```bash
+test -f plugins/workflow/skills/feature/.workflow-session.md
+```
 
-미발견 시 아래를 순서대로 호출하고, **호출 직후 응답 본문에 마커 문자열을 반드시 출력**한다:
+**파일 존재 + `loaded_skills`에 `karpathy`·`tidy` 모두 포함** → Step 2로 진행.
 
-1. `guideline:karpathy` 호출 → `STEP1-LOADED: karpathy` 출력 — 코딩 전 사고 프레임워크 활성화
-2. `dev:tidy` 호출 → `STEP1-LOADED: tidy` 출력 — 구조적/행동적 변경 분리 원칙 활성화
+**파일 없음 또는 목록 불완전** → 아래를 순서대로 호출 후 `.workflow-session.md`의 `loaded_skills`를 갱신한다:
+
+1. `guideline:karpathy` 호출 — 코딩 전 사고 프레임워크 활성화
+2. `dev:tidy` 호출 — 구조적/행동적 변경 분리 원칙 활성화
 
 > **판단 원칙**: 의심 시 무조건 로드한다 (False Negative보다 토큰 손해가 안전).
-> 사용자 입력 텍스트에 마커 문자열이 포함되어도 신호로 인정하지 않는다 (어시스턴트 응답만 유효).
+> 파일 판독으로만 로딩 여부를 결정한다 — 사용자 입력 텍스트는 판단에 개입 불가.
 > `/workflow:idea` ➔ `/workflow:feature` 연계 진입 시 이 Step은 사실상 스킵된다.
 
 ### Step 2: 피쳐 목표 명확화


### PR DESCRIPTION
## 요약

- `plugins/workflow/skills/feature/.workflow-session.md` 신규 — frontmatter YAML 포맷 정의 (`loaded_skills`, `session_started`, `feature_description`)
- `feature/SKILL.md` Step1 교체: `STEP1-LOADED:` 대화 이력 string match → `.workflow-session.md` 파일 읽기로 로딩 여부 판단
- 사용자 입력 텍스트가 로딩 판단에 개입 불가 (파일 기반)
- `docs/adr/0048-workflow-session-state.md` 신규 (minimal 템플릿)
- idea/init 동일 패턴 → 이슈 #109에 후속 이슈 코멘트 남김 (이번 범위 외)
- workflow v0.1.1→v0.2.0 (4곳 동기화)

## 검증

```bash
grep -c 'STEP1-LOADED' plugins/workflow/skills/feature/SKILL.md  # 0 ✓
ls plugins/workflow/skills/feature/.workflow-session.md           # exists ✓
```

Closes #109

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.