### PR TITLE
docs(adr): 병렬 subagent 완료 대기 지침 개선 및 ADR-0049 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,13 +33,13 @@
       "name": "git",
       "source": "./plugins/git",
       "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
-      "version": "0.7.1"
+      "version": "0.7.2"
     },
     {
       "name": "llm",
       "source": "./plugins/llm",
       "description": "LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     {
       "name": "dev",

--- a/.claude/rules/git-rules.md
+++ b/.claude/rules/git-rules.md
@@ -8,6 +8,7 @@ git 플러그인 스킬을 사용하거나 수정할 때 반드시 다음 제약
 ✓ git:review의 peer crosscheck는 자기 호스트와 다른 LLM에게 위임할 것. 자기 자신에게 cross-check를 보내는 호출 금지 [ADR-0022][ADR-0033]
 ✓ git:clean entry에서 별도 peer crosscheck를 추가하지 말 것 (post-work pipeline이므로 plan 검토 대상 없음) [ADR-0035]
 ✓ git:review의 cross-review는 Self/Peer 두 SUBAGENT 병렬 dispatch로 수행할 것 (Claude Code host) [ADR-0033]
+✓ 두 SUBAGENT 완료 대기 시 `schedule`로 주기적인 wakeup 타이머(30초)를 설정하고, 깨어날 때마다 `manage_subagents` `list` 툴로 두 subagent가 모두 Done인지 능동적으로 확인하고 루프를 돌 것 [ADR-0049]
 ✓ peer 폴백 체인은 자기 호스트를 제외한 풀에서 우선순위대로 시도하고 모든 sentinel(NOT_FOUND/TIMEOUT/ERROR)에서 다음 peer로 이동할 것 [ADR-0033]
 ✓ Auto-fix는 union+agreement 태그 기반 fix-gate로 적용할 것: critical/high는 both/single 무관 자동수정, medium/low는 both 합의 시만 자동수정·single은 코멘트 보고만 [ADR-0040]
 ✓ Self-Review SUBAGENT는 언어별 스킬 대신 pr-review-toolkit:code-reviewer를 tier별 모델(fast=haiku/balanced=sonnet/deep=opus, 기본 deep)로 사용할 것 [ADR-0036][ADR-0039]

--- a/.claude/rules/llm-rules.md
+++ b/.claude/rules/llm-rules.md
@@ -7,6 +7,7 @@
 ✓ `.context-map.md` 생성·전달·참조 금지 (ADR-0021/0022/0023 부분 supersede) [ADR-0034]
 ✓ wrapper 우선순위는 MCP/스킬/SubAgent 1순위 → stdin CLI fallback 2순위 [ADR-0034]
 ✓ self+peer 병렬 SUBAGENT dispatch 수행 (ADR-0033 패턴 차용) [ADR-0034]
+✓ 두 SUBAGENT 완료 대기 시 `schedule`로 주기적인 wakeup 타이머(30초)를 설정하고, 깨어날 때마다 `manage_subagents` `list` 툴로 두 subagent가 모두 Done인지 능동적으로 확인하고 루프를 돌 것 [ADR-0049]
 ✓ 입력 분류 4종(plan/spec/idea/diff). diff 입력은 git:review로 redirect [ADR-0034]
 ✓ peer-cli 공통 인프라(pre-flight/host-matrix/호출골격/sentinel)는 `plugins/_shared/references/peer-fallback-core.md`를 SOT로 사용할 것 [ADR-0046]
 ✓ severity 어휘(critical/high/medium/low 및 H/M/L alias)는 `plugins/_shared/references/severity-taxonomy.md`를 SOT로 사용할 것 [ADR-0047]

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,8 +11,8 @@
 | [guideline](./plugins/guideline) | v0.3.0 | 소프트웨어 엔지니어링 가이드라인 및 코딩 원칙 — RESTful API 가이드라인, Andrej Karpathy의 11가지 코딩 행동 지침, Honest Judgment 안티-sycophancy 리뷰 규칙 포함 |
 | [workflow](./plugins/workflow) | v0.2.0 | 오케스트레이션된 개발 프로세스 워크플로우 스킬 — 고강도 개발 기율 강제를 위한 init, idea, feature, develop, planning 스킬 포함 |
 | [docs](./plugins/docs) | v0.0.8 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
-| [git](./plugins/git) | v0.7.1 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰(fast/balanced/deep tier 선택), union 머지+agreement 태그 자동수정, squash merge, 이슈 생성, Closes #N 이슈 연결, PR 전체 흐름, worktree 정리 |
-| [llm](./plugins/llm) | v0.5.0 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |
+| [git](./plugins/git) | v0.7.2 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰(fast/balanced/deep tier 선택), union 머지+agreement 태그 자동수정, squash merge, 이슈 생성, Closes #N 이슈 연결, PR 전체 흐름, worktree 정리 |
+| [llm](./plugins/llm) | v0.5.1 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |
 | [dev](./plugins/dev) | v0.1.0 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
 | [context](./plugins/context) | v0.10.1 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A collection of engineering guidelines for software development, as a Claude Cod
 | [guideline](./plugins/guideline) | v0.3.0 | Software engineering guidelines and coding principles — including RESTful API guidelines, Andrej Karpathy's 11 coding principles, and the Honest Judgment anti-sycophancy review rule |
 | [workflow](./plugins/workflow) | v0.2.0 | Orchestrated developer workflow skills — including init, idea, feature, develop, and planning for rigorous software engineering |
 | [docs](./plugins/docs) | v0.0.8 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
-| [git](./plugins/git) | v0.7.1 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
-| [llm](./plugins/llm) | v0.5.0 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |
+| [git](./plugins/git) | v0.7.2 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
+| [llm](./plugins/llm) | v0.5.1 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |
 | [dev](./plugins/dev) | v0.1.0 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
 | [context](./plugins/context) | v0.10.1 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |
 

--- a/docs/adr/0049-subagent-wait-schedule-loop.md
+++ b/docs/adr/0049-subagent-wait-schedule-loop.md
@@ -1,0 +1,15 @@
+# subagent 완료 대기 시 schedule + manage_subagents 폴링 루프 도입
+
+* Status: accepted
+* Date: 2026-06-08
+* Decision Makers: ppzxc
+
+## Context and Problem Statement
+
+`git:review` 및 `llm:auto` 스킬에서 두 subagent(Self, Peer Coordinator)를 병렬 실행한 뒤 대기할 때, 기존의 "두 SUBAGENT 완료 대기 (동기 실행)" 지침은 구체적인 대기 방법론을 결여하고 있었다. 이로 인해 에이전트가 유휴 상태로 들어간 뒤 백그라운드 완료 이벤트가 유실되거나 UI 갱신이 멈춰, 사용자가 수동으로 interaction(예: ESC 키 입력)하기 전까지 대기 상태에 갇혀 있는 현상이 발생했다.
+
+## Decision Outcome
+
+Chosen option: "`schedule` 툴을 이용한 1회성 타이머 알림 설정 + `manage_subagents` `list` 툴을 활용한 능동적 폴링 지침 구체화", because 메인 에이전트가 턴을 완전히 종료하고 notification을 마냥 기다리는 대신, 주기적인 타이머 트리거로 강제 wakeup을 유도하고 `manage_subagents` `list`를 통해 직접 subagent 상태를 비교 검증함으로써 UI 대기 데드락 현상을 원천 차단할 수 있다.
+
+범위는 병렬 subagent 완료를 대기하는 `git:review`와 `llm:auto` 스킬에 적용하며, 규칙에도 반영한다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,7 @@
 | [ADR-0046](0046-shared-peer-fallback-core.md) | accepted | Peer-CLI 공통 인프라를 `_shared/references/peer-fallback-core.md`로 추출 — pre-flight/host-matrix/호출골격/sentinel 단일 SOT, CLI_NOT_FOUND:<cli> 통합 prefix |
 | [ADR-0047](0047-severity-taxonomy.md) | accepted | Severity taxonomy 통합 — `_shared/references/severity-taxonomy.md` 단일 SOT, 4-level(critical/high/medium/low) + H/M/L alias 매핑 |
 | [ADR-0048](0048-workflow-session-state.md) | accepted | workflow:feature 스킬 로딩 감지 — STEP1-LOADED: string match → `.workflow-session.md` frontmatter YAML structured read |
+| [ADR-0049](0049-subagent-wait-schedule-loop.md) | accepted | subagent 완료 대기 시 schedule + manage_subagents 폴링 루프 도입 |
 
 ## 새 ADR 추가
 

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/plugin.json
+++ b/plugins/git/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/skills/review/SKILL.md
+++ b/plugins/git/skills/review/SKILL.md
@@ -163,7 +163,10 @@ Ruleset and diff for embedding in CLI prompt:
 Output must match subagent-output-schema.md format.
 ```
 
-두 SUBAGENT 완료 대기 (동기 실행).
+두 SUBAGENT 완료 대기 (동기 실행):
+1. `invoke_subagent` 호출 직후 추가적인 텍스트 응답을 출력하지 않고 즉시 턴을 종료(stop calling tools)하여 백그라운드 완료 알림(notification)을 받도록 대기한다.
+2. 대기 과정에서 데드락을 방지하고 상태 갱신을 강제하기 위해, 1회 호출 후 `schedule` 툴을 사용하여 30초 뒤에 `Peer review status check` 알림을 설정한다. [ADR-0049]
+3. 알림을 받아 깨어나거나 subagent notification을 받으면 `manage_subagents` `list`를 호출하여 두 subagent의 status가 모두 Done인지 확인한다. 둘 다 Done이 아니라면 2번 단계(schedule 예약 및 턴 종료)를 반복하여 대기한다. [ADR-0049]
 
 ---
 

--- a/plugins/llm/.claude-plugin/plugin.json
+++ b/plugins/llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain",
   "author": {
     "name": "ppzxc",

--- a/plugins/llm/plugin.json
+++ b/plugins/llm/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain",
   "author": {
     "name": "ppzxc",

--- a/plugins/llm/skills/auto/SKILL.md
+++ b/plugins/llm/skills/auto/SKILL.md
@@ -89,7 +89,10 @@ Replace {CONTENT} with:
 --- CONTENT END ---
 ```
 
-두 SUBAGENT 완료 대기 (동기 실행).
+두 SUBAGENT 완료 대기 (동기 실행):
+1. `invoke_subagent` 호출 직후 추가적인 텍스트 응답을 출력하지 않고 즉시 턴을 종료(stop calling tools)하여 백그라운드 완료 알림(notification)을 받도록 대기한다.
+2. 대기 과정에서 데드락을 방지하고 상태 갱신을 강제하기 위해, 1회 호출 후 `schedule` 툴을 사용하여 30초 뒤에 `Peer review status check` 알림을 설정한다. [ADR-0049]
+3. 알림을 받아 깨어나거나 subagent notification을 받으면 `manage_subagents` `list`를 호출하여 두 subagent의 status가 모두 Done인지 확인한다. 둘 다 Done이 아니라면 2번 단계(schedule 예약 및 턴 종료)를 반복하여 대기한다. [ADR-0049]
 
 ---
 


### PR DESCRIPTION
## Summary
- 병렬 subagent 실행 시 대기 상태에서 CLI/에이전트가 block되는 현상을 해결하기 위한 지침과 규칙을 반영하였습니다.

## Motivation
- `git:review` 및 `llm:auto` 실행 시 subagent가 완료되었음에도 메인 에이전트가 wakeup 하지 못하고 사용자의 키 입력(ESC 등)이 있을 때까지 무한 대기하는 UI/런타임 데드락 현상이 있었습니다.

## Changes
- `docs/adr/0049-subagent-wait-schedule-loop.md`: schedule 툴을 활용한 주기적 타이머 알림 및 manage_subagents list를 이용한 능동적 완료 폴링 결정을 문서화
- `.claude/rules/git-rules.md`, `.claude/rules/llm-rules.md`: 관련 30초 대기 및 폴링 규칙 명시
- `plugins/git/skills/review/SKILL.md`, `plugins/llm/skills/auto/SKILL.md`: subagent 완료 대기 지침을 3단계 상세 절차로 개정
- `.claude-plugin/marketplace.json` 및 각 플러그인의 `plugin.json`과 `README.md`에서 버전을 git v0.7.2, llm v0.5.1로 각각 범프

## Test plan
- [ ] 로컬 변경사항 빌드 통과 및 git 커밋 완료
- [ ] git:review 및 llm:auto 스킬 로딩/형식 검증