### PR TITLE
chore(plugin): 로컬 플러그인 스킬 자동 발동 차단 및 버전 범프

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,37 +14,37 @@
     {
       "name": "guideline",
       "source": "./plugins/guideline",
-      "version": "0.8.2"
+      "version": "0.8.3"
     },
     {
       "name": "docs",
       "source": "./plugins/docs",
       "description": "Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions",
-      "version": "0.0.8"
+      "version": "0.0.9"
     },
     {
       "name": "git",
       "source": "./plugins/git",
       "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
-      "version": "0.7.3"
+      "version": "0.7.4"
     },
     {
       "name": "llm",
       "source": "./plugins/llm",
       "description": "LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain",
-      "version": "0.5.2"
+      "version": "0.5.3"
     },
     {
       "name": "dev",
       "source": "./plugins/dev",
       "description": "Development methodology skills — Tidy First, TDD, and language-agnostic development practices",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "name": "context",
       "source": "./plugins/context",
       "description": "Dev Docs System skills — self-contained 4-file task folders (spec/plan/tasks/context) for resumable development",
-      "version": "0.10.1"
+      "version": "0.10.2"
     }
   ]
 }

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,12 +8,12 @@
 
 | 플러그인 | 버전 | 설명 |
 |--------|------|------|
-| [guideline](./plugins/guideline) | v0.6.0 | 소프트웨어 엔지니어링 가이드라인 및 코딩 원칙 — RESTful API 가이드라인, Andrej Karpathy의 11가지 코딩 행동 지침, Honest Judgment 안티-sycophancy 리뷰 규칙 포함 |
-| [docs](./plugins/docs) | v0.0.8 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
-| [git](./plugins/git) | v0.7.3 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰(fast/balanced/deep tier 선택), union 머지+agreement 태그 자동수정, squash merge, 이슈 생성, Closes #N 이슈 연결, PR 전체 흐름, worktree 정리 |
-| [llm](./plugins/llm) | v0.5.2 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |
-| [dev](./plugins/dev) | v0.1.0 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
-| [context](./plugins/context) | v0.10.1 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |
+| [guideline](./plugins/guideline) | v0.8.3 | 소프트웨어 엔지니어링 가이드라인 및 코딩 원칙 — RESTful API 가이드라인, Andrej Karpathy의 11가지 코딩 행동 지침, Honest Judgment 안티-sycophancy 리뷰 규칙 포함 |
+| [docs](./plugins/docs) | v0.0.9 | 문서 결정 기록 — ADR (Nygard 포맷) 및 MADR (MADR 4.0) 아키텍처 결정 기록 |
+| [git](./plugins/git) | v0.7.4 | Git 워크플로우 스킬 — 안전한 커밋, 한글 PR 생성, 호스트 인지 peer 교차검증 PR 리뷰(fast/balanced/deep tier 선택), union 머지+agreement 태그 자동수정, squash merge, 이슈 생성, Closes #N 이슈 연결, PR 전체 흐름, worktree 정리 |
+| [llm](./plugins/llm) | v0.5.3 | LLM 위임 스킬 — 4-way peer 교차검증 (agy, claude, gemini, codex), 호스트 인지 폴백 체인 |
+| [dev](./plugins/dev) | v0.1.1 | 개발 방법론 스킬 — Tidy First, TDD, 언어 무관 개발 프랙티스 |
+| [context](./plugins/context) | v0.10.2 | Dev Docs 시스템 스킬 — 세션 단절에도 재개 가능한 4파일 자기완결 작업 폴더 |
 
 ## 마켓플레이스 등록
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ A collection of engineering guidelines for software development, as a Claude Cod
 
 | Plugin | Version | Description |
 |--------|---------|-------------|
-| [guideline](./plugins/guideline) | v0.8.2 | Software engineering guidelines and coding principles — including RESTful API guidelines, Andrej Karpathy's 11 coding principles, and the Honest Judgment anti-sycophancy review rule |
-| [docs](./plugins/docs) | v0.0.8 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
-| [git](./plugins/git) | v0.7.3 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
-| [llm](./plugins/llm) | v0.5.2 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |
-| [dev](./plugins/dev) | v0.1.0 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
-| [context](./plugins/context) | v0.10.1 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |
+| [guideline](./plugins/guideline) | v0.8.3 | Software engineering guidelines and coding principles — including RESTful API guidelines, Andrej Karpathy's 11 coding principles, and the Honest Judgment anti-sycophancy review rule |
+| [docs](./plugins/docs) | v0.0.9 | Documentation decision records — ADR (Nygard format) and MADR (MADR 4.0) for architecture decisions |
+| [git](./plugins/git) | v0.7.4 | Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup |
+| [llm](./plugins/llm) | v0.5.3 | LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain |
+| [dev](./plugins/dev) | v0.1.1 | Development methodology skills — Tidy First, TDD, and language-agnostic development practices |
+| [context](./plugins/context) | v0.10.2 | Dev Docs System skills — self-contained 4-file task folders for resumable, context-preserving development |
 
 ## Marketplace Registration
 

--- a/plugins/context/.claude-plugin/plugin.json
+++ b/plugins/context/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Dev Docs System skills — self-contained 4-file task folders (spec/plan/tasks/context) for resumable, context-preserving development across sessions",
   "author": {
     "name": "ppzxc",

--- a/plugins/context/plugin.json
+++ b/plugins/context/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Dev Docs System skills — self-contained 4-file task folders (spec/plan/tasks/context) for resumable, context-preserving development across sessions",
   "author": {
     "name": "ppzxc",

--- a/plugins/context/skills/guard/SKILL.md
+++ b/plugins/context/skills/guard/SKILL.md
@@ -2,6 +2,7 @@
 name: guard
 description: Install the context:update staleness-reminder Stop hook into the host project — /context:guard, "훅 설치", "진행상황 강제 설치", "컨텍스트 가드"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Context Guard — Stop hook 설치

--- a/plugins/context/skills/plan/SKILL.md
+++ b/plugins/context/skills/plan/SKILL.md
@@ -2,6 +2,7 @@
 name: plan
 description: Use when starting a new task from a raw idea and you want a resumable 4-file Dev Docs folder — /context:plan, "컨텍스트 플랜", "작업 폴더 만들어", "재개 가능한 계획", "context plan". IMPORTANT: When the user types /context:plan, invoke this skill with the Skill tool BEFORE any other action, including entering plan mode.
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Context Plan — 4파일 Dev Docs 폴더 생성

--- a/plugins/context/skills/recall/SKILL.md
+++ b/plugins/context/skills/recall/SKILL.md
@@ -2,6 +2,7 @@
 name: recall
 description: Use after a session break to re-anchor on a task by reading its Dev Docs folder — /context:recall, "컨텍스트 재개", "어디까지 했지"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Context Recall — 세션 재개

--- a/plugins/context/skills/update/SKILL.md
+++ b/plugins/context/skills/update/SKILL.md
@@ -2,6 +2,7 @@
 name: update
 description: Use right before context compaction to persist task state into the Dev Docs folder — /context:update, "컨텍스트 업데이트", "상태 저장", "진행상황 기록"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Context Update — 작업 상태 영속화

--- a/plugins/context/skills/verify-spec/SKILL.md
+++ b/plugins/context/skills/verify-spec/SKILL.md
@@ -2,6 +2,7 @@
 name: verify-spec
 description: Spec review retry loop + ExitPlanMode release gate for context:plan. Invokes grill-me hardening, AskUserQuestion approval loop, and ExitPlanMode as the final release gate. Can also be invoked standalone to re-run the spec review cycle — /context:verify-spec.
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Verify Spec — Spec 리뷰 루프 + ExitPlanMode 게이트

--- a/plugins/dev/.claude-plugin/plugin.json
+++ b/plugins/dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Development methodology skills — Tidy First, TDD, and language-agnostic development practices",
   "author": {
     "name": "ppzxc",

--- a/plugins/dev/plugin.json
+++ b/plugins/dev/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "0.0.4",
+  "version": "0.1.1",
   "description": "Development methodology skills — Tidy First, TDD, and language-agnostic development practices",
   "author": {
     "name": "ppzxc",

--- a/plugins/dev/skills/tidy/SKILL.md
+++ b/plugins/dev/skills/tidy/SKILL.md
@@ -2,6 +2,7 @@
 name: tidy
 description: Use when refactoring code or preparing structural changes following Kent Beck's Tidy First principles. — /dev:tidy, "tidy first", "구조 정리", "리팩토링"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # tidy-first

--- a/plugins/docs/.claude-plugin/plugin.json
+++ b/plugins/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Documentation decision records skills — ADR (Nygard format) and MADR (Markdown Architectural Decision Records 4.0) for capturing and tracking architecture decisions",
   "author": {
     "name": "ppzxc",

--- a/plugins/docs/plugin.json
+++ b/plugins/docs/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "description": "Documentation decision records skills — ADR (Nygard format) and MADR (Markdown Architectural Decision Records 4.0) for capturing and tracking architecture decisions",
   "author": {
     "name": "ppzxc",

--- a/plugins/docs/skills/adr/SKILL.md
+++ b/plugins/docs/skills/adr/SKILL.md
@@ -2,6 +2,7 @@
 name: adr
 description: "Use when creating an Architecture Decision Record in Nygard format. — /docs:adr, \"ADR 작성\", \"결정 사항 기록\""
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # docs:adr — Architecture Decision Record

--- a/plugins/docs/skills/madr/SKILL.md
+++ b/plugins/docs/skills/madr/SKILL.md
@@ -2,6 +2,7 @@
 name: madr
 description: "Use when creating a Markdown Architectural Decision Record in MADR 4.0 format. — /docs:madr, \"MADR 작성\", \"결정 사항 기록\""
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # docs:madr — Markdown Architectural Decision Record

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Git workflow skills — safe commit, Korean PR creation, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/plugin.json
+++ b/plugins/git/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Git workflow skills — safe commit, Korean PR creation with speckit spec-link and issue detection, PR review with host-aware peer cross-check and selectable review tier (fast/balanced/deep), union-merge with agreement-tagged auto-fix, squash merge, issue creation, issue-PR linkage via Closes #N, full PR lifecycle orchestration, and worktree cleanup",
   "author": {
     "name": "ppzxc",

--- a/plugins/git/skills/clean/SKILL.md
+++ b/plugins/git/skills/clean/SKILL.md
@@ -2,6 +2,7 @@
 name: clean
 description: Use when the user wants to complete the full PR workflow in sequence (commit, push, review, merge, and cleanup). — /git:clean, "PR 완료", "PR 전체 흐름", "worktree 정리"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # clean — Full PR Lifecycle + Cleanup

--- a/plugins/git/skills/commit/SKILL.md
+++ b/plugins/git/skills/commit/SKILL.md
@@ -2,6 +2,7 @@
 name: commit
 description: Use when the user wants to stage and commit local changes. — /git:commit, "커밋", "변경사항 커밋"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # commit — Safe Commit

--- a/plugins/git/skills/issue/SKILL.md
+++ b/plugins/git/skills/issue/SKILL.md
@@ -2,6 +2,7 @@
 name: issue
 description: Use when the user wants to create a GitHub issue. — /git:issue, "이슈 만들어", "이슈 생성", "버그 리포트"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # issue — Create GitHub Issue

--- a/plugins/git/skills/merge/SKILL.md
+++ b/plugins/git/skills/merge/SKILL.md
@@ -2,6 +2,7 @@
 name: merge
 description: Use when the user wants to squash-merge a GitHub PR into the main branch. — /git:merge, "PR 머지", "squash merge"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # merge — PR Squash Merge

--- a/plugins/git/skills/pull-request/SKILL.md
+++ b/plugins/git/skills/pull-request/SKILL.md
@@ -2,6 +2,7 @@
 name: pull-request
 description: Use when the user wants to push changes and open a GitHub pull request. — /git:pull-request, "PR 만들어", "PR 생성", "push하고 PR"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # pull-request — Create Pull Request

--- a/plugins/git/skills/review/SKILL.md
+++ b/plugins/git/skills/review/SKILL.md
@@ -2,6 +2,7 @@
 name: review
 description: Use when the user wants to review, automatically fix, and comment on a GitHub PR. — /git:review, "PR 리뷰", "코드 리뷰"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # review — PR Code Review & Auto-Fix

--- a/plugins/guideline/.claude-plugin/plugin.json
+++ b/plugins/guideline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guideline",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Software engineering guidelines and coding principles — including RESTful API guidelines",
   "author": {
     "name": "ppzxc",

--- a/plugins/guideline/plugin.json
+++ b/plugins/guideline/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guideline",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Software engineering guidelines and coding principles — including RESTful API guidelines",
   "author": {
     "name": "ppzxc",

--- a/plugins/guideline/skills/restful-api/SKILL.md
+++ b/plugins/guideline/skills/restful-api/SKILL.md
@@ -2,6 +2,7 @@
 name: restful-api
 description: "Use when designing, implementing, or reviewing REST APIs (URL structure, HTTP methods, status codes, JSON format, error responses, and headers). — /guideline:restful-api, \"REST API Design\", \"REST API Review\", \"API Guidelines\""
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # RESTful API Guidelines

--- a/plugins/llm/.claude-plugin/plugin.json
+++ b/plugins/llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain",
   "author": {
     "name": "ppzxc",

--- a/plugins/llm/plugin.json
+++ b/plugins/llm/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm",
-  "version": "0.5.1",
+  "version": "0.5.3",
   "description": "LLM delegation skills — 4-way peer cross-check (agy, claude, gemini, codex) with host-aware fallback chain",
   "author": {
     "name": "ppzxc",

--- a/plugins/llm/skills/agy/SKILL.md
+++ b/plugins/llm/skills/agy/SKILL.md
@@ -2,6 +2,7 @@
 name: agy
 description: Cross-check execution plans using Antigravity (agy) MCP or CLI. Analysis output only — no code execution. — /llm:agy, "agy crosscheck", "교차검증"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # agy Crosscheck

--- a/plugins/llm/skills/auto/SKILL.md
+++ b/plugins/llm/skills/auto/SKILL.md
@@ -2,6 +2,7 @@
 name: auto
 description: Use when performing automated cross-platform peer cross-check for plans, specs, and ideas. Delegated to the peer orchestrator. — /llm:auto, "교차검증", "cross-check", "peer check"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # llm:auto

--- a/plugins/llm/skills/claude/SKILL.md
+++ b/plugins/llm/skills/claude/SKILL.md
@@ -2,6 +2,7 @@
 name: claude
 description: Use when code review or architectural verification needs to be performed using Claude Code, particularly when triggered from either Claude Code directly or from Gemini/Antigravity via non-interactive CLI.
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # llm:claude

--- a/plugins/llm/skills/codex/SKILL.md
+++ b/plugins/llm/skills/codex/SKILL.md
@@ -2,6 +2,7 @@
 name: codex
 description: Delegate cross-check to Codex CLI. Wrapper skill — pure delegation only, no routing logic. Called by llm:auto. — /llm:codex, "codex crosscheck", "codex 교차검증"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # llm:codex

--- a/plugins/llm/skills/gemini/SKILL.md
+++ b/plugins/llm/skills/gemini/SKILL.md
@@ -2,6 +2,7 @@
 name: gemini
 description: Delegate cross-check to Gemini CLI. Wrapper skill — pure delegation only, no routing logic. Called by llm:auto. — /llm:gemini, "gemini crosscheck", "gemini 교차검증"
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # llm:gemini

--- a/plugins/llm/skills/peer-orchestrator/SKILL.md
+++ b/plugins/llm/skills/peer-orchestrator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: llm:peer-orchestrator
 description: Centralized multi-LLM review/cross-check orchestration
+disable-model-invocation: true
 ---
 
 # llm:peer-orchestrator


### PR DESCRIPTION
## Summary
- 로컬 플러그인 스킬들이 상황에 따라 자동으로 트리거(로딩)되는 현상을 제어하기 위해 `disable-model-invocation: true` 설정을 도입했습니다.
- 영향받는 6개 플러그인의 버전을 패치 레벨 범프하고 마켓플레이스 사양 및 README를 동기화했습니다.

## Motivation
- Java/Go 등의 코드 수정 작업 중 에이전트가 백그라운드에서 불필요하게 대량의 스킬 가이드라인을 로드하는 현상이 관측되어, 이를 방지하고 필요한 경우에만 명시적으로 호출할 수 있도록 제한이 필요했습니다.

## Changes
- `plugins/` 내 6개 플러그인(`guideline`, `docs`, `git`, `llm`, `dev`, `context`) 하위의 21개 `SKILL.md` frontmatter에 `disable-model-invocation: true` 추가
- 6개 플러그인의 `plugin.json` 및 `.claude-plugin/plugin.json` 버전 범프
- `.claude-plugin/marketplace.json` 버전 및 설명 동기화
- 루트 `README.md` 및 `README.ko.md` 버전 테이블 동기화

## Test plan
- [x] 빌드 통과
- [x] `claude plugins list`를 통한 비활성화 상태 복구 및 검증