### PR TITLE
fix(guideline): restful-api 티어 분류 일관성 교정 (v0.8.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "guideline",
       "source": "./plugins/guideline",
-      "version": "0.8.0"
+      "version": "0.8.1"
     },
     {
       "name": "docs",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A collection of engineering guidelines for software development, as a Claude Cod
 
 | Plugin | Version | Description |
 |--------|---------|-------------|
-| [guideline](./plugins/guideline) | v0.8.0 | Software engineering guidelines and coding principles — including RESTful API guidelines, Andrej Karpathy's 11 coding principles, and the Honest Judgment anti-sycophancy review rule |
+| [guideline](./plugins/guideline) | v0.8.1 | Software engineering guidelines and coding principles — including RESTful API guidelines, Andrej Karpathy's 11 coding principles, and the Honest Judgment anti-sycophancy review rule |
 | [docs](./plugins/docs) | v0.0.8 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
 | [git](./plugins/git) | v0.7.3 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
 | [llm](./plugins/llm) | v0.5.2 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |

--- a/plugins/guideline/.claude-plugin/plugin.json
+++ b/plugins/guideline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guideline",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Software engineering guidelines and coding principles — including RESTful API guidelines",
   "author": {
     "name": "ppzxc",

--- a/plugins/guideline/plugin.json
+++ b/plugins/guideline/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guideline",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Software engineering guidelines and coding principles — including RESTful API guidelines",
   "author": {
     "name": "ppzxc",

--- a/plugins/guideline/skills/restful-api/README.md
+++ b/plugins/guideline/skills/restful-api/README.md
@@ -10,8 +10,8 @@
 
 | 프로필 | 포함 티어 | 대상 | 규칙 수 |
 |--------|-----------|------|---------|
-| **Essential** | T1 전용 | 모든 API — 첫날부터 적용 | ~90 |
-| **Standard** | T1 + T2 | 프로덕션 운영 단계 | ~130 |
+| **Essential** | T1 전용 | 모든 API — 첫날부터 적용 | ~91 |
+| **Standard** | T1 + T2 | 프로덕션 운영 단계 | ~129 |
 | **Full** | T1 + T2 + T3 | 대규모/엔터프라이즈 API | ~156 |
 
 **사용 예시:** "Essential 프로필로 이 API를 리뷰해줘" → T1 규칙만 검사합니다.
@@ -128,7 +128,7 @@
 - **상태값 명명 규칙:** 사용 가능 → `ACTIVE` (`READY`/`AVAILABLE` 대신); 종료(terminal) → 과거분사 `-ED` (`SUCCEEDED`, `FAILED`, `DELETED`); 진행 중 → 현재분사 `-ING` (`RUNNING`, `CREATING`, `DELETING`)
 - 공통 패턴: `ACTIVE/INACTIVE`, `PENDING/RUNNING/SUCCEEDED/FAILED`
 - 허용되지 않는 상태 전환(전제 조건 미충족)은 `409 Conflict`를 반환하며 응답 본문에 현재 `state`를 포함합니다. `[T2]`
-- 클라이언트에게 실제 유스케이스가 있는 상태만 노출하고, 내부 구현 상태를 그대로 드러내지 마십시오. `[T2]`
+- 클라이언트에게 실제 유스케이스가 있는 상태만 노출하고, 내부 구현 상태를 그대로 드러내지 마십시오. `[T3]`
 - 시간으로부터 도출되는 단일 사실인 상태는 에넘보다 타임스탬프를 우선합니다 (예: 삭제 여부 → `deleteTime`, 소프트 딜리트 섹션 참고). `[T3]`
 
 ---
@@ -278,7 +278,7 @@ OpenAPI 매핑: `OUTPUT_ONLY` → `readOnly: true`, `INPUT_ONLY` → `writeOnly:
 - 부작용 없는 조회형 커스텀 메서드는 `GET`; 이때 요청 본문을 포함해서는 안 되며 입력은 쿼리 파라미터로 전달합니다. 읽기는 원칙적으로 표준 컬렉션 `GET` + `filter`/`q`/`fields`로 표현하며, 콜론 `GET` 커스텀 메서드는 필터·투영으로 표현할 수 **없는** 고유 연산(예: `GET /documents/{id}:preview`, `GET /text:translate`)에만 한정합니다.
 - 조회 메서드라도 파라미터가 URL 길이 한계를 초과할 때만 `POST`로 폴백합니다.
 
-**커스텀 동사 네이밍 (AIP-136):** `[T2]`
+**커스텀 동사 네이밍 (AIP-136):** `[T1]`
 - 콜론 뒤 동사는 camelCase: `:batchGet`, `:setIamPolicy` (`:batch_get` / `:BatchGet` 불가)
 - 동사 또는 동사+명사 사용; 전치사 포함 금지 (`:moveForArchive` 불가 → `:moveToArchive`)
 - 표준 메서드 동사(`get`, `list`, `create`, `update`, `delete`) 재사용 금지

--- a/plugins/guideline/skills/restful-api/SKILL.md
+++ b/plugins/guideline/skills/restful-api/SKILL.md
@@ -16,8 +16,8 @@ Each rule is tagged with `[T1]`, `[T2]`, or `[T3]`. If the user specifies a prof
 
 | Profile | Included Tiers | Target | Rule Count |
 |--------|-----------|------|---------|
-| **Essential** | T1 only | All APIs — from day one | ~90 |
-| **Standard** | T1 + T2 | Production environments | ~130 |
+| **Essential** | T1 only | All APIs — from day one | ~91 |
+| **Standard** | T1 + T2 | Production environments | ~129 |
 | **Full** | T1 + T2 + T3 | Large-scale/Enterprise APIs | ~156 |
 
 **Example usage:** "Review this API using the Essential profile" → Check only T1 rules.
@@ -132,7 +132,7 @@ Nest at most one sub-resource under a parent. For deeper relationships, promote 
 - **State value naming:** available → `ACTIVE` (not `READY`/`AVAILABLE`); terminal → past participle `-ED` (`SUCCEEDED`, `FAILED`, `DELETED`); in-progress → present participle `-ING` (`RUNNING`, `CREATING`, `DELETING`)
 - Common patterns: `ACTIVE/INACTIVE`, `PENDING/RUNNING/SUCCEEDED/FAILED`
 - A disallowed state transition (precondition not met) MUST return `409 Conflict` with the current `state` in the body `[T2]`
-- Expose only states with a real client use case — do not surface internal/implementation states `[T2]`
+- Expose only states with a real client use case — do not surface internal/implementation states `[T3]`
 - Prefer a timestamp over a state enum when the state is a single fact derivable from time (e.g., `deleteTime` for deletion — see Soft Delete) `[T3]`
 
 ## Error Response (RFC 7807/9457 + AIP-193 Hybrid)
@@ -287,7 +287,7 @@ For async actions that create a pollable job resource, use `201 Created` + `Loca
 - `GET` for side-effect-free retrieval custom methods; these MUST NOT include a request body — pass inputs as query parameters. Reads are normally expressed as a standard collection `GET` with `filter`/`q`/`fields`; reserve a `GET` custom method for a distinct named operation that **cannot** be expressed as a filter or projection (e.g., `GET /documents/{id}:preview`, `GET /text:translate`).
 - Fall back to `POST` for a retrieval method only when its parameters would exceed URL length limits.
 
-**Custom verb naming (AIP-136):** `[T2]`
+**Custom verb naming (AIP-136):** `[T1]`
 - camelCase the verb after the colon: `:batchGet`, `:setIamPolicy` (not `:batch_get` / `:BatchGet`)
 - Use a verb or verb+noun; MUST NOT contain prepositions (`:moveToArchive`, not `:moveForArchive`)
 - MUST NOT reuse standard-method verbs (`get`, `list`, `create`, `update`, `delete`) as custom verbs


### PR DESCRIPTION
## 배경
ADR-0010 티어 기준으로 신규 추가 규칙을 자가 점검한 결과 비일관 2건 발견 → 교정.

| 규칙 | 변경 | 근거 |
|---|---|---|
| 커스텀 동사 네이밍 (AIP-136) | T2 → **T1** | 스킬 내 모든 네이밍 규칙은 rename=파괴라 T1. 같은 패턴의 상태값 명명도 T1이라 내부 비일관까지 있었음 |
| 상태 미니멀리즘 (AIP-216) | T2 → **T3** | 운영 편의가 아닌 설계 거버넌스/advisory → T3 정합 |

티어 수: Essential ~91 / Standard ~129 / Full ~156. 버전 0.8.0→0.8.1(patch).

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.