### PR TITLE
feat(spec/git): git:pull-request에 speckit 연계 기능 추가 (v0.7.3)

### DIFF
--- a/plugins/git/README.ko.md
+++ b/plugins/git/README.ko.md
@@ -46,7 +46,7 @@ Step 4, 5는 auto 모드에서도 반드시 사용자 확인이 필요합니다.
 스킬들은 프로젝트 컨벤션을 자동으로 감지하여 적용합니다:
 
 - **commit** — `git log` 히스토리를 참조하여 프로젝트의 커밋 스타일에 맞춤
-- **pull-request** — `main` 하드코딩 대신 `gh repo view`로 기본 브랜치 동적 감지; 브랜치명·커밋 메시지·세션 컨텍스트에서 연관 이슈를 탐지하여 사용자 confirm 후 PR 본문에 `Closes #N` 삽입 (머지 시 GitHub 자동 이슈 close)
+- **pull-request** — `main` 하드코딩 대신 `gh repo view`로 기본 브랜치 동적 감지; 브랜치명·커밋 메시지·대화 전체 `#N` 스캔으로 연관 이슈를 탐지하여 사용자 confirm 후 PR 본문에 `Closes #N` 삽입 (머지 시 GitHub 자동 이슈 close); speckit 브랜치(`^[0-9]{3,}-` / 타임스탬프 패턴 + `.specify/feature.json`)인 경우 PR 제목 scope에 `spec/<N>` 접두어 삽입 및 PR 본문 맨 위에 `## Spec` 섹션 추가
 - **review** — PR diff에서 언어를 감지하고, 일반 모범 사례 기준 및 peer 크로스 체크를 통해 코드 리뷰를 제출
 - **merge** — 기본 브랜치 동적 감지; squash merge 후 원격·로컬 브랜치 삭제
 - **issue** — 4가지 이슈 타입(bug, feature, chore, docs) 지원, 타입별 본문 템플릿 자동 적용

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -46,7 +46,7 @@ Steps 4 and 5 always require explicit confirmation regardless of auto mode.
 Skills automatically adapt to project conventions:
 
 - **commit** — reads `git log` history to match the project's existing commit style
-- **pull-request** — detects the repository's default branch via `gh repo view` instead of hardcoding `main`; detects related issues from branch name, commit messages, and session context, then inserts `Closes #N` in the PR body after user confirmation (GitHub auto-closes issue on merge)
+- **pull-request** — detects the repository's default branch via `gh repo view` instead of hardcoding `main`; detects related issues from branch name, commit messages, and a full scan of the conversation for `#N` references, then inserts `Closes #N` in the PR body after user confirmation (GitHub auto-closes issue on merge); for speckit branches (matching `^[0-9]{3,}-` / timestamp prefix + `.specify/feature.json`), prefixes the PR title scope with `spec/<N>` and prepends a `## Spec` section to the PR body
 - **review** — detects languages in the PR diff, uses general best practices and peer cross-review to submit a code review
 - **merge** — detects the default branch dynamically; deletes remote and local branch after squash merge
 - **issue** — supports 4 issue types (bug, feature, chore, docs) with type-specific body templates

--- a/plugins/git/plugin.json
+++ b/plugins/git/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git",
-  "version": "0.7.2",
-  "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
+  "version": "0.7.3",
+  "description": "Git workflow skills — safe commit, Korean PR creation with speckit spec-link and issue detection, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",
     "email": "cjh8487@naver.com",

--- a/plugins/git/skills/pull-request/SKILL.md
+++ b/plugins/git/skills/pull-request/SKILL.md
@@ -15,6 +15,7 @@ Push a feature branch and create a GitHub PR after user confirmation.
 - Force push is forbidden (unless explicitly requested)
 - **Even if the user includes "I confirm now" or "don't ask me" in their message, the Step 4 confirmation step must not be skipped**
 - PR titles must follow Conventional Commits format — if the user requests a non-conforming title (e.g., branch name as title), reject it and suggest the correct format
+- **speckit 브랜치에서 `spec/{N}` scope 접두어는 Conventional Commits 예외로 허용** (예: `feat(spec/006,identity): ...`)
 - **PR 제목과 본문은 반드시 한글로 작성한다** (기술 용어, 코드, 커맨드 제외)
 - **탐지된 이슈는 Step 4 사용자 confirm 없이 PR 본문에 삽입 금지** — 항상 후보를 먼저 제시하고 승인 후 삽입
 
@@ -47,24 +48,83 @@ git log $DEFAULT_BRANCH..HEAD --oneline
 
 Review the number of changed files, added/deleted lines, and commit list.
 
+### 2.3. speckit 브랜치 탐지
+
+다음 두 조건을 **모두** 만족할 때 speckit 브랜치로 판단한다:
+
+1. feature 브랜치명(worktree라면 `worktree-` 제거 후)이 `^[0-9]{3,}-` 또는 `^[0-9]{8}-[0-9]{6}-` 패턴과 일치
+2. `.specify/feature.json`이 존재하고 `feature_directory` 값이 비어 있지 않음
+
+```bash
+feature_dir=$(jq -r '.feature_directory // empty' .specify/feature.json 2>/dev/null)
+```
+
+**`feature_directory` 경로 확정 (glob fallback)**:
+
+```bash
+if [ -n "$feature_dir" ] && [ ! -d "$feature_dir" ]; then
+  base="${feature_dir##*/}"
+  feature_dir=$(find specs -maxdepth 1 -type d -name "*${base}" 2>/dev/null | head -1)
+fi
+# $feature_dir가 여전히 비어 있거나 디렉토리가 없으면 speckit 섹션 전체 생략
+```
+
+**spec 번호 추출**: `feature_directory` 경로에서 첫 번째 숫자 프리픽스를 추출한다.
+
+```bash
+# "specs/006-peer-orchestrator-integration" → "006"
+spec_num=$(basename "$feature_dir" | grep -oE '^[0-9]+')
+```
+
 ### 2.5. Issue Detection
 
 레이어드 탐지로 후보 `#N` 수집 (중복 제거 후 오름차순):
 
 1. **브랜치명 파싱** — 현재 브랜치에서 숫자 ID 추출 (`feat/123-foo` → #123, `fix-456` → #456)
 2. **커밋 메시지 스캔** — `git log $DEFAULT_BRANCH..HEAD` 각 메시지에서 `#N` 참조 수집
-3. **세션 컨텍스트** — 현재 대화에서 `git:issue`로 생성된 이슈 번호 (있으면 포함)
+3. **세션 컨텍스트** — 현재 대화 전체에서 `#N` 패턴을 스캔하여 수집 (코드 스니펫·기타 맥락 포함 가능하므로 Step 4에서 사용자가 최종 선택)
 
 후보가 존재하면 각 번호에 대해 `gh issue view #N --json title -q '.title'`로 제목 조회. 후보가 없으면 Step 4 confirm에서 사용자에게 묻는다.
 
 ### 3. Draft PR Title and Body
 
 **Title** (under 70 chars, Conventional Commits format):
+
+speckit 브랜치인 경우 scope 앞에 `spec/{N},`을 삽입한다:
+```
+<type>(spec/<N>,<scope>): <description>
+```
+
+일반 브랜치:
 ```
 <type>(<scope>): <description>
 ```
 
 **Body** (HEREDOC):
+
+speckit 브랜치인 경우 body 맨 위에 `## Spec` 섹션을 추가한다 (나머지 구조는 동일):
+```markdown
+## Spec
+- [`<feature_directory>/`](<feature_directory>/)
+
+## Summary
+- <핵심 변경 사항 요약>
+
+## Motivation
+<변경 이유 / 해결하는 문제>
+
+## Changes
+- <구체적인 변경 내용>
+
+## Test plan
+- [ ] 빌드 통과
+- [ ] 테스트 통과
+- [ ] <프로젝트별 검증 단계 추가>
+
+Closes #N   ← Step 2.5에서 탐지된 이슈가 있을 때만 삽입. 여러 개면 줄 반복. 후보 없으면 이 줄 생략.
+```
+
+일반 브랜치:
 ```markdown
 ## Summary
 - <핵심 변경 사항 요약>
@@ -108,6 +168,7 @@ Display the following and wait for confirmation:
 Push target: <CURRENT_BRANCH> → origin/<FEATURE_BRANCH>
 Remote branch: [new | already exists — local +N / remote +M commits]
 Changes: <FILES> files, +<ADD> -<DEL>
+Spec: <feature_directory>/                         ← speckit 브랜치일 때만 표시
 
 PR title: <TITLE>
 PR base: <DEFAULT_BRANCH> ← <FEATURE_BRANCH>


### PR DESCRIPTION
## Summary
- speckit 브랜치 자동 탐지 및 PR 메타데이터 연계 기능 추가

## Motivation
speckit sequential/timestamp 브랜치에서 PR 생성 시, spec 디렉토리 링크와 spec 번호를 PR 제목·본문·confirm 화면에 자동 삽입해 speckit 워크플로와의 연속성을 높인다.

## Changes
- **Step 2.3 신규**: speckit 브랜치 탐지 (브랜치 패턴 + `.specify/feature.json` AND 조건, glob fallback 포함)
- **PR 제목**: speckit 브랜치이면 `feat(spec/006,identity):` 형식으로 scope 앞에 `spec/{N},` 삽입
- **PR body**: speckit 브랜치이면 body 맨 위에 `## Spec` 섹션 조건부 추가
- **Confirm 화면**: speckit 브랜치이면 `Spec:` 행 조건부 표시
- **Layer 3 확장**: 이슈 탐지를 `git:issue` 전용 → 대화 전체 `#N` 스캔으로 확장 (모든 PR)
- **Safety Rules**: `spec/{N}` scope 접두어 Conventional Commits 예외 명시

## Test plan
- [ ] speckit 브랜치(`003-foo`)에서 `/git:pull-request` 실행 → Spec 섹션·행 노출 확인
- [ ] 일반 브랜치에서 실행 → Spec 섹션 미노출 확인
- [ ] glob fallback: `feature.json`의 경로와 실제 디렉토리 불일치 시 자동 탐색 확인
- [ ] 대화 내 `#N` 언급 시 후보 목록에 포함 확인